### PR TITLE
Attachments: Alignment Support Mark II

### DIFF
--- a/Classes/Public/Extensions/NSTextStorage+Helpers.swift
+++ b/Classes/Public/Extensions/NSTextStorage+Helpers.swift
@@ -1,0 +1,32 @@
+//
+//  NSTextStorage+.swift
+//  Pods
+//
+//  Created by Jorge Leandro Perez on 9/6/16.
+//
+//
+
+import Foundation
+
+
+/// NSTextStorage Helpers
+///
+extension NSTextStorage
+{
+    /// Enumerates all of the available NSTextAttachment's of the specified kind, in a given range.
+    /// For each one of those elements, the specified block will be called.
+    ///
+    /// - Parameters:
+    ///     - range: The range that should be checked. Nil wil cause the whole text to be scanned
+    ///     - type: The kind of Attachment we're after
+    ///     - block: Closure to be executed, for each one of the elements
+    ///
+    func enumerateAttachments<T : NSTextAttachment>(range: NSRange? = nil, ofType type: T.Type, block: ((T, NSRange) -> Void)) {
+        let range = range ?? NSMakeRange(0, length)
+        enumerateAttribute(NSAttachmentAttributeName, inRange: range, options: []) { (object, range, stop) in
+            if let object = object as? T {
+                block(object, range)
+            }
+        }
+    }
+}

--- a/Classes/Public/Extensions/UITextView+Helpers.swift
+++ b/Classes/Public/Extensions/UITextView+Helpers.swift
@@ -4,9 +4,7 @@ import UIKit
 ///
 extension UITextView
 {
-    /// A convenience metod for getting the CGRect of the currentl text selection.
-    ///
-    /// - Returns: The CGRect of the current text selection.
+    /// A convenience metod for getting the CGRect of the current text selection.
     ///
     public func rectForCurrentSelection() -> CGRect {
         return layoutManager.boundingRectForGlyphRange(selectedRange, inTextContainer: textContainer)
@@ -15,13 +13,24 @@ extension UITextView
 
     /// Determines what's the position of the cursor, expressed as the character index we're currently at.
     ///
-    /// - Returns: An integer indicating the current position.
-    ///
     public func positionForCursor() -> Int {
         guard let selectedRange = selectedTextRange else {
             return 0
         }
 
         return offsetFromPosition(beginningOfDocument, toPosition: selectedRange.start)
+    }
+
+    /// Determines the frame occupied onscreen by a given range.
+    ///
+    func frameForTextInRange(range: NSRange) -> CGRect {
+        guard let firstPosition = positionFromPosition(beginningOfDocument, offset: range.location),
+            let lastPosition = positionFromPosition(beginningOfDocument, offset: range.location + range.length),
+            let textRange = textRangeFromPosition(firstPosition, toPosition: lastPosition) else
+        {
+            return CGRectZero
+        }
+
+        return firstRectForRange(textRange)
     }
 }

--- a/Classes/Public/TextKit/AztecAttachmentManager.swift
+++ b/Classes/Public/TextKit/AztecAttachmentManager.swift
@@ -240,12 +240,21 @@ private extension AztecAttachmentManager
             return
         }
 
-/// TODO: Alignment
         let size = view.frame.size
         var frame = textView.frameForTextInRange(range)
-        frame.size = size
-        frame.origin.x = textContainer.size.width - size.width - textContainer.lineFragmentPadding
 
+        switch attachment.alignment {
+        case .Left:
+            frame.origin.x = textContainer.lineFragmentPadding
+        case .Center:
+            frame.origin.x = round((textContainer.size.width - size.width) * 0.5)
+        case .Right:
+            frame.origin.x = textContainer.size.width - size.width - textContainer.lineFragmentPadding
+        case .None:
+            break
+        }
+
+        frame.size = size
         view.frame = frame
     }
 
@@ -264,12 +273,12 @@ private extension AztecAttachmentManager
             return
         }
 
-        let maximumWidth = attachment.maximumWidthForContainer(textContainer)
+        let maximumWidth = attachment.maximumAssociatedViewWidthForContainer(textContainer)
         let ratio = view.frame.size.width / view.frame.size.height
         let newSize = CGSize(width: floor(maximumWidth), height: floor(maximumWidth / ratio))
 
         view.frame.size = newSize
-        attachment.lineHeight = newSize.height
+        attachment.associatedViewSize = newSize
     }
 }
 

