### PR TITLE
Changes the code a bit to remove an IUO.

### DIFF
--- a/Classes/Public/TextKit/AztecVisualEditor.swift
+++ b/Classes/Public/TextKit/AztecVisualEditor.swift
@@ -6,7 +6,11 @@ import Foundation
 public class AztecVisualEditor : NSObject
 {
     let textView: UITextView
-    var attachmentManager: AztecAttachmentManager!
+
+    lazy var attachmentManager: AztecAttachmentManager = {
+        AztecAttachmentManager(textView: self.textView, delegate: self)
+    }()
+
     var storage: AztecTextStorage {
         return textView.textStorage as! AztecTextStorage
     }
@@ -32,7 +36,6 @@ public class AztecVisualEditor : NSObject
 
     // MARK: - Lifecycle Methods
 
-
     public init(textView: UITextView) {
         assert(textView.textStorage.isKindOfClass(AztecTextStorage.self), "AztecVisualEditor should only be used with UITextView's backed by AztecTextStorage")
 
@@ -40,7 +43,6 @@ public class AztecVisualEditor : NSObject
 
         super.init()
 
-        attachmentManager = AztecAttachmentManager(textView: textView, delegate: self)
         textView.layoutManager.delegate = self
     }
 


### PR DESCRIPTION
Changes the code a bit to remove an IUO.  The property was only an IUO due to an initialization limitation - the property was trully non-optional and this change helps to better reflect that.