### PR TITLE
Cleans up trait toggling.

### DIFF
--- a/Classes/Public/TextKit/AztecTextStorage.swift
+++ b/Classes/Public/TextKit/AztecTextStorage.swift
@@ -131,15 +131,15 @@ public extension AztecTextStorage
                                 return
                             }
 
-                            var newTraits: UInt32
-                            if assigning {
-                                newTraits =  font.fontDescriptor().symbolicTraits.rawValue | trait.rawValue
+                            var newTraits = font.fontDescriptor().symbolicTraits
 
+                            if assigning {
+                                newTraits.insert(trait)
                             } else {
-                                newTraits =  font.fontDescriptor().symbolicTraits.rawValue & ~trait.rawValue
+                                newTraits.remove(trait)
                             }
 
-                            let descriptor = font.fontDescriptor().fontDescriptorWithSymbolicTraits(UIFontDescriptorSymbolicTraits(rawValue: newTraits))
+                            let descriptor = font.fontDescriptor().fontDescriptorWithSymbolicTraits(newTraits)
                             let newFont = UIFont(descriptor: descriptor, size: font.pointSize)
 
                             self.removeAttribute(NSFontAttributeName, range: range)


### PR DESCRIPTION
Cleans up trait toggling.  This PR introduces changes to avoid accessing `rawValue` where possible.

**How to test:**
Toggle bold, italic, underline, etc... for a range of text.
Make sure that the style is applied if any section of the range does not have the style.
Make sure that the style is removed if the full range has the selected style.