### PR TITLE
Removed the Aztec prefix from some classes.

### DIFF
--- a/Classes/Public/GUI/FormatBar/FormatBar.swift
+++ b/Classes/Public/GUI/FormatBar/FormatBar.swift
@@ -2,10 +2,10 @@ import Foundation
 import UIKit
 
 
-public class AztecFormatBar: UIToolbar
+public class FormatBar: UIToolbar
 {
 
-    public var formatter: AztecFormatBarDelegate?
+    public var formatter: FormatBarDelegate?
 
 
     override public var items: [UIBarButtonItem]? {
@@ -63,23 +63,23 @@ public class AztecFormatBar: UIToolbar
     }
 
 
-    public var formatBarItems: [AztecFormatBarItem] {
+    public var formatBarItems: [FormatBarItem] {
         guard let items = items else {
-            return [AztecFormatBarItem]()
+            return [FormatBarItem]()
         }
         return items.filter({ (element) -> Bool in
-            if let _ = element as? AztecFormatBarItem {
+            if let _ = element as? FormatBarItem {
                 return true
             }
             return false
-        }) as! [AztecFormatBarItem]
+        }) as! [FormatBarItem]
     }
 
 
     // MARK: - Styles
 
 
-    func configureButtonStyle(button: AztecFormatBarItem) {
+    func configureButtonStyle(button: FormatBarItem) {
         button.tintColor = tintColor
         button.selectedTintColor = selectedTintColor
         button.highlightedTintColor = highlightedTintColor
@@ -87,7 +87,7 @@ public class AztecFormatBar: UIToolbar
     }
 
 
-    func configureButtonAction(button: AztecFormatBarItem) {
+    func configureButtonAction(button: FormatBarItem) {
         button.target = self
         button.action = #selector(self.dynamicType.handleButtonAction(_:))
     }
@@ -107,7 +107,7 @@ public class AztecFormatBar: UIToolbar
     // MARK: - Actions
 
 
-    func handleButtonAction(sender: AztecFormatBarItem) {
+    func handleButtonAction(sender: FormatBarItem) {
         formatter?.handleActionForIdentifier(sender.identifier!)
     }
 

--- a/Classes/Public/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Classes/Public/GUI/FormatBar/FormatBarDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 
-public protocol AztecFormatBarDelegate : NSObjectProtocol
+public protocol FormatBarDelegate : NSObjectProtocol
 {
     func handleActionForIdentifier(identifier: String)
 }

--- a/Classes/Public/GUI/FormatBar/FormatBarItem.swift
+++ b/Classes/Public/GUI/FormatBar/FormatBarItem.swift
@@ -3,7 +3,7 @@ import UIKit
 
 
 
-public class AztecFormatBarItem: UIBarButtonItem
+public class FormatBarItem: UIBarButtonItem
 {
 
     public var identifier: String?

--- a/Classes/Public/GUI/FormatBar/FormattingIdentifier.swift
+++ b/Classes/Public/GUI/FormatBar/FormattingIdentifier.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum AztecFormattingIdentifier: String
+public enum FormattingIdentifier: String
 {
     case Bold = "bold"
     case Italic = "italic"

--- a/Classes/Public/TextKit/AztecVisualEditor.swift
+++ b/Classes/Public/TextKit/AztecVisualEditor.swift
@@ -68,19 +68,19 @@ public class AztecVisualEditor : NSObject
         }
 
         if boldFormattingSpansRange(range) {
-            identifiers.append(AztecFormattingIdentifier.Bold.rawValue)
+            identifiers.append(FormattingIdentifier.Bold.rawValue)
         }
 
         if italicFormattingSpansRange(range) {
-            identifiers.append(AztecFormattingIdentifier.Italic.rawValue)
+            identifiers.append(FormattingIdentifier.Italic.rawValue)
         }
 
         if underlineFormattingSpansRange(range) {
-            identifiers.append(AztecFormattingIdentifier.Underline.rawValue)
+            identifiers.append(FormattingIdentifier.Underline.rawValue)
         }
 
         if strikethroughFormattingSpansRange(range) {
-            identifiers.append(AztecFormattingIdentifier.Strikethrough.rawValue)
+            identifiers.append(FormattingIdentifier.Strikethrough.rawValue)
         }
 
         return identifiers
@@ -104,19 +104,19 @@ public class AztecVisualEditor : NSObject
         let index = adjustedIndex(index)
 
         if formattingAtIndexContainsBold(index) {
-            identifiers.append(AztecFormattingIdentifier.Bold.rawValue)
+            identifiers.append(FormattingIdentifier.Bold.rawValue)
         }
 
         if formattingAtIndexContainsItalic(index) {
-            identifiers.append(AztecFormattingIdentifier.Italic.rawValue)
+            identifiers.append(FormattingIdentifier.Italic.rawValue)
         }
 
         if formattingAtIndexContainsUnderline(index) {
-            identifiers.append(AztecFormattingIdentifier.Underline.rawValue)
+            identifiers.append(FormattingIdentifier.Underline.rawValue)
         }
 
         if formattingAtIndexContainsStrikethrough(index) {
-            identifiers.append(AztecFormattingIdentifier.Strikethrough.rawValue)
+            identifiers.append(FormattingIdentifier.Strikethrough.rawValue)
         }
 
         return identifiers

--- a/Example/WordPress-Aztec-iOS/EditorDemoController.swift
+++ b/Example/WordPress-Aztec-iOS/EditorDemoController.swift
@@ -225,7 +225,7 @@ class EditorDemoController: UIViewController
 
 
     func updateFormatBar() {
-        guard let toolbar = textView.inputAccessoryView as? AztecFormatBar else {
+        guard let toolbar = textView.inputAccessoryView as? Aztec.FormatBar else {
             return
         }
 
@@ -251,36 +251,36 @@ extension EditorDemoController : UITextFieldDelegate
 }
 
 
-extension EditorDemoController : AztecFormatBarDelegate
+extension EditorDemoController : Aztec.FormatBarDelegate
 {
 
     func handleActionForIdentifier(identifier: String) {
         switch identifier {
-        case AztecFormattingIdentifier.Bold.rawValue :
+        case Aztec.FormattingIdentifier.Bold.rawValue :
             toggleBold()
             break
-        case AztecFormattingIdentifier.Italic.rawValue :
+        case Aztec.FormattingIdentifier.Italic.rawValue :
             toggleItalic()
             break
-        case AztecFormattingIdentifier.Underline.rawValue :
+        case Aztec.FormattingIdentifier.Underline.rawValue :
             toggleUnderline()
             break
-        case AztecFormattingIdentifier.Strikethrough.rawValue :
+        case Aztec.FormattingIdentifier.Strikethrough.rawValue :
             toggleStrikethrough()
             break
-        case AztecFormattingIdentifier.Blockquote.rawValue :
+        case Aztec.FormattingIdentifier.Blockquote.rawValue :
             toggleBlockquote()
             break
-        case AztecFormattingIdentifier.Unorderedlist.rawValue :
+        case Aztec.FormattingIdentifier.Unorderedlist.rawValue :
             toggleUnorderedList()
             break
-        case AztecFormattingIdentifier.Orderedlist.rawValue :
+        case Aztec.FormattingIdentifier.Orderedlist.rawValue :
             toggleOrderedList()
             break
-        case AztecFormattingIdentifier.Link.rawValue :
+        case Aztec.FormattingIdentifier.Link.rawValue :
             toggleLink()
             break
-        case AztecFormattingIdentifier.Media.rawValue :
+        case Aztec.FormattingIdentifier.Media.rawValue :
             insertImage()
             break;
         default:
@@ -335,31 +335,31 @@ extension EditorDemoController : AztecFormatBarDelegate
 
     // MARK: -
 
-    func createToolbar() -> AztecFormatBar {
+    func createToolbar() -> Aztec.FormatBar {
         let flex = UIBarButtonItem(barButtonSystemItem: .FlexibleSpace, target: nil, action: nil)
         let items = [
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_media"), identifier: AztecFormattingIdentifier.Media.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_media"), identifier: Aztec.FormattingIdentifier.Media.rawValue),
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_bold"), identifier: AztecFormattingIdentifier.Bold.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_bold"), identifier: Aztec.FormattingIdentifier.Bold.rawValue),
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_italic"), identifier: AztecFormattingIdentifier.Italic.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_italic"), identifier: Aztec.FormattingIdentifier.Italic.rawValue),
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_underline"), identifier: AztecFormattingIdentifier.Underline.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_underline"), identifier: Aztec.FormattingIdentifier.Underline.rawValue),
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_strikethrough"), identifier: AztecFormattingIdentifier.Strikethrough.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_strikethrough"), identifier: Aztec.FormattingIdentifier.Strikethrough.rawValue),
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_quote"), identifier: AztecFormattingIdentifier.Blockquote.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_quote"), identifier: Aztec.FormattingIdentifier.Blockquote.rawValue),
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_ul"), identifier: AztecFormattingIdentifier.Unorderedlist.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_ul"), identifier: Aztec.FormattingIdentifier.Unorderedlist.rawValue),
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_ol"), identifier: AztecFormattingIdentifier.Orderedlist.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_ol"), identifier: Aztec.FormattingIdentifier.Orderedlist.rawValue),
             flex,
-            AztecFormatBarItem(image: templateImage(named:"icon_format_link"), identifier: AztecFormattingIdentifier.Link.rawValue),
+            Aztec.FormatBarItem(image: templateImage(named:"icon_format_link"), identifier: Aztec.FormattingIdentifier.Link.rawValue),
             flex,
         ]
 
-        let toolbar = AztecFormatBar()
+        let toolbar = Aztec.FormatBar()
         toolbar.tintColor = UIColor.grayColor()
         toolbar.highlightedTintColor = UIColor.blueColor()
         toolbar.selectedTintColor = UIColor.darkGrayColor()


### PR DESCRIPTION
Removes the Aztec prefix from some classes, since they're already inside the module `Aztec`.

**To test:**

1. Make sure the app builds
2. Make sure the unit tests run properly.
3. Make sure the demo app hasn't lost any functionality.

