### PR TITLE
Implements block-level node finding, and node splitting.

### DIFF
--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -402,7 +402,7 @@ extension Libxml2 {
         /// Removes the specified child nodes.  Only updates their parents if specified.
         ///
         /// - Parameters:
-        ///     - chldren: the child nodes to remove.
+        ///     - children: the child nodes to remove.
         ///     - updateParent: whether the children node's parent must be update to `nil` or not.
         ///             If not specified, the parent is updated.
         ///

--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -302,7 +302,7 @@ extension Libxml2 {
             var result = [Node]()
             var offset = length()
 
-            for index in children.count - 1...0 {
+            for index in (children.count - 1).stride(through: 0, by: -1) {
 
                 let child = children[index]
 
@@ -315,7 +315,7 @@ extension Libxml2 {
                     result.insert(child, atIndex: 0)
                 } else if splitEdge && childEndPosition > rangeEndPosition {
 
-                    let splitRange = NSRange(location: rangeEndPosition, length: childEndPosition - rangeEndPosition)
+                    let splitRange = NSRange(location: rangeEndPosition - offset, length: childEndPosition - rangeEndPosition)
                     child.split(forRange: splitRange)
 
                     result.insert(child, atIndex: 0)

--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -293,7 +293,7 @@ extension Libxml2 {
                     child.parent = nil
                 }
 
-                return removeChild
+                return !removeChild
             })
         }
 
@@ -305,6 +305,8 @@ extension Libxml2 {
             for index in children.count - 1...0 {
 
                 let child = children[index]
+
+                offset = offset - child.length()
 
                 let childEndPosition = offset + child.length()
                 let rangeEndPosition = range.location + range.length
@@ -321,8 +323,6 @@ extension Libxml2 {
                 } else {
                     break
                 }
-
-                offset = offset - child.length()
             }
             
             return result
@@ -355,6 +355,10 @@ extension Libxml2 {
 
         override func split(forRange range: NSRange) {
 
+            guard range.location > 0 || range.length < length() else {
+                return
+            }
+
             guard let parent = parent,
                 let nodeIndex = parent.children.indexOf(self) else {
                     assertionFailure("Can't split a node without a parent.")
@@ -365,11 +369,17 @@ extension Libxml2 {
             let postNodes = children(after: range, splitEdge: true)
 
             if postNodes.count > 0 {
-                parent.children.insertContentsOf(postNodes, at: nodeIndex + 1)
+                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes)
+
+                parent.children.insert(newElement, atIndex: nodeIndex + 1)
+                remove(postNodes, updateParent: false)
             }
 
             if preNodes.count > 0 {
-                parent.children.insertContentsOf(preNodes, at: nodeIndex)
+                let newElement = ElementNode(name: name, attributes: attributes, children: preNodes)
+
+                parent.children.insert(newElement, atIndex: nodeIndex)
+                remove(preNodes, updateParent: false)
             }
         }
 

--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -427,7 +427,7 @@ extension Libxml2 {
                 remove(postNodes, updateParent: false)
             }
 
-            let preNodes = children(before: range, splitEdge: true)
+            let preNodes = children(before: range.location, splitEdge: true)
 
             if preNodes.count > 0 {
                 let newElement = ElementNode(name: name, attributes: attributes, children: preNodes)

--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -262,7 +262,8 @@ extension Libxml2 {
                         if let previousRangeWithoutMatch = rangeWithoutMatch {
                             rangeWithoutMatch = NSRange(location: previousRangeWithoutMatch.location, length: previousRangeWithoutMatch.length + intersectionRangeInChildCoordinates.length)
                         } else {
-                            rangeWithoutMatch = intersectionRangeInChildCoordinates
+                            rangeWithoutMatch = intersectionRange
+
                         }
                     }
                 }
@@ -314,24 +315,6 @@ extension Libxml2 {
             }
 
             return self
-        }
-
-        /// Returns the lowest-level block-type element nodes in this node's hierarchy that wrap the 
-        /// specified range.  If no child element node wraps the specified range, this method
-        /// returns this node.
-        ///
-        /// - Parameters:
-        ///     - range: the range we want to find the wrapping node of.
-        ///
-        /// - Returns: an array of block-level nodes, and the sub-range (from the specified range)
-        ///         that they wrap.
-        ///
-        func lowestBlockElementNodesWrapping(range: NSRange) -> [(node: ElementNode, range: NSRange)] {
-
-            //let mainNode = lowestElementNodeWrapping(range)
-
-            // Look for block-level elements in children
-            return []
         }
 
         /// Calls this method to obtain all the text nodes containing a specified range.

--- a/Classes/Private/Libxml2/Data/Node.swift
+++ b/Classes/Private/Libxml2/Data/Node.swift
@@ -15,11 +15,19 @@ extension Libxml2 {
             self.name = name
         }
 
+        func range() -> NSRange {
+            return NSRange(location: 0, length: length())
+        }
+
         /// Override.
         ///
         func length() -> Int {
             assertionFailure("This method should always be overridden.")
             return 0
+        }
+
+        func split(forRange range: NSRange) {
+            assertionFailure("This method should always be overridden.")
         }
 
         /// Retrieve all element nodes between the receiver and the root node.
@@ -83,16 +91,16 @@ extension Libxml2 {
         /// the parent and child node references.
         ///
         /// - Parameters:
-        ///     - name: the new node name.
+        ///     - nodeName: the new node name.
         ///     - attributes: the new node attributes.
         ///
         /// - Returns: the newly created element.
         ///
-        func wrapInNewNode(named name: String, attributes: [Attribute] = []) -> ElementNode {
+        func wrap(inNodeNamed nodeName: String, withAttributes attributes: [Attribute] = []) -> ElementNode {
 
             let originalParent = parent
 
-            let newNode = ElementNode(name: name, attributes: attributes, children: [self])
+            let newNode = ElementNode(name: nodeName, attributes: attributes, children: [self])
 
             if let parent = originalParent {
                 guard let index = parent.children.indexOf(self) else {
@@ -105,6 +113,13 @@ extension Libxml2 {
             }
 
             return newNode
+        }
+
+        /// Override.
+        ///
+        func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute]) {
+            assertionFailure("This method should always be overridden.")
+            return
         }
     }
 }

--- a/Classes/Private/Libxml2/Data/Node.swift
+++ b/Classes/Private/Libxml2/Data/Node.swift
@@ -19,6 +19,8 @@ extension Libxml2 {
             return NSRange(location: 0, length: length())
         }
 
+        // MARK: - Override in Subclasses
+
         /// Override.
         ///
         func length() -> Int {
@@ -29,6 +31,14 @@ extension Libxml2 {
         func split(forRange range: NSRange) {
             assertionFailure("This method should always be overridden.")
         }
+
+
+        func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute]) {
+            assertionFailure("This method should always be overridden.")
+            return
+        }
+
+        // MARK: - DOM Queries
 
         /// Retrieve all element nodes between the receiver and the root node.
         /// The root node is included in the results.  The receiver is only included if it's an
@@ -87,6 +97,8 @@ extension Libxml2 {
             return nil
         }
 
+        // MARK: - DOM Modification
+
         /// Wraps this node in a new node with the specified name.  Also takes care of updating
         /// the parent and child node references.
         ///
@@ -108,18 +120,10 @@ extension Libxml2 {
                     return newNode
                 }
 
-                parent.children[index] = newNode
-                newNode.parent = parent
+                parent.insert(newNode, at: index)
             }
 
             return newNode
-        }
-
-        /// Override.
-        ///
-        func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute]) {
-            assertionFailure("This method should always be overridden.")
-            return
         }
     }
 }

