### PR TITLE
Removes some unused custom attribute information.

### DIFF
--- a/Classes/Private/NSAttributedString/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Classes/Private/NSAttributedString/Converters/HTMLNodeToNSAttributedString.swift
@@ -63,11 +63,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     private func convertTextNode(node: TextNode, inheritingAttributes inheritedAttributes: [String:AnyObject]) -> NSAttributedString {
-
-        var attributes = inheritedAttributes
-        attributes[keyForNode(node)] = node
-
-        return NSAttributedString(string: node.text, attributes: attributes)
+        return NSAttributedString(string: node.text, attributes: inheritedAttributes)
     }
 
     /// Converts an `ElementNode` to `NSAttributedString`.
@@ -125,8 +121,6 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
             content.appendAttributedString(childContent)
         }
-
-        content.addAttribute(keyForNode(node), value: node, range: NSRange(location: 0, length: content.length))
 
         return content
     }


### PR DESCRIPTION
We were initially storing some custom attributes representing HTML tags in our editor's final visual string.

These are no longer needed as its not through this attributes that we're editing HTML tags.

**How to test:**
1. Make sure that when loading a post the styles are still working.
2. Make some simple editions to a post, and make sure when switching to HTML-mode that they still work as they do in `develop`.
3. Make sure the unit tests still run correctly.