### PR TITLE
Text nodes no longer support attributes.

### DIFF
--- a/Classes/Private/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Classes/Private/Libxml2/Converters/In/InNodeConverter.swift
@@ -74,8 +74,7 @@ extension Libxml2.In {
             let nodeName = getNodeName(rawNode)
 
             let text = String(CString: UnsafePointer<Int8>(rawNode.content), encoding: NSUTF8StringEncoding)!
-            let attributes = createAttributes(fromNode: rawNode)
-            let node = TextNode(text: text, attributes: attributes)
+            let node = TextNode(text: text)
 
             return node
         }

--- a/Classes/Private/Libxml2/Data/Node.swift
+++ b/Classes/Private/Libxml2/Data/Node.swift
@@ -4,17 +4,15 @@ extension Libxml2.HTML {
     ///
     class Node: Equatable, CustomReflectable {
 
-        private(set) var attributes = [Attribute]()
         let name: String
         weak var parent: Node?
 
         func customMirror() -> Mirror {
-            return Mirror(self, children: ["name": name, "parent": parent, "attributes": attributes])
+            return Mirror(self, children: ["name": name, "parent": parent])
         }
 
-        init(name: String, attributes: [Attribute]) {
+        init(name: String) {
             self.name = name
-            self.attributes.appendContentsOf(attributes)
         }
     }
 
@@ -22,16 +20,18 @@ extension Libxml2.HTML {
     ///
     class ElementNode: Node {
 
+        private(set) var attributes = [Attribute]()
         let children: [Node]
 
         init(name: String, attributes: [Attribute], children: [Node]) {
             self.children = children
+            self.attributes.appendContentsOf(attributes)
 
-            super.init(name: name, attributes: attributes)
+            super.init(name: name)
         }
 
         override func customMirror() -> Mirror {
-            return Mirror(self, children: ["name": name, "parent": parent, "attributes": attributes, "children": children], ancestorRepresentation: .Suppressed)
+            return Mirror(self, children: ["type": "element", "name": name, "parent": parent, "attributes": attributes, "children": children], ancestorRepresentation: .Suppressed)
         }
     }
 
@@ -41,14 +41,14 @@ extension Libxml2.HTML {
 
         let text: String
 
-        init(text: String, attributes: [Attribute]) {
+        init(text: String) {
             self.text = text
 
-            super.init(name: "text", attributes: attributes)
+            super.init(name: "text")
         }
 
         override func customMirror() -> Mirror {
-            return Mirror(self, children: ["name": name, "text": text, "parent": parent, "attributes": attributes], ancestorRepresentation: .Suppressed)
+            return Mirror(self, children: ["type": "text", "name": name, "text": text, "parent": parent], ancestorRepresentation: .Suppressed)
         }
     }
 }

--- a/Classes/Private/NSAttributedString/Converters/NSAttributedStringToHTMLNode.swift
+++ b/Classes/Private/NSAttributedString/Converters/NSAttributedStringToHTMLNode.swift
@@ -15,7 +15,7 @@ class NSAttributedStringToHMTLNode: SafeConverter {
         if rootNode.children.count == 0 {
             // No children at the root node means no post content.  An empty text node should do.
             //
-            return TextNode(text: "", attributes: [])
+            return TextNode(text: "")
         } else {
             return rootNode.children[0]
         }

--- a/Example/Tests/Exporter/OutNodeConverterTests.swift
+++ b/Example/Tests/Exporter/OutNodeConverterTests.swift
@@ -25,7 +25,7 @@ class OutNodeConverterTests: XCTestCase {
 
         let nodeName = "text"
         let nodeText = "This is the text."
-        let textNode = TextNode(text: nodeText, attributes: [])
+        let textNode = TextNode(text: nodeText)
         let xmlNodePtr = Libxml2.Out.NodeConverter().convert(textNode)
         let xmlNode = xmlNodePtr.memory
 
@@ -81,7 +81,7 @@ class OutNodeConverterTests: XCTestCase {
     func testElementAndChildTextNodeConversion() {
 
         let innerNodeText = "some text"
-        let innerNode = TextNode(text: innerNodeText, attributes: [])
+        let innerNode = TextNode(text: innerNodeText)
 
         let outerNodeName = "element"
         let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode])

--- a/Example/Tests/Importer/InNodeConverterTests.swift
+++ b/Example/Tests/Importer/InNodeConverterTests.swift
@@ -58,7 +58,6 @@ class InNodeConverterTests: XCTestCase {
         XCTAssertEqual(textNode.name, textNodeName)
         XCTAssertEqual(textNode.text, text)
         XCTAssertEqual(textNode.parent, nil)
-        XCTAssertEqual(textNode.attributes.count, 0)
     }
 
     func testTextNodeInParentNodeConversion() {
@@ -93,6 +92,5 @@ class InNodeConverterTests: XCTestCase {
         XCTAssertEqual(outTextNode.name, textNodeName)
         XCTAssertEqual(outTextNode.text, text)
         XCTAssertEqual(outTextNode.parent, outParentNode)
-        XCTAssertEqual(outTextNode.attributes.count, 0)
     }
 }


### PR DESCRIPTION
Text nodes no longer support attributes, since they really should never have. 😄 

This PR cleans up text nodes to only accept their text content in their initializer.

**How to test:**
Build the app.
Run the unit tests and make sure they succeed.