--- a/Classes/Private/Libxml2/Data/TextNode.swift
+++ b/Classes/Private/Libxml2/Data/TextNode.swift
@@ -22,5 +22,56 @@ extension Libxml2 {
         override func length() -> Int {
             return text.characters.count
         }
+
+        override func split(forRange range: NSRange) {
+
+            guard let swiftRange = text.rangeFromNSRange(range) else {
+                fatalError("This scenario should not be possible. Review the logic.")
+            }
+
+            guard let parent = parent,
+                let nodeIndex = parent.children.indexOf(self) else {
+
+                fatalError("This scenario should not be possible. Review the logic.")
+            }
+
+            let preRange = text.startIndex ..< swiftRange.startIndex
+            let postRange = swiftRange.endIndex ..< text.endIndex
+
+            if postRange.count > 0 {
+                let newNode = TextNode(text: text.substringWithRange(postRange))
+                newNode.parent = parent
+
+                text.removeRange(postRange)
+                parent.children.insert(newNode, atIndex: nodeIndex + 1)
+            }
+
+            if preRange.count > 0 {
+                let newNode = TextNode(text: text.substringWithRange(preRange))
+                newNode.parent = parent
+
+                text.removeRange(preRange)
+                parent.children.insert(newNode, atIndex: nodeIndex)
+            }
+        }
+
+
+        /// Wraps the specified range inside a node with the specified name.
+        ///
+        /// - Parameters:
+        ///     - targetRange: the range that must be wrapped.
+        ///     - nodeName: the name of the node to wrap the range in.
+        ///     - attributes: the attributes the wrapping node will have when created.
+        ///
+        override func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute]) {
+
+            guard !NSEqualRanges(targetRange, NSRange(location: 0, length: length())) else {
+                wrap(inNodeNamed: nodeName, withAttributes: attributes)
+                return
+            }
+
+            split(forRange: targetRange)
+            wrap(inNodeNamed: nodeName, withAttributes: attributes)
+        }
     }
 }

