### PR TITLE
Text editing support

### DIFF
--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -203,7 +203,7 @@ extension Libxml2 {
                 let childLength = child.length()
                 let childRange = NSRange(location: offset, length: childLength)
                 let intersectionRange = NSIntersectionRange(childRange, targetRange)
-                let childRangeInterceptsTargetRange =
+                let childRangeInterceptsTargetRange = 
                     (intersectionRange.location > 0 && intersectionRange.length < childLength)
                     || intersectionRange.length > 0
 

--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -136,6 +136,33 @@ extension Libxml2 {
 
         // MARK: - DOM Queries
 
+        /// Returns the child node at the specified location.
+        ///
+        func childNode(atLocation location: Int, defaultToLeftNode: Bool = true) -> Node {
+
+            let defaultToRightNode = !defaultToLeftNode
+            let offset = Int(0)
+
+            for (index, child) in children.enumerate() {
+
+                // On the last element, we need to force-default to the left node.
+                //
+                let bypassedDefaultToLeftNode = (defaultToLeftNode || index == children.count)
+
+                let finalLocation = offset + child.length()
+                let returnThisNode =
+                    (location == offset && defaultToRightNode)
+                    || location < finalLocation
+                    || (location == offset + child.length() && bypassedDefaultToLeftNode)
+
+                if returnThisNode {
+                    return child
+                }
+            }
+
+            fatalError("The specified location is out of bounds.")
+        }
+
         /// Get a list of child nodes intersecting the specified range.
         ///
         /// - Parameters:
@@ -466,6 +493,17 @@ extension Libxml2 {
             children.insertContentsOf(newChildren, at: childIndex)
         }
 
+        /// Removes the receiver from its parent.
+        ///
+        func removeFromParent() {
+            guard let parent = parent else {
+                assertionFailure("It doesn't make sense to call this method without a parent")
+                return
+            }
+
+            parent.remove(self)
+        }
+
 
         /// Removes the specified child node.  Only updates its parent if specified.
         ///
@@ -590,6 +628,39 @@ extension Libxml2 {
             }
 
             return result
+        }
+
+        override func deleteCharacters(inRange range: NSRange) {
+            if range.location == 0 && range.length == length() {
+                removeFromParent()
+            } else {
+                let childrenAndIntersections = childNodes(intersectingRange: range)
+
+                for (child, intersection) in childrenAndIntersections {
+                    child.deleteCharacters(inRange: intersection)
+                }
+            }
+        }
+
+        override func replaceCharacters(inRange range: NSRange, withString string: String) {
+
+            let childrenAndIntersections = childNodes(intersectingRange: range)
+
+            for (index, childAndIntersection) in childrenAndIntersections.enumerate() {
+
+                let child = childAndIntersection.child
+                let intersection = childAndIntersection.intersection
+
+                if index == 0 && string.characters.count > 0 {
+                    child.replaceCharacters(inRange: intersection, withString: string)
+                } else {
+                    child.deleteCharacters(inRange: intersection)
+                }
+            }
+
+            let child = childNode(atLocation: range.location)
+
+            child.replaceCharacters(inRange: range, withString: string)
         }
 
         /// Splits this node following the specified range.

--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -203,7 +203,9 @@ extension Libxml2 {
                 let childLength = child.length()
                 let childRange = NSRange(location: offset, length: childLength)
                 let intersectionRange = NSIntersectionRange(childRange, targetRange)
-                let childRangeInterceptsTargetRange = (intersectionRange.length > 0)
+                let childRangeInterceptsTargetRange =
+                    (intersectionRange.location > 0 && intersectionRange.length < childLength)
+                    || intersectionRange.length > 0
 
                 if childRangeInterceptsTargetRange {
 
@@ -657,10 +659,6 @@ extension Libxml2 {
                     child.deleteCharacters(inRange: intersection)
                 }
             }
-
-            let child = childNode(atLocation: range.location)
-
-            child.replaceCharacters(inRange: range, withString: string)
         }
 
         /// Splits this node following the specified range.

--- a/Classes/Private/Libxml2/Data/Node.swift
+++ b/Classes/Private/Libxml2/Data/Node.swift
@@ -28,6 +28,14 @@ extension Libxml2 {
             return 0
         }
 
+        func deleteCharacters(inRange range: NSRange) {
+            assertionFailure("This method should always be overridden.")
+        }
+
+        func replaceCharacters(inRange range: NSRange, withString: String) {
+            assertionFailure("This method should always be overridden.")
+        }
+
         func split(forRange range: NSRange) {
             assertionFailure("This method should always be overridden.")
         }

--- a/Classes/Private/Libxml2/Data/TextNode.swift
+++ b/Classes/Private/Libxml2/Data/TextNode.swift
@@ -23,6 +23,24 @@ extension Libxml2 {
             return text.characters.count
         }
 
+        override func deleteCharacters(inRange range: NSRange) {
+
+            guard let textRange = text.rangeFromNSRange(range) else {
+                fatalError("The specified range is out of bounds.")
+            }
+
+            text.removeRange(textRange)
+        }
+
+        override func replaceCharacters(inRange range: NSRange, withString string: String) {
+
+            guard let textRange = text.rangeFromNSRange(range) else {
+                fatalError("The specified range is out of bounds.")
+            }
+
+            text.replaceRange(textRange, with: string)
+        }
+
         override func split(forRange range: NSRange) {
 
             guard let swiftRange = text.rangeFromNSRange(range) else {

--- a/Classes/Public/TextKit/AztecTextStorage.swift
+++ b/Classes/Public/TextKit/AztecTextStorage.swift
@@ -43,7 +43,9 @@ public class AztecTextStorage: NSTextStorage {
 
         // NOTE: Hook in any custom attribute handling here.
 
-        textStore.replaceCharactersInRange(range, withString:str)
+        textStore.replaceCharactersInRange(range, withString: str)
+        rootNode.replaceCharacters(inRange: range, withString: str)
+
         edited(.EditedCharacters, range: range, changeInLength: (str as NSString).length - range.length)
 
         endEditing()
@@ -58,14 +60,6 @@ public class AztecTextStorage: NSTextStorage {
         edited(.EditedAttributes, range: range, changeInLength: 0)
 
         endEditing()
-    }
-
-
-    override public func processEditing() {
-        // Edits have happened and are about to be implemented.
-        // Do any last minute changes here *BEFORE* calling super.about
-
-        super.processEditing()
     }
 
     // MARK: - Styles

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -669,4 +669,28 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(underline.children.count, 1)
         XCTAssertEqual(underline.children[0].length(), 4)
     }
+
+    /// Tests `childNodes(intersectingRange:)` with a zero-length range.
+    ///
+    /// Input HTML: <p>This is a test string.</p>
+    /// Range: (5...5)
+    ///
+    /// Expected results:
+    ///     - should find 1 matching child node (the text node)
+    ///     - the range should be unchanged
+    ///
+    func testChildNodesIntersectingRange() {
+        let textNode = TextNode(text: "This is a test string.")
+        let rangeLocation = 5
+        XCTAssert(rangeLocation < textNode.length(),
+                  "For this text we need to make sure the range location is inside the test node.")
+
+        let range = NSRange(location: rangeLocation, length: 0)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+
+        let children = paragraph.childNodes(intersectingRange: range)
+        XCTAssertEqual(children.count, 1)
+        XCTAssertEqual(children[0].child, textNode)
+        XCTAssert(NSEqualRanges(children[0].intersection, range))
+    }
 }

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -689,7 +689,12 @@ class ElementNodeTests: XCTestCase {
         let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
 
         let children = paragraph.childNodes(intersectingRange: range)
-        XCTAssertEqual(children.count, 1)
+
+        guard children.count == 1 else {
+            XCTFail("Expected 1 child.")
+            return
+        }
+
         XCTAssertEqual(children[0].child, textNode)
         XCTAssert(NSEqualRanges(children[0].intersection, range))
     }


### PR DESCRIPTION
Fixes #46.

Adds text editing support which is reflected in the HTML output.

**How to test:**
1. Launch the editor.
2. Edit some text (no styles for the scope of this PR, just text)
3. Switch to HTML mode and make sure the output is as expected.