### PR TITLE
Apply bold style

### DIFF
--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -766,11 +766,11 @@ extension Libxml2 {
         ///
         private func forceWrapChildren(intersectingRange targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute]) {
 
-            let childNodesIntersectingRange = childNodes(intersectingRange: targetRange)
-            assert(childNodesIntersectingRange.count > 0)
+            let childNodesAndRanges = childNodes(intersectingRange: targetRange)
+            assert(childNodesAndRanges.count > 0)
 
-            if childNodesIntersectingRange.count == 1 {
-                let childData = childNodesIntersectingRange[0]
+            if childNodesAndRanges.count == 1 {
+                let childData = childNodesAndRanges[0]
                 let childNode = childData.child
                 let intersection = childData.intersection
 
@@ -779,22 +779,26 @@ extension Libxml2 {
                 } else {
                     childNode.wrap(range: intersection, inNodeNamed: nodeName, withAttributes: attributes)
                 }
-            } else if childNodesIntersectingRange.count > 1 {
+            } else if childNodesAndRanges.count > 1 {
 
-                let firstChild = childNodesIntersectingRange[0].child
-                let firstChildIntersection = childNodesIntersectingRange[0].intersection
+                let firstChild = childNodesAndRanges[0].child
+                let firstChildIntersection = childNodesAndRanges[0].intersection
 
                 if !NSEqualRanges(firstChild.range(), firstChildIntersection) {
                     firstChild.split(forRange: firstChildIntersection)
                 }
 
-                let lastChild = childNodesIntersectingRange[childNodesIntersectingRange.count - 1].child
-                let lastChildIntersection = childNodesIntersectingRange[0].intersection
+                let lastChild = childNodesAndRanges[childNodesAndRanges.count - 1].child
+                let lastChildIntersection = childNodesAndRanges[0].intersection
 
                 if !NSEqualRanges(lastChild.range(), lastChildIntersection) {
                     lastChild.split(forRange: lastChildIntersection)
                 }
-                
+
+                let children = childNodesAndRanges.map({ (child: Node, intersection: NSRange) -> Node in
+                    return child
+                })
+
                 wrap(children, inNodeNamed: nodeName, withAttributes: attributes)
             }
         }
@@ -843,7 +847,7 @@ extension Libxml2 {
 
             let newNode = ElementNode(name: nodeName, attributes: attributes, children: children)
 
-            self.children[insertionIndexOfNewNode] = newNode
+            self.children.insert(newNode, atIndex: insertionIndexOfNewNode)
             newNode.parent = self
 
             remove(children, updateParent: false)

--- a/Classes/Private/Libxml2/Data/Node.swift
+++ b/Classes/Private/Libxml2/Data/Node.swift
@@ -111,13 +111,13 @@ extension Libxml2 {
         func wrap(inNodeNamed nodeName: String, withAttributes attributes: [Attribute] = []) -> ElementNode {
 
             let originalParent = parent
+            let originalIndex = parent?.children.indexOf(self)
 
             let newNode = ElementNode(name: nodeName, attributes: attributes, children: [self])
 
             if let parent = originalParent {
-                guard let index = parent.children.indexOf(self) else {
-                    assertionFailure("A node's parent should contain the node. Review the child/parent updating logic.")
-                    return newNode
+                guard let index = originalIndex else {
+                    fatalError("If the node has a parent, the index should be obtainable.")
                 }
 
                 parent.insert(newNode, at: index)

--- a/Classes/Public/TextKit/AztecTextStorage.swift
+++ b/Classes/Public/TextKit/AztecTextStorage.swift
@@ -74,17 +74,12 @@ public class AztecTextStorage: NSTextStorage {
     // MARK: - DOM
 
     private func disableBoldInDom(range: NSRange) {
-        rootNode.unwrap(range: range, fromNodeNamed: "strong")
+        rootNode.unwrap(range: range, fromNodeNamed: "b")
     }
 
     private func enableBoldInDOM(range: NSRange) {
-        //rootNode.wrap(range: range, inNodeNamed: "strong")
 
-        let elementsAndRanges = rootNode.lowestBlockLevelElements(intersectingRange: range)
-
-        for (element, intersection) in elementsAndRanges.generate() {
-            element.wrapChildren(intersectingRange: intersection, inNodeNamed: "b", withAttributes: [])
-        }
+        rootNode.wrapChildren(intersectingRange: range, inNodeNamed: "b", withAttributes: [])
     }
 
     // MARK: - HTML Interaction

--- a/Classes/Public/TextKit/AztecTextStorage.swift
+++ b/Classes/Public/TextKit/AztecTextStorage.swift
@@ -78,7 +78,13 @@ public class AztecTextStorage: NSTextStorage {
     }
 
     private func enableBoldInDOM(range: NSRange) {
-        rootNode.wrap(range: range, inNodeNamed: "strong")
+        //rootNode.wrap(range: range, inNodeNamed: "strong")
+
+        let elementsAndRanges = rootNode.lowestBlockLevelElements(intersectingRange: range)
+
+        for (element, intersection) in elementsAndRanges.generate() {
+            element.wrapChildren(intersectingRange: intersection, inNodeNamed: "b", withAttributes: [])
+        }
     }
 
     // MARK: - HTML Interaction

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -543,4 +543,47 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(em.children.count, 1)
         XCTAssertEqual(em.children[0], textNode1)
     }
+
+
+    /// Tests wrapping child nodes intersecting a certain range in a new `b` node.
+    ///
+    /// HTML String: <div><em>Hello </em><i>there!</i></div>
+    /// Wrap range: (0...6)
+    ///
+    /// The result should be: <div><b><em>Hello </em><u>there!</u></b></div>
+    ///
+    func testWrapChildrenInNewBNode3() {
+
+        let boldNodeName = "b"
+
+        let textPart1 = "Hello "
+        let textPart2 = "there!"
+
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
+        let underline = ElementNode(name: "u", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [em, underline])
+
+        div.wrapChildren(intersectingRange: div.range(), inNodeNamed: boldNodeName, withAttributes: [])
+
+        XCTAssertEqual(div.children.count, 1)
+
+        guard let boldNode = div.children[0] as? ElementNode else {
+            XCTFail("Expected a bold node here.")
+            return
+        }
+
+        XCTAssertEqual(boldNode.name, boldNodeName)
+        XCTAssertEqual(boldNode.children.count, 2)
+        XCTAssertEqual(boldNode.children[0], em)
+        XCTAssertEqual(boldNode.children[1], underline)
+
+        XCTAssertEqual(em.children.count, 1)
+        XCTAssertEqual(em.children[0], textNode1)
+
+        XCTAssertEqual(underline.children.count, 1)
+        XCTAssertEqual(underline.children[0], textNode2)
+    }
 }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -437,6 +437,7 @@ class ElementNodeTests: XCTestCase {
 
 
     /// Tests obtaining the block-level elements intercepting the full range of the following
+    ///
     /// HTML string: <div><p>Hello </p>there!</div>
     ///
     /// The results should be:
@@ -463,5 +464,83 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(results[1].element.name, "div")
         XCTAssertEqual(results[1].intersection.location, 6)
         XCTAssertEqual(results[1].intersection.length, 6)
+    }
+
+    /// Tests wrapping child nodes intersecting a certain range in a new `b` node.
+    ///
+    /// HTML String: <div><em>Hello </em>there!</div>
+    /// Wrap range: (0...6)
+    ///
+    /// The result should be: <div><b><em>Hello </em></b>there!</div>
+    ///
+    func testWrapChildrenInNewBNode1() {
+
+        let boldNodeName = "b"
+        let range = NSRange(location: 0, length: 6)
+
+        let textPart1 = "Hello "
+        let textPart2 = "there!"
+
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
+        let div = ElementNode(name: "div", attributes: [], children: [em, textNode2])
+
+        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [])
+
+        XCTAssertEqual(div.children.count, 2)
+        XCTAssertEqual(div.children[1], textNode2)
+
+        guard let boldNode = div.children[0] as? ElementNode else {
+            XCTFail("Expected a bold node here.")
+            return
+        }
+
+        XCTAssertEqual(boldNode.name, boldNodeName)
+        XCTAssertEqual(boldNode.children.count, 1)
+        XCTAssertEqual(boldNode.children[0], em)
+
+        XCTAssertEqual(em.children.count, 1)
+        XCTAssertEqual(em.children[0], textNode1)
+    }
+
+    /// Tests wrapping child nodes intersecting a certain range in a new `b` node.
+    ///
+    /// HTML String: <div><em>Hello </em>there!</div>
+    /// Wrap range: (0...6)
+    ///
+    /// The result should be: <div><b><em>Hello </em></b>there!</div>
+    ///
+    func testWrapChildrenInNewBNode2() {
+
+        let boldNodeName = "b"
+        let range = NSRange(location: 0, length: 6)
+
+        let textPart1 = "Hello "
+        let textPart2 = "there!"
+
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
+        let div = ElementNode(name: "div", attributes: [], children: [em, textNode2])
+
+        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [])
+
+        XCTAssertEqual(div.children.count, 2)
+        XCTAssertEqual(div.children[1], textNode2)
+
+        guard let boldNode = div.children[0] as? ElementNode else {
+            XCTFail("Expected a bold node here.")
+            return
+        }
+
+        XCTAssertEqual(boldNode.name, boldNodeName)
+        XCTAssertEqual(boldNode.children.count, 1)
+        XCTAssertEqual(boldNode.children[0], em)
+
+        XCTAssertEqual(em.children.count, 1)
+        XCTAssertEqual(em.children[0], textNode1)
     }
 }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -548,7 +548,7 @@ class ElementNodeTests: XCTestCase {
     /// Tests wrapping child nodes intersecting a certain range in a new `b` node.
     ///
     /// HTML String: <div><em>Hello </em><i>there!</i></div>
-    /// Wrap range: (0...6)
+    /// Wrap range: full text range / full div node range
     ///
     /// The result should be: <div><b><em>Hello </em><u>there!</u></b></div>
     ///


### PR DESCRIPTION
It's now possible to apply bold-style to text runs.  It's also smart about how it wraps existing nodes, and how it inserts and breaks the bold styling (where necessary).

Related to #18.

**Known limitations:**
1. It doesn't check for pre-existing bold styling, so it's possible to end up having HTML such as `<strong><b>hello</b></strong>`.
2. Removing bold doesn't affect HTML.

**How to test:**
1. Run the editor demo.
2. Select any range of text.
3. Make it bold.  Make sure the HTML is affected by switching to HTML mode.
4. Make sure to run the unit tests too.