--- a/Classes/Private/Libxml2/Data/TextNode.swift
+++ b/Classes/Private/Libxml2/Data/TextNode.swift
@@ -40,18 +40,16 @@ extension Libxml2 {
 
             if postRange.count > 0 {
                 let newNode = TextNode(text: text.substringWithRange(postRange))
-                newNode.parent = parent
 
                 text.removeRange(postRange)
-                parent.children.insert(newNode, atIndex: nodeIndex + 1)
+                parent.insert(newNode, at: nodeIndex + 1)
             }
 
             if preRange.count > 0 {
                 let newNode = TextNode(text: text.substringWithRange(preRange))
-                newNode.parent = parent
 
                 text.removeRange(preRange)
-                parent.children.insert(newNode, atIndex: nodeIndex)
+                parent.insert(newNode, at: nodeIndex)
             }
         }
 

--- a/Classes/Public/TextKit/AztecTextStorage.swift
+++ b/Classes/Public/TextKit/AztecTextStorage.swift
@@ -67,58 +67,18 @@ public class AztecTextStorage: NSTextStorage {
         if enable {
             enableBoldInDOM(range)
         } else {
-            //    disableBoldInDom(range)
+            disableBoldInDom(range)
         }
     }
 
     // MARK: - DOM
 
-    private func enableBoldInDOM(range: NSRange) {
-        wrap(range: range, inNodeNamed: "strong")
+    private func disableBoldInDom(range: NSRange) {
+        rootNode.unwrap(range: range, fromNodeNamed: "strong")
     }
 
-    private func wrap(range newNodeRange: NSRange, inNodeNamed newNodeName: String) {
-
-        let textNodes = rootNode.textNodesWrapping(newNodeRange)
-
-        for (node, range) in textNodes {
-            guard let parent = node.parent,
-                let nodeIndex = parent.children.indexOf(node) else {
-
-                assertionFailure("This scenario should not be possible. Review the logic.")
-                continue
-            }
-
-            let nodeLength = node.length()
-
-            if range.length != nodeLength {
-                guard let swiftRange = node.text.rangeFromNSRange(range) else {
-                    assertionFailure("This scenario should not be possible. Review the logic.")
-                    continue
-                }
-
-                let preRange = node.text.startIndex ..< swiftRange.startIndex
-                let postRange = swiftRange.endIndex ..< node.text.endIndex
-
-                if postRange.count > 0 {
-                    let newNode = TextNode(text: node.text.substringWithRange(postRange))
-                    newNode.parent = parent
-
-                    node.text.removeRange(postRange)
-                    parent.children.insert(newNode, atIndex: nodeIndex + 1)
-                }
-
-                if preRange.count > 0 {
-                    let newNode = TextNode(text: node.text.substringWithRange(preRange))
-                    newNode.parent = parent
-
-                    node.text.removeRange(preRange)
-                    parent.children.insert(newNode, atIndex: nodeIndex)
-                }
-            }
-
-            node.wrapInNewNode(named: newNodeName)
-        }
+    private func enableBoldInDOM(range: NSRange) {
+        rootNode.wrap(range: range, inNodeNamed: "strong")
     }
 
     // MARK: - HTML Interaction

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -5,6 +5,7 @@ class ElementNodeTests: XCTestCase {
 
     typealias Attribute = Libxml2.Attribute
     typealias ElementNode = Libxml2.ElementNode
+    typealias RootNode = Libxml2.RootNode
     typealias StringAttribute = Libxml2.StringAttribute
     typealias TextNode = Libxml2.TextNode
 
@@ -195,6 +196,70 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(nodesAndRanges[0].node, text1)
 
         XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: text1.length() - 1, length: 0)))
