### PR TITLE
Fixes the editor with no sample HTML

### DIFF
--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -169,13 +169,17 @@ extension Libxml2 {
         ///     - targetRange: the range we're intersecting the child nodes with.  The range is in
         ///             this node's coordinates (the parent node's coordinates, from the children
         ///             PoV).
+        ///     - preferLeftNode: for zero-length target ranges, this parameter is used to
+        ///             disambiguate if we're referring to the last position in a node, or to the
+        ///             first position in the following node (since both positions have the same
+        ///             offset).  By default this is true.
         ///
         /// - Returns: an array of pairs of child nodes and their ranges in child coordinates.
         ///
-        func childNodes(intersectingRange targetRange: NSRange) -> [(child: Node, intersection: NSRange)] {
+        func childNodes(intersectingRange targetRange: NSRange, preferLeftNode: Bool = true) -> [(child: Node, intersection: NSRange)] {
             var results = [(child: Node, intersection: NSRange)]()
 
-            enumerateChildNodes(intersectingRange: targetRange) { (child, intersection) in
+            enumerateChildNodes(intersectingRange: targetRange, preferLeftNode: preferLeftNode) { (child, intersection) in
                 results.append((child, intersection))
             }
 
@@ -188,24 +192,46 @@ extension Libxml2 {
         ///     - targetRange: the range we're intersecting the child nodes with.  The range is in
         ///             this node's coordinates (the parent node's coordinates, from the children
         ///             PoV).
+        ///     - preferLeftNode: for zero-length target ranges, this parameter is used to
+        ///             disambiguate if we're referring to the last position in a node, or to the
+        ///             first position in the following node (since both positions have the same
+        ///             offset).
         ///     - matchFound: the closure to execute for each child node intersecting
         ///             `targetRange`.
         ///
         /// - Returns: an array of child nodes and their intersection.  The intersection range is in
         ///         child coordinates.
         ///
-        func enumerateChildNodes(intersectingRange targetRange: NSRange, onMatchFound matchFound: (child: Node, intersection: NSRange) -> Void ) {
+        func enumerateChildNodes(intersectingRange targetRange: NSRange, preferLeftNode: Bool = true, onMatchFound matchFound: (child: Node, intersection: NSRange) -> Void ) {
 
             var offset = Int(0)
 
-            for child in children {
+            for (index, child) in children.enumerate() {
 
                 let childLength = child.length()
                 let childRange = NSRange(location: offset, length: childLength)
-                let intersectionRange = NSIntersectionRange(childRange, targetRange)
-                let childRangeInterceptsTargetRange = 
-                    (intersectionRange.location > 0 && intersectionRange.length < childLength)
-                    || intersectionRange.length > 0
+                let intersectionRange: NSRange
+                let childRangeInterceptsTargetRange: Bool
+
+                if targetRange.length > 0 {
+
+                    intersectionRange = NSIntersectionRange(childRange, targetRange)
+
+                    childRangeInterceptsTargetRange =
+                        (intersectionRange.location > 0 && intersectionRange.length < childLength)
+                        || intersectionRange.length > 0
+                } else {
+                    let targetLocation = targetRange.location
+                    let preferLeftNode = preferLeftNode || (index == children.count - 1)
+                    let preferRightNode = !preferLeftNode || (index == 0)
+
+                    childRangeInterceptsTargetRange =
+                        (preferRightNode && targetLocation == offset)
+                        || (preferLeftNode && targetLocation == offset + childLength)
+                        || (targetLocation > offset && targetLocation < offset + childLength)
+
+                    intersectionRange = NSRange(location: targetLocation - offset, length: 0)
+                }
 
                 if childRangeInterceptsTargetRange {
 
@@ -459,6 +485,21 @@ extension Libxml2 {
         }
 
         // MARK: - DOM modification
+
+        /// Appends a node into the list of children for this element.
+        ///
+        /// - Parameters:
+        ///     - child: the node to append.
+        ///
+        func append(child: Node) {
+
+            if let parent = child.parent {
+                parent.remove([child])
+            }
+
+            children.append(child)
+            child.parent = self
+        }
 
         /// Inserts a node into the list of children for this element.
         ///

--- a/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -222,15 +222,15 @@ extension Libxml2 {
                         || intersectionRange.length > 0
                 } else {
                     let targetLocation = targetRange.location
-                    let preferLeftNode = preferLeftNode || (index == children.count - 1)
-                    let preferRightNode = !preferLeftNode || (index == 0)
+                    let preferLeftNode = preferLeftNode || (index == children.count - 1 && targetLocation == offset + childLength)
+                    let preferRightNode = !preferLeftNode || (index == 0 && targetLocation == 0)
 
                     childRangeInterceptsTargetRange =
                         (preferRightNode && targetLocation == offset)
                         || (preferLeftNode && targetLocation == offset + childLength)
                         || (targetLocation > offset && targetLocation < offset + childLength)
 
-                    intersectionRange = NSRange(location: targetLocation - offset, length: 0)
+                    intersectionRange = NSRange(location: targetLocation, length: 0)
                 }
 
                 if childRangeInterceptsTargetRange {

--- a/Classes/Public/Converters/HTMLToAttributedString.swift
+++ b/Classes/Public/Converters/HTMLToAttributedString.swift
@@ -3,6 +3,7 @@ import Foundation
 class HTMLToAttributedString: Converter {
 
     typealias RootNode = Libxml2.RootNode
+    typealias TextNode = Libxml2.TextNode
 
     /// The default font descriptor that will be used as a base for conversions.
     ///
@@ -17,6 +18,11 @@ class HTMLToAttributedString: Converter {
         let nodeToAttributedString = HMTLNodeToNSAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
 
         let rootNode = try htmlToNode.convert(html)
+
+        if rootNode.children.count == 0 {
+            rootNode.append(TextNode(text: html))
+        }
+
         let attributedString = nodeToAttributedString.convert(rootNode)
 
         return (rootNode, attributedString)

--- a/Classes/Public/TextKit/AztecTextStorage.swift
+++ b/Classes/Public/TextKit/AztecTextStorage.swift
@@ -36,7 +36,7 @@ public class AztecTextStorage: NSTextStorage {
     private var textStore = NSMutableAttributedString(string: "", attributes: nil)
 
     private var rootNode: RootNode = {
-        return RootNode(children: [])
+        return RootNode(children: [TextNode(text: "")])
     }()
 
     // MARK: - NSTextStorage

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -673,7 +673,7 @@ class ElementNodeTests: XCTestCase {
     /// Tests `childNodes(intersectingRange:)` with a zero-length range.
     ///
     /// Input HTML: <p>This is a test string.</p>
-    /// Range: (5...5)
+    /// Range: (5...0)
     ///
     /// Expected results:
     ///     - should find 1 matching child node (the text node)

--- a/Example/Tests/HTML/ElementNodeTests.swift
+++ b/Example/Tests/HTML/ElementNodeTests.swift
@@ -679,7 +679,7 @@ class ElementNodeTests: XCTestCase {
     ///     - should find 1 matching child node (the text node)
     ///     - the range should be unchanged
     ///
-    func testChildNodesIntersectingRange() {
+    func testChildNodesIntersectingRange1() {
         let textNode = TextNode(text: "This is a test string.")
         let rangeLocation = 5
         XCTAssert(rangeLocation < textNode.length(),
@@ -688,14 +688,117 @@ class ElementNodeTests: XCTestCase {
         let range = NSRange(location: rangeLocation, length: 0)
         let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
 
-        let children = paragraph.childNodes(intersectingRange: range)
+        let childrenAndRanges = paragraph.childNodes(intersectingRange: range)
 
-        guard children.count == 1 else {
+        guard childrenAndRanges.count == 1 else {
             XCTFail("Expected 1 child.")
             return
         }
 
-        XCTAssertEqual(children[0].child, textNode)
-        XCTAssert(NSEqualRanges(children[0].intersection, range))
+        XCTAssertEqual(childrenAndRanges[0].child, textNode)
+        XCTAssert(NSEqualRanges(childrenAndRanges[0].intersection, range))
+    }
+
+
+    /// Tests `childNodes(intersectingRange:)` with a zero-length range.
+    ///
+    /// Input HTML: <p>This is a test string.</p>
+    /// Range: (0...0)
+    ///
+    /// Expected results:
+    ///     - should find 1 matching child node (the text node)
+    ///     - the range should be unchanged
+    ///
+    func testChildNodesIntersectingRange2() {
+        let textNode = TextNode(text: "This is a test string.")
+        let rangeLocation = 0
+        XCTAssert(rangeLocation < textNode.length(),
+                  "For this text we need to make sure the range location is inside the test node.")
+
+        let range = NSRange(location: rangeLocation, length: 0)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+
+        let childrenAndRanges = paragraph.childNodes(intersectingRange: range)
+
+        guard childrenAndRanges.count == 1 else {
+            XCTFail("Expected 1 child.")
+            return
+        }
+
+        XCTAssertEqual(childrenAndRanges[0].child, textNode)
+        XCTAssert(NSEqualRanges(childrenAndRanges[0].intersection, range))
+    }
+
+    /// Tests `childNodes(intersectingRange:)` with a zero-length range.
+    ///
+    /// Input HTML: <p><b>Hello</b><b>Hello again!</b></p>
+    /// Prefer left node: true
+    /// Range: (5...0)
+    ///
+    /// Expected results:
+    ///     - should find 1 matching child node (the first bold node)
+    ///     - the range should be unchanged
+    ///
+    func testChildNodesIntersectingRange3() {
+
+        let textNode1 = TextNode(text: "Hello")
+        let textNode2 = TextNode(text: "Hello again!")
+
+        let rangeLocation = 5
+        XCTAssert(rangeLocation == textNode1.length(),
+                  "For this text we need to make sure the range location is inside the test node.")
+
+        let range = NSRange(location: rangeLocation, length: 0)
+
+        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2])
+
+        let childrenAndRanges = paragraph.childNodes(intersectingRange: range, preferLeftNode: true)
+
+        guard childrenAndRanges.count == 1 else {
+            XCTFail("Expected 1 child.")
+            return
+        }
+
+        XCTAssertEqual(childrenAndRanges[0].child, bold1)
+        XCTAssert(NSEqualRanges(childrenAndRanges[0].intersection, range))
+    }
+
+
+    /// Tests `childNodes(intersectingRange:)` with a zero-length range.
+    ///
+    /// Input HTML: <p><b>Hello</b><b>Hello again!</b></p>
+    /// Prefer left node: false
+    /// Range: (5...0)
+    ///
+    /// Expected results:
+    ///     - should find 1 matching child node (the second bold node)
+    ///     - the range should be unchanged
+    ///
+    func testChildNodesIntersectingRange4() {
+
+        let textNode1 = TextNode(text: "Hello")
+        let textNode2 = TextNode(text: "Hello again!")
+
+        let rangeLocation = 5
+        XCTAssert(rangeLocation == textNode1.length(),
+                  "For this text we need to make sure the range location is inside the test node.")
+
+        let range = NSRange(location: rangeLocation, length: 0)
+
+        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2])
+
+        let childrenAndRanges = paragraph.childNodes(intersectingRange: range, preferLeftNode: false)
+
+        guard childrenAndRanges.count == 1 else {
+            XCTFail("Expected 1 child.")
+            return
+        }
+
+        XCTAssertEqual(childrenAndRanges[0].child, bold2)
+        XCTAssert(NSEqualRanges(childrenAndRanges[0].intersection, NSRange(location: 0, length: 0)))
     }
 }

--- a/Example/WordPress-Aztec-iOS/EditorDemoController.swift
+++ b/Example/WordPress-Aztec-iOS/EditorDemoController.swift
@@ -86,6 +86,8 @@ class EditorDemoController: UIViewController
         }
     }
 
+    var loadSampleHTML = false
+
 
     // MARK: - Lifecycle Methods
 
@@ -106,14 +108,19 @@ class EditorDemoController: UIViewController
         view.addSubview(richTextView)
         view.addSubview(htmlTextView)
 
-        editor.setHTML(getSampleHTML())
-
         configureConstraints()
         configureNavigationBar()
 
         layoutTextView()
     }
 
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if loadSampleHTML {
+            editor.setHTML(getSampleHTML())
+        }
+    }
 
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)

--- a/Example/WordPress-Aztec-iOS/EditorDemoController.swift
+++ b/Example/WordPress-Aztec-iOS/EditorDemoController.swift
@@ -6,8 +6,7 @@ import Photos
 
 class EditorDemoController: UIViewController
 {
-    private var bottomConstraint: NSLayoutConstraint!
-
+    static let margin = CGFloat(20)
 
     private (set) lazy var editor: AztecVisualEditor = {
         return AztecVisualEditor(textView: self.richTextView)
@@ -27,8 +26,6 @@ class EditorDemoController: UIViewController
         tv.inputAccessoryView = toolbar
         tv.textColor = UIColor.darkTextColor()
         tv.translatesAutoresizingMaskIntoConstraints = false
-        tv.addSubview(self.titleTextField)
-        tv.addSubview(self.separatorView)
 
         return tv
     }()
@@ -53,7 +50,6 @@ class EditorDemoController: UIViewController
         tf.accessibilityLabel = NSLocalizedString("Title", comment: "Post title")
         tf.attributedPlaceholder = NSAttributedString(string: placeholderText,
                                                       attributes: [NSForegroundColorAttributeName: UIColor.lightGrayColor()])
-        tf.autoresizingMask = [UIViewAutoresizing.FlexibleWidth]
         tf.delegate = self
         tf.font = UIFont.preferredFontForTextStyle(UIFontTextStyleHeadline)
         let toolbar = self.createToolbar()
@@ -62,6 +58,7 @@ class EditorDemoController: UIViewController
         tf.inputAccessoryView = toolbar
         tf.returnKeyType = .Next
         tf.textColor = UIColor.darkTextColor()
+        tf.translatesAutoresizingMaskIntoConstraints = false
 
         return tf
     }()
@@ -69,8 +66,8 @@ class EditorDemoController: UIViewController
     private(set) lazy var separatorView: UIView = {
         let v = UIView(frame: CGRect(x: 0, y: 0, width: 44, height: 1))
 
-        v.autoresizingMask = [.FlexibleWidth]
         v.backgroundColor = UIColor.darkTextColor()
+        v.translatesAutoresizingMaskIntoConstraints = false
 
         return v
     }()
@@ -105,13 +102,14 @@ class EditorDemoController: UIViewController
         edgesForExtendedLayout = .None
         navigationController?.navigationBar.translucent = false
 
+        view.backgroundColor = UIColor.whiteColor()
+        view.addSubview(titleTextField)
+        view.addSubview(separatorView)
         view.addSubview(richTextView)
         view.addSubview(htmlTextView)
 
         configureConstraints()
         configureNavigationBar()
-
-        layoutTextView()
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -150,21 +148,34 @@ class EditorDemoController: UIViewController
     // MARK: - Configuration Methods
 
     func configureConstraints() {
-        bottomConstraint = richTextView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor)
 
         NSLayoutConstraint.activateConstraints([
-            richTextView.leftAnchor.constraintEqualToAnchor(view.leftAnchor),
-            richTextView.rightAnchor.constraintEqualToAnchor(view.rightAnchor),
-            richTextView.topAnchor.constraintEqualToAnchor(view.topAnchor),
-            bottomConstraint!
-        ])
+            titleTextField.leftAnchor.constraintEqualToAnchor(view.leftAnchor, constant: self.dynamicType.margin),
+            titleTextField.rightAnchor.constraintEqualToAnchor(view.rightAnchor, constant: -self.dynamicType.margin),
+            titleTextField.topAnchor.constraintEqualToAnchor(view.topAnchor, constant: self.dynamicType.margin),
+            titleTextField.heightAnchor.constraintEqualToConstant(titleTextField.font!.lineHeight)
+            ])
+
+        NSLayoutConstraint.activateConstraints([
+            separatorView.leftAnchor.constraintEqualToAnchor(view.leftAnchor, constant: self.dynamicType.margin),
+            separatorView.rightAnchor.constraintEqualToAnchor(view.rightAnchor, constant: -self.dynamicType.margin),
+            separatorView.topAnchor.constraintEqualToAnchor(titleTextField.bottomAnchor, constant: self.dynamicType.margin),
+            separatorView.heightAnchor.constraintEqualToConstant(separatorView.frame.height)
+            ])
+
+        NSLayoutConstraint.activateConstraints([
+            richTextView.leftAnchor.constraintEqualToAnchor(view.leftAnchor, constant: self.dynamicType.margin),
+            richTextView.rightAnchor.constraintEqualToAnchor(view.rightAnchor, constant: -self.dynamicType.margin),
+            richTextView.topAnchor.constraintEqualToAnchor(separatorView.bottomAnchor, constant: self.dynamicType.margin),
+            richTextView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor, constant: -self.dynamicType.margin)
+            ])
 
         NSLayoutConstraint.activateConstraints([
             htmlTextView.leftAnchor.constraintEqualToAnchor(richTextView.leftAnchor),
             htmlTextView.rightAnchor.constraintEqualToAnchor(richTextView.rightAnchor),
             htmlTextView.topAnchor.constraintEqualToAnchor(richTextView.topAnchor),
             htmlTextView.bottomAnchor.constraintEqualToAnchor(richTextView.bottomAnchor),
-        ])
+            ])
     }
 
     func configureNavigationBar() {
@@ -183,42 +194,37 @@ class EditorDemoController: UIViewController
     }
 
 
-
-    // MARK: - Layout
-
-    func layoutTextView() {
-        let lineHeight = titleTextField.font!.lineHeight
-        let offset: CGFloat = 15.0
-        let width: CGFloat = richTextView.frame.width - (offset * 2)
-        let height: CGFloat = lineHeight * 2.0
-        titleTextField.frame = CGRect(x: offset, y: 0, width: width, height: height)
-
-        separatorView.frame = CGRect(x: offset, y: titleTextField.frame.maxY, width: width, height: 1)
-
-        let top: CGFloat = separatorView.frame.maxY + lineHeight
-        richTextView.textContainerInset = UIEdgeInsets(top: top, left: offset, bottom: lineHeight, right: offset)
-    }
-
-
     // MARK: - Keyboard Handling
 
     func keyboardWillShow(notification: NSNotification) {
         guard
             let userInfo = notification.userInfo as? [String: AnyObject],
-            let keyboardFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.CGRectValue(),
-            let duration: NSTimeInterval = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue
+            let keyboardFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.CGRectValue()
             else {
                 return
         }
-        bottomConstraint?.constant = -(view.frame.maxY - keyboardFrame.minY)
-        UIView.animateWithDuration(duration) {
-            self.view.layoutIfNeeded()
-        }
+
+        refreshInsets(forKeyboardFrame: keyboardFrame)
     }
 
 
     func keyboardWillHide(notification: NSNotification) {
-        bottomConstraint?.constant = 0
+        guard
+            let userInfo = notification.userInfo as? [String: AnyObject],
+            let keyboardFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.CGRectValue()
+            else {
+                return
+        }
+
+        refreshInsets(forKeyboardFrame: keyboardFrame)
+    }
+
+    private func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
+        htmlTextView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+        htmlTextView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+
+        richTextView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+        richTextView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
     }
 
 

--- a/Example/WordPress-Aztec-iOS/ViewController.swift
+++ b/Example/WordPress-Aztec-iOS/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UITableViewController
 
         rows = [
             DemoRow(title: "Editor Demo", action: { self.showEditorDemo() }),
+            DemoRow(title: "Empty Editor Demo", action: { self.showEditorDemo(loadSampleHTML: false) }),
             DemoRow(title: "Cursor Callout Demo", action: { self.showCursorCalloutDemo() }),
             DemoRow(title: "Draggable Demo", action: { self.showDraggableDemo() }),
             DemoRow(title: "Formatter Demo", action: { self.showFormatterDemo() })
@@ -27,8 +28,9 @@ class ViewController: UITableViewController
     // MARK: Actions
 
 
-    func showEditorDemo() {
+    func showEditorDemo(loadSampleHTML loadSampleHTML: Bool = true) {
         let controller = EditorDemoController()
+        controller.loadSampleHTML = loadSampleHTML
         navigationController?.pushViewController(controller, animated: true)
     }
 


### PR DESCRIPTION
Fixes #53.

The editor was breaking bad when trying to start it up without an initial sample content.  This PR fixes it.

This PR also fixes some layout issues - the title field is now visible in both visual and HTML modes.

**How to test:**
1. Launch the demo app.
2. There's a new "Empty Editor Demo" option in the main menu.  Pick it.
3. A blank editor window will open up, edit the content.
4. Switch to HTML mode and make sure the HTML is what you'd expect.