### PR TITLE
Fixed an error in the bold-editing-logic.

### DIFF
--- a/Classes/Private/Libxml2/Data/Node.swift
+++ b/Classes/Private/Libxml2/Data/Node.swift
@@ -101,6 +101,7 @@ extension Libxml2 {
                 }
 
                 parent.children[index] = newNode
+                newNode.parent = parent
             }
 
             return newNode

--- a/Classes/Public/TextKit/AztecTextStorage.swift
+++ b/Classes/Public/TextKit/AztecTextStorage.swift
@@ -102,6 +102,7 @@ public class AztecTextStorage: NSTextStorage {
 
                 if postRange.count > 0 {
                     let newNode = TextNode(text: node.text.substringWithRange(postRange))
+                    newNode.parent = parent
 
                     node.text.removeRange(postRange)
                     parent.children.insert(newNode, atIndex: nodeIndex + 1)
@@ -109,6 +110,7 @@ public class AztecTextStorage: NSTextStorage {
 
                 if preRange.count > 0 {
                     let newNode = TextNode(text: node.text.substringWithRange(preRange))
+                    newNode.parent = parent
 
                     node.text.removeRange(preRange)
                     parent.children.insert(newNode, atIndex: nodeIndex)


### PR DESCRIPTION
There was an error with the bold editing logic that was causing a crash.

Brings us closer to closing #18.

**How to reproduce the original error:**
1. Launch the editor from `develop`.
2. Select the word "post" from the second line.
3. Make it bold.
4. Now select the full line, including the word "post".
5. Make it bold again.
6. Crash!

**How to test:**
Same steps as above, but they should no longer crash and the text should be made bold.