+    }
+
+    func testSplitWithFullRange() {
+
+        let textNode = TextNode(text: "Some text goes here")
+        let elemNode = ElementNode(name: "SomeNode", attributes: [], children: [textNode])
+        let rootNode = RootNode(children: [elemNode])
+
+        let splitRange = NSRange(location: 0, length: textNode.length())
+
+        elemNode.split(forRange: splitRange)
+
+        XCTAssertEqual(rootNode.children.count, 1)
+        XCTAssertEqual(rootNode.children[0], elemNode)
+
+        XCTAssertEqual(elemNode.children.count, 1)
+        XCTAssertEqual(elemNode.children[0], textNode)
+    }
+
+    func testSplitWithPartialRange1() {
+
+        let elemNodeName = "SomeNode"
+        let textPart1 = "Some"
+        let textPart2 = " text goes here"
+        let fullText = "\(textPart1)\(textPart2)"
+
+        let textNode = TextNode(text: fullText)
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
+        let rootNode = RootNode(children: [elemNode])
+
+        let splitRange = NSRange(location: 0, length: textPart1.characters.count)
+
+        elemNode.split(forRange: splitRange)
+
+        XCTAssertEqual(rootNode.children.count, 2)
+
+        XCTAssertEqual(rootNode.children[0].name, elemNodeName)
+        XCTAssertEqual(rootNode.children[1].name, elemNodeName)
+
+        guard let elemNode1 = rootNode.children[0] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        guard let elemNode2 = rootNode.children[1] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        XCTAssertEqual(elemNode1.children.count, 1)
+        XCTAssertEqual(elemNode2.children.count, 1)
+
+        guard let textNode1 = elemNode1.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        guard let textNode2 = elemNode2.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        XCTAssertEqual(textNode1.text, textPart1)
+        XCTAssertEqual(textNode2.text, textPart2)
     }
     
 }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -261,5 +261,113 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(textNode1.text, textPart1)
         XCTAssertEqual(textNode2.text, textPart2)
     }
-    
+
+    func testSplitWithPartialRange2() {
+
+        let elemNodeName = "SomeNode"
+        let textPart1 = "Some"
+        let textPart2 = " text goes here"
+        let fullText = "\(textPart1)\(textPart2)"
+
+        let textNode = TextNode(text: fullText)
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
+        let rootNode = RootNode(children: [elemNode])
+
+        let splitRange = NSRange(location: textPart1.characters.count, length: textPart2.characters.count)
+
+        elemNode.split(forRange: splitRange)
+
+        XCTAssertEqual(rootNode.children.count, 2)
+
+        XCTAssertEqual(rootNode.children[0].name, elemNodeName)
+        XCTAssertEqual(rootNode.children[1].name, elemNodeName)
+
+        guard let elemNode1 = rootNode.children[0] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        guard let elemNode2 = rootNode.children[1] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        XCTAssertEqual(elemNode1.children.count, 1)
+        XCTAssertEqual(elemNode2.children.count, 1)
+
+        guard let textNode1 = elemNode1.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        guard let textNode2 = elemNode2.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        XCTAssertEqual(textNode1.text, textPart1)
+        XCTAssertEqual(textNode2.text, textPart2)
+    }
+
+
+    func testSplitWithPartialRange3() {
+
+        let elemNodeName = "SomeNode"
+        let textPart1 = "Some"
+        let textPart2 = " text goes "
+        let textPart3 = "here"
+        let fullText = "\(textPart1)\(textPart2)\(textPart3)"
+
+        let textNode = TextNode(text: fullText)
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
+        let rootNode = RootNode(children: [elemNode])
+
+        let splitRange = NSRange(location: textPart1.characters.count, length: textPart2.characters.count)
+
+        elemNode.split(forRange: splitRange)
+
+        XCTAssertEqual(rootNode.children.count, 3)
+
+        XCTAssertEqual(rootNode.children[0].name, elemNodeName)
+        XCTAssertEqual(rootNode.children[1].name, elemNodeName)
+        XCTAssertEqual(rootNode.children[2].name, elemNodeName)
+
+        guard let elemNode1 = rootNode.children[0] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        guard let elemNode2 = rootNode.children[1] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        guard let elemNode3 = rootNode.children[2] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        XCTAssertEqual(elemNode1.children.count, 1)
+        XCTAssertEqual(elemNode2.children.count, 1)
+        XCTAssertEqual(elemNode3.children.count, 1)
+
+        guard let textNode1 = elemNode1.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        guard let textNode2 = elemNode2.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        guard let textNode3 = elemNode3.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        XCTAssertEqual(textNode1.text, textPart1)
+        XCTAssertEqual(textNode2.text, textPart2)
+        XCTAssertEqual(textNode3.text, textPart3)
+    }
 }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -370,4 +370,68 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(textNode2.text, textPart2)
         XCTAssertEqual(textNode3.text, textPart3)
     }
