### PR TITLE
Implements bold and italic styles.

### DIFF
--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -300,7 +300,7 @@ extension Libxml2 {
                                 if let previousRangeWithoutMatch = rangeWithoutMatch {
                                     rangeWithoutMatch = NSRange(location: previousRangeWithoutMatch.location, length: previousRangeWithoutMatch.length + range.length)
                                 } else {
-                                    rangeWithoutMatch = range
+                                    rangeWithoutMatch = NSRange(location: offset + range.location, length: range.length)
                                 }
                             },
                             onMatchFound: { [weak self] (child, intersection) in

--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -64,6 +64,16 @@ extension Libxml2 {
             }
         }
 
+        class Equivalence {
+            let elementName1: String
+            let elementName2: String
+
+            init(ofElementNamed elementName1: String, andElementNamed elementName2: String) {
+                self.elementName1 = elementName1
+                self.elementName2 = elementName2
+            }
+        }
+
         private(set) var attributes = [Attribute]()
         private(set) var children: [Node]
 
@@ -187,8 +197,6 @@ extension Libxml2 {
         ///     - targetRange: the range we're intersecting the child nodes with.  The range is in
         ///             this node's coordinates (the parent node's coordinates, from the children
         ///             PoV).
-        ///     - matchFound: the closure to execute for each child element intersecting
-        ///             `targetRange`.
         ///
         /// - Returns: an array of child nodes and their intersection.  The intersection range is in
         ///         child coordinates.
@@ -588,7 +596,8 @@ extension Libxml2 {
         ///
         override func split(forRange range: NSRange) {
 
-            guard range.location > 0 || range.length < length() else {
+            guard range.location >= 0 && range.location + range.length <= length() else {
+                assertionFailure("Specified range is out-of-bounds.")
                 return
             }
 
@@ -617,13 +626,8 @@ extension Libxml2 {
             }
         }
 
-        func unwrap() {
-            guard let parent = parent else {
-                assertionFailure("The root node in a hierarchy cannot be unwrapped using this method.")
-                return
-            }
-
-            parent.replace(child: self, with: self.children)
+        func unwrap(fromElementsNamed elementNames: [String]) {
+            unwrap(range: range(), fromElementsNamed: elementNames)
         }
 
         /// Unwraps the specified range from nodes with the specified name.  If there are multiple
@@ -631,15 +635,17 @@ extension Libxml2 {
         ///
         /// - Parameters:
         ///     - range: the range that must be unwrapped.
-        ///     - nodeName: the name of the node the range must be unwrapped from.
+        ///     - elementNames: the names of the elements the range must be unwrapped from.
         ///
         /// - Todo: this method works with node names only for now.  At some point we'll want to
         ///         modify this to be able to do more complex lookups.  For instance we'll want
         ///         to be able to unwrapp CSS attributes, not just nodes by name.
         ///
-        func unwrap(range range: NSRange, fromNodeNamed nodeName: String) {
+        func unwrap(range range: NSRange, fromElementsNamed elementNames: [String]) {
 
-            if name == nodeName {
+            unwrapChildren(intersectingRange: range, fromElementsNamed: elementNames)
+
+            if elementNames.contains(name) {
 
                 let rangeEndLocation = range.location + range.length
 
@@ -661,7 +667,53 @@ extension Libxml2 {
                     wrap(range: postRange, inNodeNamed: name, withAttributes: attributes)
                 }
 
-                unwrap()
+                unwrapChildren()
+            }
+        }
+
+        /// Unwraps the receiver's children from the receiver.
+        ///
+        func unwrapChildren() {
+            if let parent = parent {
+                parent.replace(child: self, with: self.children)
+            } else {
+                for child in children {
+                    child.parent = nil
+                }
+
+                children.removeAll()
+            }
+        }
+
+        func unwrapChildren(children: [Node], fromElementsNamed elementNames: [String]) {
+
+            for child in children {
+
+                guard let childElement = child as? ElementNode else {
+                    continue
+                }
+
+                childElement.unwrap(fromElementsNamed: elementNames)
+            }
+        }
+
+        /// Unwraps all child nodes from elements with the specified names.
+        ///
+        /// - Parameters:
+        ///     - range: the range we want to unwrap.
+        ///     - elementNames: the name of the elements we want to unwrap the nodes from.
+        ///
+        func unwrapChildren(intersectingRange range: NSRange, fromElementsNamed elementNames: [String]) {
+
+            let childNodesAndRanges = childNodes(intersectingRange: range)
+            assert(childNodesAndRanges.count > 0)
+
+            for (child, range) in childNodesAndRanges {
+                guard let childElement = child as? ElementNode else {
+                    continue
+                }
+
+                childElement.unwrap(range: range, fromElementsNamed: elementNames)
             }
         }
 
@@ -708,17 +760,20 @@ extension Libxml2 {
         ///     - checkBlockLevel: if `true`, this method will check if its necessary to find the
         ///             lowest block-level element nodes before doing the wrapping.
         ///
-        func wrapChildren(intersectingRange targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute]) {
+        func wrapChildren(intersectingRange targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) {
+
+            // Before wrapping a range in a node, we remove all equivalent nodes from the range.
+            //
+            if equivalentElementNames.count > 0 {
+                unwrap(range: targetRange, fromElementsNamed: equivalentElementNames)
+            }
 
             let mustFindLowestBlockLevelElements = !StandardName.isBlockLevelNodeName(nodeName)
 
             if mustFindLowestBlockLevelElements {
                 let elementsAndIntersections = lowestBlockLevelElements(intersectingRange: targetRange)
 
-                for elementAndIntersection in elementsAndIntersections {
-
-                    let element = elementAndIntersection.element
-                    let intersection = elementAndIntersection.intersection
+                for (element, intersection) in elementsAndIntersections {
 
                     element.forceWrapChildren(
                         intersectingRange: intersection,
@@ -747,11 +802,8 @@ extension Libxml2 {
             forceWrapChildren(intersectingRange: targetRange, inNodeNamed: nodeName, withAttributes: attributes)
         }
 
-
         /// Force wraps child nodes intersecting the specified range inside new elements with the
         /// specified properties.
-        ///
-        /// but it does not check any block-level element logic.
         ///
         /// - Important: this is almost the same as
         ///         `wrapChildren(intersectingRange:, inNodeNamed:, withAttributes:)` but this
@@ -761,8 +813,6 @@ extension Libxml2 {
         ///     - targetRange: the range that must be wrapped.
         ///     - nodeName: the name of the node to wrap the range in.
         ///     - attributes: the attributes the wrapping node will have when created.
-        ///     - checkBlockLevel: if `true`, this method will check if its necessary to find the
-        ///             lowest block-level element nodes before doing the wrapping.
         ///
         private func forceWrapChildren(intersectingRange targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute]) {
 
@@ -789,7 +839,7 @@ extension Libxml2 {
                 }
 
                 let lastChild = childNodesAndRanges[childNodesAndRanges.count - 1].child
-                let lastChildIntersection = childNodesAndRanges[0].intersection
+                let lastChildIntersection = childNodesAndRanges[childNodesAndRanges.count - 1].intersection
 
                 if !NSEqualRanges(lastChild.range(), lastChildIntersection) {
                     lastChild.split(forRange: lastChildIntersection)

--- a/Classes/Private/Libxml2/Libxml2.swift
+++ b/Classes/Private/Libxml2/Libxml2.swift
@@ -1,12 +1,9 @@
 import Foundation
 
-enum Libxml2 {
-    enum In {
+class Libxml2 {
+    class In {
     }
 
-    enum Out {
-    }
-
-    enum HTML {
+    class Out {
     }
 }

--- a/Classes/Public/TextKit/AztecTextStorage.swift
+++ b/Classes/Public/TextKit/AztecTextStorage.swift
@@ -9,6 +9,18 @@ public class AztecTextStorage: NSTextStorage {
     typealias TextNode = Libxml2.TextNode
     typealias RootNode = Libxml2.RootNode
 
+    /// Element names for bold.
+    ///
+    /// - Note: The first element name is the preferred one.
+    ///
+    private static let elementNamesForBold = ["b", "strong"]
+
+    /// Element names for italic.
+    ///
+    /// - Note: The first element name is the preferred one.
+    ///
+    private static let elementNamesForItalic = ["em", "i"]
+
     private var textStore = NSMutableAttributedString(string: "", attributes: nil)
 
     private var rootNode: RootNode = {
@@ -71,15 +83,51 @@ public class AztecTextStorage: NSTextStorage {
         }
     }
 
+    func toggleItalic(range: NSRange) {
+
+        let enable = !fontTrait(.TraitItalic, spansRange: range)
+
+        modifyTrait(.TraitItalic, range: range, enable: enable)
+
+        if enable {
+            enableItalicInDOM(range)
+        } else {
+            disableItalicInDom(range)
+        }
+    }
+
     // MARK: - DOM
 
     private func disableBoldInDom(range: NSRange) {
-        rootNode.unwrap(range: range, fromNodeNamed: "b")
+        rootNode.unwrap(range: range, fromElementsNamed: self.dynamicType.elementNamesForBold)
+    }
+
+    private func disableItalicInDom(range: NSRange) {
+        rootNode.unwrap(range: range, fromElementsNamed: self.dynamicType.elementNamesForItalic)
     }
 
     private func enableBoldInDOM(range: NSRange) {
 
-        rootNode.wrapChildren(intersectingRange: range, inNodeNamed: "b", withAttributes: [])
+        enableInDom(
+            self.dynamicType.elementNamesForBold[0],
+            inRange: range,
+            equivalentElementNames: self.dynamicType.elementNamesForBold)
+    }
+
+    private func enableInDom(elementName: String, inRange range: NSRange, equivalentElementNames: [String]) {
+        rootNode.wrapChildren(
+            intersectingRange: range,
+            inNodeNamed: elementName,
+            withAttributes: [],
+            equivalentElementNames: equivalentElementNames)
+    }
+
+    private func enableItalicInDOM(range: NSRange) {
+
+        enableInDom(
+            self.dynamicType.elementNamesForItalic[0],
+            inRange: range,
+            equivalentElementNames: self.dynamicType.elementNamesForItalic)
     }
 
     // MARK: - HTML Interaction

--- a/Classes/Public/TextKit/AztecVisualEditor.swift
+++ b/Classes/Public/TextKit/AztecVisualEditor.swift
@@ -202,7 +202,7 @@ public class AztecVisualEditor : NSObject {
     ///     - range: The NSRange to edit.
     ///
     public func toggleBold(range range: NSRange) {
-        // Bail if nothing is selected
+
         if range.length == 0 {
             return
         }
@@ -217,11 +217,12 @@ public class AztecVisualEditor : NSObject {
     ///     - range: The NSRange to edit.
     ///
     public func toggleItalic(range range: NSRange) {
-        // Bail if nothing is selected
+
         if range.length == 0 {
             return
         }
-        storage.toggleFontTrait(.TraitItalic, range: range)
+
+        storage.toggleItalic(range)
     }
 
 

--- a/Example/Tests/AztecVisualEditorTests.swift
+++ b/Example/Tests/AztecVisualEditorTests.swift
@@ -73,10 +73,7 @@ class AztecVisualEditorTests: XCTestCase {
     // MARK: - Retrieve Format Identifiers
 
     func testFormatIdentifiersSpanningRange() {
-        let attributes = [
-            NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
 
         let range = NSRange(location: 3, length: 3)
         let identifiers = editor.formatIdentifiersSpanningRange(range)
@@ -86,10 +83,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testFormatIdentifiersAtIndex() {
-        let attributes = [
-            NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
 
         var identifiers = editor.formatIdentifiersAtIndex(4)
         XCTAssert(identifiers.count == 1)
@@ -117,10 +111,7 @@ class AztecVisualEditorTests: XCTestCase {
     // MARK: - Toggle Attributes
 
     func testToggleBold() {
-        let attributes = [
-            NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
         let range = NSRange(location: 3, length: 3)
 
         XCTAssert(editor.boldFormattingSpansRange(range))
@@ -135,10 +126,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testToggleItalic() {
-        let attributes = [
-            NSFontAttributeName: UIFont.italicSystemFontOfSize(10)
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<i>bar</i>baz")
         let range = NSRange(location: 3, length: 3)
 
         XCTAssert(editor.italicFormattingSpansRange(range))
@@ -153,10 +141,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testToggleUnderline() {
-        let attributes = [
-            NSUnderlineStyleAttributeName: NSUnderlineStyle.StyleSingle.rawValue
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<u>bar</u>baz")
         let range = NSRange(location: 3, length: 3)
 
         XCTAssert(editor.underlineFormattingSpansRange(range))
@@ -171,10 +156,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testToggleStrike() {
-        let attributes = [
-            NSStrikethroughStyleAttributeName: NSUnderlineStyle.StyleSingle.rawValue
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<strike>bar</strike>baz")
         let range = NSRange(location: 3, length: 3)
 
         XCTAssert(editor.strikethroughFormattingSpansRange(range))
@@ -219,10 +201,7 @@ class AztecVisualEditorTests: XCTestCase {
     // MARK: - Test Attributes Exist
 
     func testBoldSpansRange() {
-        let attributes = [
-            NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
 
         XCTAssert(editor.boldFormattingSpansRange(NSRange(location: 3, length: 3)))
         XCTAssert(editor.boldFormattingSpansRange(NSRange(location: 3, length: 2)))
@@ -233,10 +212,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testItalicSpansRange() {
-        let attributes = [
-            NSFontAttributeName: UIFont.italicSystemFontOfSize(10)
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<i>bar</i>baz")
 
         XCTAssert(editor.italicFormattingSpansRange(NSRange(location: 3, length: 3)))
         XCTAssert(editor.italicFormattingSpansRange(NSRange(location: 3, length: 2)))
@@ -247,10 +223,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testUnderlineSpansRange() {
-        let attributes = [
-            NSUnderlineStyleAttributeName: NSUnderlineStyle.StyleSingle.rawValue
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<u>bar</u>baz")
 
         XCTAssert(editor.underlineFormattingSpansRange(NSRange(location: 3, length: 3)))
         XCTAssert(editor.underlineFormattingSpansRange(NSRange(location: 3, length: 2)))
@@ -261,10 +234,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testStrikethroughSpansRange() {
-        let attributes = [
-            NSStrikethroughStyleAttributeName: NSUnderlineStyle.StyleSingle.rawValue
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<strike>bar</strike>baz")
 
         XCTAssert(editor.strikethroughFormattingSpansRange(NSRange(location: 3, length: 3)))
         XCTAssert(editor.strikethroughFormattingSpansRange(NSRange(location: 3, length: 2)))
@@ -287,10 +257,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testBoldAtIndex() {
-        let attributes = [
-            NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
 
         XCTAssert(editor.formattingAtIndexContainsBold(3))
         XCTAssert(editor.formattingAtIndexContainsBold(4))
@@ -301,10 +268,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testItalicAtIndex() {
-        let attributes = [
-            NSFontAttributeName: UIFont.italicSystemFontOfSize(10)
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<i>bar</i>baz")
 
         XCTAssert(editor.formattingAtIndexContainsItalic(3))
         XCTAssert(editor.formattingAtIndexContainsItalic(4))
@@ -315,10 +279,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testUnderlineAtIndex() {
-        let attributes = [
-            NSUnderlineStyleAttributeName: NSUnderlineStyle.StyleSingle.rawValue
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<u>bar</u>baz")
 
         XCTAssert(editor.formattingAtIndexContainsUnderline(3))
         XCTAssert(editor.formattingAtIndexContainsUnderline(4))
@@ -329,10 +290,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     func testStrikethroughAtIndex() {
-        let attributes = [
-            NSStrikethroughStyleAttributeName: NSUnderlineStyle.StyleSingle.rawValue
-        ]
-        let editor = editorConfiguredForTestingWithAttributes(attributes)
+        let editor = editorConfiguredForTesting(withHTML: "foo<strike>bar</strike>baz")
 
         XCTAssert(editor.formattingAtIndexContainsStrikethrough(3))
         XCTAssert(editor.formattingAtIndexContainsStrikethrough(4))
@@ -359,14 +317,11 @@ class AztecVisualEditorTests: XCTestCase {
 
     // MARK: - Helpers
 
-    func editorConfiguredForTestingWithAttributes(attributes: [String: AnyObject]) -> AztecVisualEditor {
+    func editorConfiguredForTesting(withHTML html: String) -> AztecVisualEditor {
         let textView = AztecVisualEditor.createTextView()
         let editor = AztecVisualEditor(textView: textView)
 
-        let attrStr = NSMutableAttributedString(string: "foo")
-        attrStr.appendAttributedString(NSAttributedString(string: "bar", attributes: attributes))
-        attrStr.appendAttributedString(NSAttributedString(string: "baz"))
-        textView.attributedText = attrStr
+        editor.setHTML(html)
 
         return editor
     }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -547,7 +547,7 @@ class ElementNodeTests: XCTestCase {
 
     /// Tests wrapping child nodes intersecting a certain range in a new `b` node.
     ///
-    /// HTML String: <div><em>Hello </em><i>there!</i></div>
+    /// HTML String: <div><em>Hello </em><u>there!</u></div>
     /// Wrap range: full text range / full div node range
     ///
     /// The result should be: <div><b><em>Hello </em><u>there!</u></b></div>
@@ -571,6 +571,54 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(div.children.count, 1)
 
         guard let boldNode = div.children[0] as? ElementNode else {
+            XCTFail("Expected a bold node here.")
+            return
+        }
+
+        XCTAssertEqual(boldNode.name, boldNodeName)
+        XCTAssertEqual(boldNode.children.count, 2)
+        XCTAssertEqual(boldNode.children[0], em)
+        XCTAssertEqual(boldNode.children[1], underline)
+
+        XCTAssertEqual(em.children.count, 1)
+        XCTAssertEqual(em.children[0], textNode1)
+
+        XCTAssertEqual(underline.children.count, 1)
+        XCTAssertEqual(underline.children[0], textNode2)
+    }
+
+
+    /// Tests wrapping child nodes intersecting a certain range in a new `b` node.
+    ///
+    /// HTML String: <div><em>Hello </em><i>there!</i></div>
+    /// Wrap range: (2...8)
+    ///
+    /// The result should be: <div><em>He</em><b><em>llo </em><u>ther</u></b><u>e!</u></div>
+    ///
+    func testWrapChildrenInNewBNode4() {
+
+        let boldNodeName = "b"
+
+        let textPart1 = "Hello "
+        let textPart2 = "there!"
+
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
+        let underline = ElementNode(name: "u", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [em, underline])
+
+        let range = NSRange(location: 2, length: 8)
+
+        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [], equivalentElementNames: [])
+
+        XCTAssertEqual(div.children.count, 3)
+
+        XCTAssertEqual(div.children[0], em)
+        XCTAssertEqual(div.children[2], underline)
+
+        guard let boldNode = div.children[1] as? ElementNode else {
             XCTFail("Expected a bold node here.")
             return
         }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -615,8 +615,10 @@ class ElementNodeTests: XCTestCase {
 
         XCTAssertEqual(div.children.count, 3)
 
-        XCTAssertEqual(div.children[0], em)
-        XCTAssertEqual(div.children[2], underline)
+        XCTAssertEqual(div.children[0].name, "em")
+        XCTAssertEqual(div.children[0].length(), 2)
+        XCTAssertEqual(div.children[2].name, "u")
+        XCTAssertEqual(div.children[2].length(), 2)
 
         guard let boldNode = div.children[1] as? ElementNode else {
             XCTFail("Expected a bold node here.")
@@ -629,9 +631,9 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(boldNode.children[1], underline)
 
         XCTAssertEqual(em.children.count, 1)
-        XCTAssertEqual(em.children[0], textNode1)
+        XCTAssertEqual(em.children[0].length(), 4)
 
         XCTAssertEqual(underline.children.count, 1)
-        XCTAssertEqual(underline.children[0], textNode2)
+        XCTAssertEqual(underline.children[0].length(), 4)
     }
 }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -487,7 +487,7 @@ class ElementNodeTests: XCTestCase {
         let em = ElementNode(name: "em", attributes: [], children: [textNode1])
         let div = ElementNode(name: "div", attributes: [], children: [em, textNode2])
 
-        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [])
+        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [], equivalentElementNames: [])
 
         XCTAssertEqual(div.children.count, 2)
         XCTAssertEqual(div.children[1], textNode2)
@@ -526,7 +526,7 @@ class ElementNodeTests: XCTestCase {
         let em = ElementNode(name: "em", attributes: [], children: [textNode1])
         let div = ElementNode(name: "div", attributes: [], children: [em, textNode2])
 
-        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [])
+        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [], equivalentElementNames: [])
 
         XCTAssertEqual(div.children.count, 2)
         XCTAssertEqual(div.children[1], textNode2)
@@ -566,7 +566,7 @@ class ElementNodeTests: XCTestCase {
         let underline = ElementNode(name: "u", attributes: [], children: [textNode2])
         let div = ElementNode(name: "div", attributes: [], children: [em, underline])
 
-        div.wrapChildren(intersectingRange: div.range(), inNodeNamed: boldNodeName, withAttributes: [])
+        div.wrapChildren(intersectingRange: div.range(), inNodeNamed: boldNodeName, withAttributes: [], equivalentElementNames: [])
 
         XCTAssertEqual(div.children.count, 1)
 

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -70,6 +70,39 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(node, mainNode)
     }
 
+    /// Tries to obtain the lowest block-level elements intersecting the specified range.
+    ///
+    /// HTML string: <p>Hello <b>world</b>!</p>
+    /// Range: (6...5)
+    ///
+    /// The result should be: 
+    ///     - element: the main paragraph
+    ///     - range: (6...5)
+    ///
+    func testEnumerateBlockLowestElementsIntersectingRange() {
+
+        let textNode1 = TextNode(text: "Hello ")
+        let textNode2 = TextNode(text: "world")
+        let textNode3 = TextNode(text: "!")
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+
+        let range = NSRange(location: textNode1.length(), length: textNode2.length())
+        let atLeastOneElementFound = expectationWithDescription("At least one elements should be returned in the enumeration.")
+
+        paragraph.enumerateLowestBlockLevelElements(intersectingRange: range) { (element, intersection) in
+            XCTAssertEqual(element, paragraph)
+            XCTAssertEqual(intersection.location, range.location)
+            XCTAssertEqual(intersection.length, range.length)
+            atLeastOneElementFound.fulfill()
+        }
+        waitForExpectationsWithTimeout(0) { (error) in
+            if let error = error {
+                XCTFail(error.description)
+            }
+        }
+    }
+
     func testTextNodesWrappingRange1() {
         let text1 = TextNode(text: "text1 goes here")
         let text2 = TextNode(text: "text2 goes here")


### PR DESCRIPTION
Implements bold and italic style editing.  This means you should be able to toggle bold and italics on and off, following the editing logic of our previous editor.

Fixes: #18 and #41.

**Known issues:**
- There's an issue related to our HTML importer not ignoring some characters that can cause node duplication if you switch back and forth several times between visual and HTML mode while editing styles.  This will be fixed separately.