--- a/Classes/Public/TextKit/AztecAttachmentManager.swift
+++ b/Classes/Public/TextKit/AztecAttachmentManager.swift
@@ -236,16 +236,24 @@ private extension AztecAttachmentManager
     ///     - range: The range of the AztecTextAttachment in the textView's NSTextStorage
     ///
     private func layoutAttachmentViewForAttachment(attachment: AztecTextAttachment, atRange range: NSRange) {
-        guard let attachmentView = attachmentViews[attachment.identifier] else {
+        guard let view = attachmentViews[attachment.identifier] else {
             return
         }
 
-        attachmentView.frame = textView.frameForTextInRange(range)
+/// TODO: Alignment
+        let size = view.frame.size
+        var frame = textView.frameForTextInRange(range)
+        frame.size = size
+        frame.origin.x = textContainer.size.width - size.width - textContainer.lineFragmentPadding
+
+        view.frame = frame
     }
 
 
-    /// Resize (if necessary) the custom view for the specified attachment so that
-    /// it fits within the width of its textContainer.
+    /// Resize (if necessary) the custom view for the specified attachment so that it fits within the
+    /// width of its textContainer.
+    ///
+    /// Note: We also set the Attachment's Line Height!!
     ///
     /// - Parameters:
     ///     - attachment: The AztecTextAttachment
@@ -256,12 +264,12 @@ private extension AztecAttachmentManager
             return
         }
 
-        let maximumWidth = container.size.width - (2 * container.lineFragmentPadding)
+        let maximumWidth = attachment.maximumWidthForContainer(textContainer)
         let ratio = view.frame.size.width / view.frame.size.height
+        let newSize = CGSize(width: floor(maximumWidth), height: floor(maximumWidth / ratio))
 
-        let newSize = CGSizeMake(floor(maximumWidth), floor(maximumWidth / ratio))
         view.frame.size = newSize
-        attachment.size = newSize
+        attachment.lineHeight = newSize.height
     }
 }
 