+
+    func testSplitWithPartialRangeAndBlockLevelNodes1() {
+
+        let elemNodeName = "SomeNode"
+        let blockNodeName = "p"
+
+        let textPart1 = "Some"
+        let textPart2 = " text goes "
+        let textPart3 = "here"
+        let fullText = "\(textPart1)\(textPart2)\(textPart3)"
+
+        let textNode = TextNode(text: fullText)
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
+        let blockNode = ElementNode(name: blockNodeName, attributes: [], children: [elemNode])
+        let rootNode = RootNode(children: [blockNode])
+
+        let splitRange = NSRange(location: textPart1.characters.count, length: textPart2.characters.count)
+
+        blockNode.split(forRange: splitRange)
+
+        XCTAssertEqual(rootNode.children.count, 3)
+
+        XCTAssertEqual(rootNode.children[0].name, elemNodeName)
+        XCTAssertEqual(rootNode.children[1].name, elemNodeName)
+        XCTAssertEqual(rootNode.children[2].name, elemNodeName)
+
+        guard let elemNode1 = rootNode.children[0] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        guard let elemNode2 = rootNode.children[1] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        guard let elemNode3 = rootNode.children[2] as? ElementNode else {
+            XCTFail("Expected an element node.")
+            return
+        }
+
+        XCTAssertEqual(elemNode1.children.count, 1)
+        XCTAssertEqual(elemNode2.children.count, 1)
+        XCTAssertEqual(elemNode3.children.count, 1)
+
+        guard let textNode1 = elemNode1.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        guard let textNode2 = elemNode2.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        guard let textNode3 = elemNode3.children[0] as? TextNode else {
+            XCTFail("Expected a text node.")
+            return
+        }
+
+        XCTAssertEqual(textNode1.text, textPart1)
+        XCTAssertEqual(textNode2.text, textPart2)
+        XCTAssertEqual(textNode3.text, textPart3)
+    }
 }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -371,67 +371,32 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(textNode3.text, textPart3)
     }
 
-    func testSplitWithPartialRangeAndBlockLevelNodes1() {
+    /// Tests obtaining the block-level elements intercepting the full range of the following
+    /// HTML string: <div>Hello <p>there</p></div>
+    ///
+    /// The results should be:
+    ///     - (node: div, range: (0...6))
+    ///     - (node: p, range: (0...5))
+    ///
+    func testEnumerate() {
 
-        let elemNodeName = "SomeNode"
-        let blockNodeName = "p"
+        let textPart1 = "Hello "
+        let textPart2 = "there"
 
-        let textPart1 = "Some"
-        let textPart2 = " text goes "
-        let textPart3 = "here"
-        let fullText = "\(textPart1)\(textPart2)\(textPart3)"
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
 
-        let textNode = TextNode(text: fullText)
-        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
-        let blockNode = ElementNode(name: blockNodeName, attributes: [], children: [elemNode])
-        let rootNode = RootNode(children: [blockNode])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph])
 
-        let splitRange = NSRange(location: textPart1.characters.count, length: textPart2.characters.count)
+        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
 
