### PR TITLE
Fixes attributes conversion.

### DIFF
--- a/Classes/Private/Libxml2/Converters/Out/OutHTMLAttributeConverter.swift
+++ b/Classes/Private/Libxml2/Converters/Out/OutHTMLAttributeConverter.swift
@@ -6,6 +6,12 @@ extension Libxml2.Out {
 
         typealias Attribute = Libxml2.Attribute
         typealias StringAttribute = Libxml2.StringAttribute
+
+        private let node: xmlNodePtr
+
+        init(forNode node: xmlNodePtr = nil) {
+            self.node = node
+        }
         
         /// Converts a single HTML.Attribute into a single libxml2 attribute
         ///
@@ -41,8 +47,8 @@ extension Libxml2.Out {
             let value = rawStringAttribute.value
             let valueCStr = value.cStringUsingEncoding(NSUTF8StringEncoding)!
             let valuePtr = UnsafeMutablePointer<xmlChar>(valueCStr)
-            
-            return xmlNewProp(nil, namePtr, valuePtr)
+
+            return xmlNewProp(node, namePtr, valuePtr)
         }
         
         /// Creates a libxml2 attribute from a HTML.Attribute.
@@ -57,7 +63,7 @@ extension Libxml2.Out {
             let nameCStr = name.cStringUsingEncoding(NSUTF8StringEncoding)!
             let namePtr = UnsafePointer<xmlChar>(nameCStr)
             
-            return xmlNewProp(nil, namePtr, nil)
+            return xmlNewProp(node, namePtr, nil)
         }
     }
 }

--- a/Classes/Private/Libxml2/Converters/Out/OutHTMLNodeConverter.swift
+++ b/Classes/Private/Libxml2/Converters/Out/OutHTMLNodeConverter.swift
@@ -43,6 +43,11 @@ extension Libxml2.Out {
             let namePtr = UnsafeMutablePointer<xmlChar>(nameCStr)
             
             let node = xmlNewNode(nil, namePtr)
+            let attributeConverter = AttributeConverter(forNode: node)
+
+            for rawAttribute in rawNode.attributes {
+                attributeConverter.convert(rawAttribute)
+            }
             
             for child in rawNode.children {
                 let childNode = nodeConverter.convert(child)


### PR DESCRIPTION
Fixes our attributes conversion logic.

When going back to HTML-mode, all attributes were being removed.

**How to test:**
1. Launch the demo editor.
2. Go to HTML mode.
3. Make sure all the HTML attributes from the original HTML are showing up.

Props to @SergioEstevao for spotting this issue.