--- a/Classes/Public/TextKit/AztecAttachmentManager.swift
+++ b/Classes/Public/TextKit/AztecAttachmentManager.swift
@@ -100,19 +100,20 @@ public class AztecAttachmentManager
     /// - Returns: The NSRange of the attachment represented by the view, or nil.
     ///
     public func rangeOfAttachmentForView(view: UIView) -> NSRange? {
-        guard let targetAttachment = attachmentForView(view), textStorage = layoutManager.textStorage else {
+        guard let targetAttachment = attachmentForView(view) else {
             return nil
         }
 
         var rangeOfAttachment: NSRange?
 
-        enumerateAttachments(ofType: AztecTextAttachment.self) { (attachment, range) in
+        textStorage.enumerateAttachments(ofType: AztecTextAttachment.self) { (attachment, range) in
             guard attachment == targetAttachment else {
                 return
             }
 
             rangeOfAttachment = range
         }
+
         return rangeOfAttachment
     }
 
@@ -131,7 +132,6 @@ public class AztecAttachmentManager
         attachmentViews[attachment.identifier] = view
         resizeViewForAttachment(attachment, toFitInContainer: textContainer)
         textView.addSubview(view)
-
 
         layoutAttachmentViews()
     }
@@ -156,7 +156,7 @@ public class AztecAttachmentManager
     public func reloadAttachments() {
         resetAttachmentManager()
 
-        enumerateAttachments(ofType: AztecTextAttachment.self) { (attachment, range) in
+        textStorage.enumerateAttachments(ofType: AztecTextAttachment.self) { (attachment, range) in
             self.attachments.append(attachment)
 
             guard let view = self.delegate?.attachmentManager(self, viewForAttachment: attachment) else {
@@ -227,28 +227,6 @@ private extension AztecAttachmentManager
     }
 
 
-
-    /// Enumerates all of the available NSTextAttachment's of the specified kind, in a given range.
-    /// For each one of those elements, the specified block will be called.
-    ///
-    /// - Parameters:
-    ///     - range: The range that should be checked. Nil wil cause the whole text to be scanned
-    ///     - type: The kind of Attachment we're after
-    ///     - block: Closure to be executed, for each one of the elements
-    ///
-    func enumerateAttachments<T : NSTextAttachment>(range: NSRange? = nil, ofType type: T.Type, block: ((T, NSRange) -> Void)) {
-        guard let textStorage = layoutManager.textStorage else {
-            assertionFailure("Unable to enumerate attachments. No NSTextStorage.")
-            return
-        }
-
-        let range = range ?? NSMakeRange(0, textStorage.length)
-        textStorage.enumerateAttribute(NSAttachmentAttributeName, inRange: range, options: []) { (object, range, stop) in
-            if let object = object as? T {
-                block(object, range)
-            }
-        }
-    }
     /// Updates the layout of the attachment view for the specified attachment but
     /// creating a new exclusion path for the view based on the location of the
     /// specified attachment.

--- a/Classes/Public/TextKit/AztecAttachmentManager.swift
+++ b/Classes/Public/TextKit/AztecAttachmentManager.swift
@@ -42,8 +42,7 @@ public class AztecAttachmentManager
 
     /// Designaged initializer.
     ///
-    /// - Parameters:
-    ///     - textView: The UITextView to manage attachment layout.
+    /// - Parameter textView: The UITextView to manage attachment layout.
     ///
     public init(textView: UITextView) {
         self.textView = textView
@@ -54,8 +53,7 @@ public class AztecAttachmentManager
 
     /// Returns the custom view for the specified AztecTextAttachment or nil if not found.
     ///
-    /// - Parameters:
-    ///     - attachment: The AztecTextAttachment
+    /// - Parameter attachment: The AztecTextAttachment
     ///
     /// - Returns: A UIView optional
     ///
@@ -66,8 +64,7 @@ public class AztecAttachmentManager
 
     /// Get the AztecTextAttachment being represented by the specified view.
     ///
-    /// - Parameters:
-    ///     - view: The custom view representing the attachment.
+    /// - Parameter view: The custom view representing the attachment.
     ///
     /// - Returns: The matching AztecTextAttachment or nil
     ///
@@ -81,8 +78,7 @@ public class AztecAttachmentManager
 
     /// Get the AztecTextAttachment for the specified identifier.
     ///
-    /// - Parameters:
-    ///     - identifier: The identifier of the attachment.
+    /// - Parameter identifier: The identifier of the attachment.
     ///
     /// - Returns: The matching AztecTextAttachment or nil
     ///
@@ -97,8 +93,7 @@ public class AztecAttachmentManager
     /// Get the range in text storage of the AztecTextAttachment represented by 
     /// the specified view.
     ///
-    /// - Paramters:
-    ///     - view: The view representing an attachment.
+    /// - Parameter view: The view representing an attachment.
     ///
     /// - Returns: The NSRange of the attachment represented by the view, or nil.
     ///
@@ -215,7 +210,7 @@ public class AztecAttachmentManager
         }
 
         // HACK HACK
-        // Hoping that both, God and the reviewer forgive me... this fixes several scenarios in which 
+        // Hoping that both, God and the reviewer forgive me... this fixes several scenarios in which
         // Exclusion Paths were not being properly respected.
         // Ref. http://stackoverflow.com/questions/24681960/incorrect-exclusionpaths-with-new-lines-in-a-uitextview?noredirect=1&lq=1
         //

--- a/Classes/Public/TextKit/AztecTextAttachment.swift
+++ b/Classes/Public/TextKit/AztecTextAttachment.swift
@@ -5,19 +5,6 @@ import Foundation
 ///
 public class AztecTextAttachment: NSTextAttachment
 {
-    /// Supported Types
-    ///
-    public enum Kind {
-        case Image(image: UIImage)
-    }
-
-    /// Wrapping Options. Analog to what Apple Pages does!
-    ///
-    public enum TextWrapping {
-        case Around
-        case AboveAndBelow
-    }
-
     /// Identifier used to match this attachment with a custom UIView subclass
     ///
     private(set) public var identifier: String
@@ -26,9 +13,13 @@ public class AztecTextAttachment: NSTextAttachment
     ///
     public var kind: Kind?
 
-    /// Wrapping Mode
+    /// Attachment Size
     ///
-    public var textWrapping = TextWrapping.AboveAndBelow
+    public var size: Size = .Maximum
+
+    /// Indicates the Height to be occupied onscreen
+    ///
+    var lineHeight = CGFloat.min
 
 
     /// Designed Initializer
@@ -38,27 +29,65 @@ public class AztecTextAttachment: NSTextAttachment
         super.init(data: nil, ofType: nil)
     }
 
+    /// Required Initializer
+    ///
     required public init?(coder aDecoder: NSCoder) {
         identifier = ""
         super.init(coder: aDecoder)
     }
 
-
-    /// Overriden Methods
+    /// Returns the "Onscreen Character Size". We'll always return the full width, plus, the scaled View's
+    /// Height.
     ///
     public override func attachmentBoundsForTextContainer(textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
-        switch textWrapping {
-        case .AboveAndBelow:
-            return aboveAndBelowBoundsForTextContainer(textContainer, proposedLineFragment: lineFrag, glyphPosition: position)
-        case .Around:
-            return super.attachmentBoundsForTextContainer(textContainer, proposedLineFragment: lineFrag, glyphPosition: position, characterIndex: charIndex)
-        }
+        let characterSize = CGSizeMake(lineFrag.width, lineHeight)
+        return CGRect(origin: CGPointZero, size: characterSize)
     }
 
-    private func aboveAndBelowBoundsForTextContainer(textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint) -> CGRect {
-        let padding = textContainer?.lineFragmentPadding ?? 0.0
-        let width = lineFrag.width - position.x - padding * 2.0
 
-        return CGRect(x: 0.0, y: 0.0, width: floor(width), height: lineFrag.height)
+    /// Returns the maximum allowed Width for a given TextContainer, considering both, container constraints
+    /// and Attachment Target Size.
+    ///
+    func maximumWidthForContainer(textContainer: NSTextContainer) -> CGFloat {
+        let maximumContainerWidth = textContainer.size.width - (2 * textContainer.lineFragmentPadding)
+        return min(size.targetWidth, maximumContainerWidth)
+    }
+}
+
+
+
+/// Nested Types
+///
+extension AztecTextAttachment
+{
+    /// Supported Media
+    ///
+    public enum Kind {
+        case Image(image: UIImage)
+    }
+
+    /// Size Onscreen!
+    ///
+    public enum Size {
+        case Thumbnail
+        case Medium
+        case Large
+        case Maximum
+
+        var targetWidth: CGFloat {
+            switch self {
+            case .Thumbnail:    return Settings.thumbnail
+            case .Medium:       return Settings.medium
+            case .Large:        return Settings.large
+            case .Maximum:      return Settings.maximum
+            }
+        }
+
+        private struct Settings {
+            static let thumbnail    = CGFloat(135)
+            static let medium       = CGFloat(270)
+            static let large        = CGFloat(360)
+            static let maximum      = CGFloat.max
+        }
     }
 }

--- a/Classes/Public/TextKit/AztecTextAttachment.swift
+++ b/Classes/Public/TextKit/AztecTextAttachment.swift
@@ -98,18 +98,18 @@ extension AztecTextAttachment
 
         var targetWidth: CGFloat {
             switch self {
-            case .Thumbnail:    return Settings.thumbnail
-            case .Medium:       return Settings.medium
-            case .Large:        return Settings.large
-            case .Maximum:      return Settings.maximum
+            case .Thumbnail: return Settings.thumbnail
+            case .Medium: return Settings.medium
+            case .Large: return Settings.large
+            case .Maximum: return Settings.maximum
             }
         }
 
         private struct Settings {
-            static let thumbnail    = CGFloat(135)
-            static let medium       = CGFloat(270)
-            static let large        = CGFloat(360)
-            static let maximum      = CGFloat.max
+            static let thumbnail = CGFloat(135)
+            static let medium = CGFloat(270)
+            static let large = CGFloat(360)
+            static let maximum = CGFloat.max
         }
     }
 }

--- a/Classes/Public/TextKit/AztecTextAttachment.swift
+++ b/Classes/Public/TextKit/AztecTextAttachment.swift
@@ -13,13 +13,18 @@ public class AztecTextAttachment: NSTextAttachment
     ///
     public var kind: Kind?
 
+    /// Attachment Alignment
+    ///
+    public var alignment: Alignment = .Center
+
     /// Attachment Size
     ///
-    public var size: Size = .Medium
+    public var size: Size = .Maximum
 
-    /// Indicates the Height to be occupied onscreen
+// TODO: Nuke If Possible
+    /// Indicates the scaled dimensions of the associated view
     ///
-    var lineHeight = CGFloat.min
+    var associatedViewSize = CGSizeZero
 
 
     /// Designed Initializer
@@ -36,19 +41,27 @@ public class AztecTextAttachment: NSTextAttachment
         super.init(coder: aDecoder)
     }
 
-    /// Returns the "Onscreen Character Size". We'll always return the full width, plus, the scaled View's
-    /// Height.
+    /// Returns the "Onscreen Character Size" of the attachment range. When we're in Alignment.None,
+    /// the attachment will be 'Inline', and thus, we'll return the actual Associated View Size.
+    /// Otherwise, we'll always take the whole container's width.
     ///
     public override func attachmentBoundsForTextContainer(textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
-        let characterSize = CGSizeMake(lineFrag.width, lineHeight)
+        let characterSize: CGSize
+        switch alignment {
+        case .None:
+            characterSize = associatedViewSize
+        default:
+            characterSize = CGSizeMake(lineFrag.width, associatedViewSize.height)
+        }
+
         return CGRect(origin: CGPointZero, size: characterSize)
     }
 
-
+// TODO: Nuke If Possible
     /// Returns the maximum allowed Width for a given TextContainer, considering both, container constraints
     /// and Attachment Target Size.
     ///
-    func maximumWidthForContainer(textContainer: NSTextContainer) -> CGFloat {
+    func maximumAssociatedViewWidthForContainer(textContainer: NSTextContainer) -> CGFloat {
         let maximumContainerWidth = textContainer.size.width - (2 * textContainer.lineFragmentPadding)
         return min(size.targetWidth, maximumContainerWidth)
     }
@@ -60,6 +73,15 @@ public class AztecTextAttachment: NSTextAttachment
 ///
 extension AztecTextAttachment
 {
+    /// Alignment
+    ///
+    public enum Alignment {
+        case None
+        case Left
+        case Center
+        case Right
+    }
+
     /// Supported Media
     ///
     public enum Kind {

--- a/Classes/Public/TextKit/TextView.swift
+++ b/Classes/Public/TextKit/TextView.swift
@@ -14,6 +14,17 @@ public class TextView: UITextView {
         return textStorage as! AztecTextStorage
     }
 
+    override public var bounds: CGRect {
+        didSet {
+            if oldValue.size == bounds.size {
+                return
+            }
+
+            attachmentManager.resizeAttachments()
+        }
+    }
+
+
     // MARK: - Initializers
 
     public init(defaultFont: UIFont) {
@@ -56,6 +67,7 @@ public class TextView: UITextView {
         layoutManager.delegate = self
         attachmentManager.delegate = self
     }
+
 
     /// Get the default paragraph style for the editor.
     ///


### PR DESCRIPTION
### Description:
In this PR we're implementing support for:

- Attachment Alignment
- Attachment Resizing
- Dynamic Resize upon Rotation

### Details:
We're updating the mechanism used by the TextAttachments. Reasoning is as follows:

- At least initially, we'll support **Inline Attachments** and **Above and Below** attachments (say, on its own "Block", replicating Apple Pages's behavior)
- We should be able to delete attachments by means of the *backspace* button
- The Exclusion Paths mechanism is a way of indicating the TextView not to allow text in specific regions. Since the Attachments live within the text itself, and not as an external entity, it's a good idea to deal with this by means of the 'Attachment Bounds'.

For all of the above, in this PR we're shifting from the **Exclusion Paths** mechanism, to something simpler: Instead of calculating the attachment's frame ourselves, we'll provide the "Required Size" that the attachment should take, and we let TextKit do the heavy lifting for us.

### Internals:
- The Attachment will take the container's full width, whenever the Alignment is set to .Left / .Center / .Right, and will occupy the actual associated view's height, always
- `AztecTextAttachment.attachmentBoundsForTextContainer` reserves the actual space, and the Associated View's size doesn't really need to match. It might be equal or smaller!

### Testing:
- Update the Alignment [here](https://github.com/wordpress-mobile/WordPress-Aztec-iOS/pull/62/files#diff-b3d458fc1044eeda87d98ae1bc8e4dbdR18)
- Update the Image Size [here](https://github.com/wordpress-mobile/WordPress-Aztec-iOS/pull/62/files#diff-b3d458fc1044eeda87d98ae1bc8e4dbdR22)
- Launch the editor, and insert an image
- Verify that after rotating the device, the image properly resizes (to the expected maximum)
- Verify that Alignment.None allows text on the right / left
- Verify that Alignment.Left / .Center / .Right takes the full TextView's width

Needs Review: @diegoreymendez 
cc @aerych 

### Notes:
- Don't worry, we'll implement the actual UI in another PR
- There are *two* TODO's in `AztecTextAttachment`, to be revisited in yet another PR