-        blockNode.split(forRange: splitRange)
-
-        XCTAssertEqual(rootNode.children.count, 3)
-
-        XCTAssertEqual(rootNode.children[0].name, elemNodeName)
-        XCTAssertEqual(rootNode.children[1].name, elemNodeName)
-        XCTAssertEqual(rootNode.children[2].name, elemNodeName)
-
-        guard let elemNode1 = rootNode.children[0] as? ElementNode else {
-            XCTFail("Expected an element node.")
-            return
-        }
-
-        guard let elemNode2 = rootNode.children[1] as? ElementNode else {
-            XCTFail("Expected an element node.")
-            return
-        }
-
-        guard let elemNode3 = rootNode.children[2] as? ElementNode else {
-            XCTFail("Expected an element node.")
-            return
-        }
-
-        XCTAssertEqual(elemNode1.children.count, 1)
-        XCTAssertEqual(elemNode2.children.count, 1)
-        XCTAssertEqual(elemNode3.children.count, 1)
-
-        guard let textNode1 = elemNode1.children[0] as? TextNode else {
-            XCTFail("Expected a text node.")
-            return
-        }
-
-        guard let textNode2 = elemNode2.children[0] as? TextNode else {
-            XCTFail("Expected a text node.")
-            return
-        }
-
-        guard let textNode3 = elemNode3.children[0] as? TextNode else {
-            XCTFail("Expected a text node.")
-            return
-        }
-
-        XCTAssertEqual(textNode1.text, textPart1)
-        XCTAssertEqual(textNode2.text, textPart2)
-        XCTAssertEqual(textNode3.text, textPart3)
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].element.name, "div")
+        XCTAssertEqual(results[0].intersection.location, 0)
+        XCTAssertEqual(results[0].intersection.length, 6)
+        XCTAssertEqual(results[1].element.name, "p")
+        XCTAssertEqual(results[1].intersection.location, 0)
+        XCTAssertEqual(results[1].intersection.length, 5)
     }
 }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -378,7 +378,7 @@ class ElementNodeTests: XCTestCase {
     ///     - (node: div, range: (0...6))
     ///     - (node: p, range: (0...5))
     ///
-    func testEnumerate() {
+    func testLowestBlockLevelElements1() {
 
         let textPart1 = "Hello "
         let textPart2 = "there"
@@ -398,5 +398,70 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(results[1].element.name, "p")
         XCTAssertEqual(results[1].intersection.location, 0)
         XCTAssertEqual(results[1].intersection.length, 5)
+    }
+
+    /// Tests obtaining the block-level elements intercepting the full range of the following
+    /// HTML string: <div>Hello <p>there</p> man!</div>
+    ///
+    /// The results should be:
+    ///     - (node: div, range: (0...6))
+    ///     - (node: p, range: (0...5))
+    ///     - (node: div, range: (11...5))
+    ///
+    func testLowestBlockLevelElements2() {
+
+        let textPart1 = "Hello "
+        let textPart2 = "there"
+        let textPart3 = " man!"
+
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+        let textNode3 = TextNode(text: textPart3)
+
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3])
+
+        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
+
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(results[0].element.name, "div")
+        XCTAssertEqual(results[0].intersection.location, 0)
+        XCTAssertEqual(results[0].intersection.length, 6)
+        XCTAssertEqual(results[1].element.name, "p")
+        XCTAssertEqual(results[1].intersection.location, 0)
+        XCTAssertEqual(results[1].intersection.length, 5)
+        XCTAssertEqual(results[2].element.name, "div")
+        XCTAssertEqual(results[2].intersection.location, 11)
+        XCTAssertEqual(results[2].intersection.length, 5)
+    }
+
+
+    /// Tests obtaining the block-level elements intercepting the full range of the following
+    /// HTML string: <div><p>Hello </p>there!</div>
+    ///
+    /// The results should be:
+    ///     - (node: p, range: (0...6))
+    ///     - (node: div, range: (6...6))
+    ///
+    func testLowestBlockLevelElements3() {
+
+        let textPart1 = "Hello "
+        let textPart2 = "there!"
+
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2])
+
+        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].element.name, "p")
+        XCTAssertEqual(results[0].intersection.location, 0)
+        XCTAssertEqual(results[0].intersection.length, 6)
+        XCTAssertEqual(results[1].element.name, "div")
+        XCTAssertEqual(results[1].intersection.location, 6)
+        XCTAssertEqual(results[1].intersection.length, 6)
     }
 }


### PR DESCRIPTION
This PR implements several logical instruments we'll need to update the DOM.

- Block-level node finding basically means we can find all lowest (hierarchy-wise) block-level nodes intercepting a range.
- Splitting nodes and their children using a range.

**How to test:**
- Since this PR is mostly non-hooked logical methods, there's not much that can be tested from the GUI yet.
- Run the unit tests and make sure they succeed.