### PR TITLE
Fixes an issue with the default font being changed.

### DIFF
--- a/Classes/Public/TextKit/AztecVisualEditor.swift
+++ b/Classes/Public/TextKit/AztecVisualEditor.swift
@@ -7,6 +7,7 @@ public class AztecVisualEditor : NSObject {
 
     typealias ElementNode = Libxml2.ElementNode
 
+    let defaultFont: UIFont
     let textView: UITextView
 
     lazy var attachmentManager: AztecAttachmentManager = {
@@ -37,9 +38,10 @@ public class AztecVisualEditor : NSObject {
 
     // MARK: - Lifecycle Methods
 
-    public init(textView: UITextView) {
+    public init(textView: UITextView, defaultFont: UIFont) {
         assert(textView.textStorage.isKindOfClass(AztecTextStorage.self), "AztecVisualEditor should only be used with UITextView's backed by AztecTextStorage")
 
+        self.defaultFont = defaultFont
         self.textView = textView
 
         super.init()
@@ -107,6 +109,15 @@ public class AztecVisualEditor : NSObject {
     ///     - html: The raw HTML we'd be editing.
     ///
     public func setHTML(html: String) {
+
+        // NOTE: there's a bug in UIKit that causes the textView's font to be changed under certain
+        //      conditions.  We are assigning the default font here again to avoid that issue.
+        //
+        //      More information about the bug here:
+        //          https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/58
+        //
+        textView.font = defaultFont
+
         storage.setHTML(html, withDefaultFontDescriptor: textView.font!.fontDescriptor())
     }
 

--- a/Example/Tests/AztecVisualEditorTests.swift
+++ b/Example/Tests/AztecVisualEditorTests.swift
@@ -39,7 +39,7 @@ class AztecVisualEditorTests: XCTestCase {
 
     func testMaxIndex() {
         let textView = AztecVisualEditor.createTextView()
-        let editor = AztecVisualEditor(textView: textView)
+        let editor = AztecVisualEditor(textView: textView, defaultFont: UIFont.systemFontOfSize(14))
 
         textView.text = "foo"
 
@@ -53,7 +53,7 @@ class AztecVisualEditorTests: XCTestCase {
 
     func testAdjustedIndex() {
         let textView = AztecVisualEditor.createTextView()
-        let editor = AztecVisualEditor(textView: textView)
+        let editor = AztecVisualEditor(textView: textView, defaultFont: UIFont.systemFontOfSize(14))
 
         textView.text = "foobarbaz"
 
@@ -319,7 +319,7 @@ class AztecVisualEditorTests: XCTestCase {
 
     func editorConfiguredForTesting(withHTML html: String) -> AztecVisualEditor {
         let textView = AztecVisualEditor.createTextView()
-        let editor = AztecVisualEditor(textView: textView)
+        let editor = AztecVisualEditor(textView: textView, defaultFont: UIFont.systemFontOfSize(14))
 
         editor.setHTML(html)
 
@@ -328,7 +328,7 @@ class AztecVisualEditorTests: XCTestCase {
 
     func editorConfiguredWithParagraphs() -> AztecVisualEditor {
         let textView = AztecVisualEditor.createTextView()
-        let editor = AztecVisualEditor(textView: textView)
+        let editor = AztecVisualEditor(textView: textView, defaultFont: UIFont.systemFontOfSize(14))
 
         let attributes = [NSParagraphStyleAttributeName : NSParagraphStyle()]
         let paragraph = "Lorem ipsum dolar sit amet.\n"

--- a/Example/WordPress-Aztec-iOS/EditorDemoController.swift
+++ b/Example/WordPress-Aztec-iOS/EditorDemoController.swift
@@ -10,7 +10,7 @@ class EditorDemoController: UIViewController
     static let defaultContentFont = UIFont.systemFontOfSize(14)
 
     private (set) lazy var editor: AztecVisualEditor = {
-        return AztecVisualEditor(textView: self.richTextView)
+        return AztecVisualEditor(textView: self.richTextView, defaultFont: self.dynamicType.defaultContentFont)
     }()
 
 


### PR DESCRIPTION
Fixes #58.

**How to test:**

1. Run the app.
2. Open the editor with sample content.
3. Select an italic or bold range of text.
4. Switch to HTML mode.
5. Switch back to visual mode and make sure the default font wasn't changed.