### PR TITLE
Removes the Aztec prefix from several classes.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -44,11 +44,11 @@
 		599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F252B1D8BC9A1002871D6 /* FormatBarDelegate.swift */; };
 		599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F252C1D8BC9A1002871D6 /* FormatBarItem.swift */; };
 		599F25501D8BC9A1002871D6 /* FormattingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F252D1D8BC9A1002871D6 /* FormattingIdentifier.swift */; };
-		599F25521D8BC9A1002871D6 /* AztecTextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25301D8BC9A1002871D6 /* AztecTextAttachment.swift */; };
-		599F25531D8BC9A1002871D6 /* AztecTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25311D8BC9A1002871D6 /* AztecTextStorage.swift */; };
+		599F25521D8BC9A1002871D6 /* TextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25301D8BC9A1002871D6 /* TextAttachment.swift */; };
+		599F25531D8BC9A1002871D6 /* TextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25311D8BC9A1002871D6 /* TextStorage.swift */; };
 		599F25541D8BC9A1002871D6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25321D8BC9A1002871D6 /* TextView.swift */; };
 		599F255C1D8BCDB4002871D6 /* Gridicons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 599F255B1D8BCDB4002871D6 /* Gridicons.framework */; };
-		599F25941D8BDCFC002871D6 /* AztecTextStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25921D8BDCFC002871D6 /* AztecTextStorageTests.swift */; };
+		599F25941D8BDCFC002871D6 /* TextStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25921D8BDCFC002871D6 /* TextStorageTests.swift */; };
 		599F25951D8BDCFC002871D6 /* AztecVisualEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25931D8BDCFC002871D6 /* AztecVisualEditorTests.swift */; };
 		59FEA06F1D8BDFA700D138DF /* OutHTMLConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA05F1D8BDFA700D138DF /* OutHTMLConverterTests.swift */; };
 		59FEA0741D8BDFA700D138DF /* ElementNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA0651D8BDFA700D138DF /* ElementNodeTests.swift */; };
@@ -115,15 +115,15 @@
 		599F252B1D8BC9A1002871D6 /* FormatBarDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatBarDelegate.swift; sourceTree = "<group>"; };
 		599F252C1D8BC9A1002871D6 /* FormatBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatBarItem.swift; sourceTree = "<group>"; };
 		599F252D1D8BC9A1002871D6 /* FormattingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattingIdentifier.swift; sourceTree = "<group>"; };
-		599F25301D8BC9A1002871D6 /* AztecTextAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecTextAttachment.swift; sourceTree = "<group>"; };
-		599F25311D8BC9A1002871D6 /* AztecTextStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecTextStorage.swift; sourceTree = "<group>"; };
+		599F25301D8BC9A1002871D6 /* TextAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextAttachment.swift; sourceTree = "<group>"; };
+		599F25311D8BC9A1002871D6 /* TextStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStorage.swift; sourceTree = "<group>"; };
 		599F25321D8BC9A1002871D6 /* TextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		599F25571D8BCA01002871D6 /* libxml2-umbrella.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "libxml2-umbrella.h"; sourceTree = "<group>"; };
 		599F25581D8BCA01002871D6 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		599F255B1D8BCDB4002871D6 /* Gridicons.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Gridicons.framework; path = Example/Carthage/Build/iOS/Gridicons.framework; sourceTree = "<group>"; };
 		599F258F1D8BDCA9002871D6 /* EditingLogic.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; name = EditingLogic.rtf; path = ../Documentation/EditingLogic.rtf; sourceTree = "<group>"; };
 		599F25901D8BDCA9002871D6 /* UnsupportedTags.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; name = UnsupportedTags.rtf; path = ../Documentation/UnsupportedTags.rtf; sourceTree = "<group>"; };
-		599F25921D8BDCFC002871D6 /* AztecTextStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecTextStorageTests.swift; sourceTree = "<group>"; };
+		599F25921D8BDCFC002871D6 /* TextStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStorageTests.swift; sourceTree = "<group>"; };
 		599F25931D8BDCFC002871D6 /* AztecVisualEditorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecVisualEditorTests.swift; sourceTree = "<group>"; };
 		59FEA05E1D8BDFA700D138DF /* OutAttributeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutAttributeConverterTests.swift; sourceTree = "<group>"; };
 		59FEA05F1D8BDFA700D138DF /* OutHTMLConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutHTMLConverterTests.swift; sourceTree = "<group>"; };
@@ -191,7 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				5951CB9E1D8BC93600E1866F /* Info.plist */,
-				599F25921D8BDCFC002871D6 /* AztecTextStorageTests.swift */,
+				599F25921D8BDCFC002871D6 /* TextStorageTests.swift */,
 				599F25931D8BDCFC002871D6 /* AztecVisualEditorTests.swift */,
 				59FEA05D1D8BDFA700D138DF /* Exporter */,
 				59FEA0641D8BDFA700D138DF /* HTML */,
@@ -361,8 +361,8 @@
 		599F252E1D8BC9A1002871D6 /* TextKit */ = {
 			isa = PBXGroup;
 			children = (
-				599F25301D8BC9A1002871D6 /* AztecTextAttachment.swift */,
-				599F25311D8BC9A1002871D6 /* AztecTextStorage.swift */,
+				599F25301D8BC9A1002871D6 /* TextAttachment.swift */,
+				599F25311D8BC9A1002871D6 /* TextStorage.swift */,
 				599F25321D8BC9A1002871D6 /* TextView.swift */,
 			);
 			path = TextKit;
@@ -545,7 +545,7 @@
 			files = (
 				599F25471D8BC9A1002871D6 /* HTMLConstants.swift in Sources */,
 				599F25371D8BC9A1002871D6 /* InAttributeConverter.swift in Sources */,
-				599F25531D8BC9A1002871D6 /* AztecTextStorage.swift in Sources */,
+				599F25531D8BC9A1002871D6 /* TextStorage.swift in Sources */,
 				599F25461D8BC9A1002871D6 /* HTMLNodeToNSAttributedString.swift in Sources */,
 				599F253C1D8BC9A1002871D6 /* OutHTMLAttributeConverter.swift in Sources */,
 				599F254B1D8BC9A1002871D6 /* String+RangeConversion.swift in Sources */,
@@ -554,7 +554,7 @@
 				599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */,
 				599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */,
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,
-				599F25521D8BC9A1002871D6 /* AztecTextAttachment.swift in Sources */,
+				599F25521D8BC9A1002871D6 /* TextAttachment.swift in Sources */,
 				599F25541D8BC9A1002871D6 /* TextView.swift in Sources */,
 				599F254A1D8BC9A1002871D6 /* NSAttributedString+Helpers.swift in Sources */,
 				599F254C1D8BC9A1002871D6 /* UITextView+Helpers.swift in Sources */,
@@ -591,7 +591,7 @@
 				599F25951D8BDCFC002871D6 /* AztecVisualEditorTests.swift in Sources */,
 				594C9D711D8BE6B800D74542 /* OutAttributeConverterTests.swift in Sources */,
 				59FEA06F1D8BDFA700D138DF /* OutHTMLConverterTests.swift in Sources */,
-				599F25941D8BDCFC002871D6 /* AztecTextStorageTests.swift in Sources */,
+				599F25941D8BDCFC002871D6 /* TextStorageTests.swift in Sources */,
 				59FEA0741D8BDFA700D138DF /* ElementNodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Aztec/Classes/Private/NSAttributedString/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Private/NSAttributedString/Converters/HTMLNodeToNSAttributedString.swift
@@ -161,7 +161,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         } else if elementName == "img" {
 
             let identifier = NSUUID().UUIDString
-            let attachment = AztecTextAttachment(identifier: identifier)
+            let attachment = TextAttachment(identifier: identifier)
 
             if let urlString = elementNode.valueForStringAttribute(named: "src"),
                 let url = NSURL(string: urlString) {

--- a/Aztec/Classes/Public/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/Public/TextKit/TextAttachment.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// Custom text attachment.
 ///
-public class AztecTextAttachment: NSTextAttachment
+public class TextAttachment: NSTextAttachment
 {
     /// Identifier used to match this attachment with a custom UIView subclass
     ///
@@ -115,7 +115,7 @@ public class AztecTextAttachment: NSTextAttachment
 
 /// Nested Types
 ///
-extension AztecTextAttachment
+extension TextAttachment
 {
     /// Alignment
     ///

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -2,13 +2,13 @@ import Foundation
 import UIKit
 
 protocol TextStorageImageProvider {
-    func storage(storage: AztecTextStorage, attachment: AztecTextAttachment, imageForURL url: NSURL, onSuccess success: (UIImage) -> (), onFailure failure: () -> ()) -> UIImage
-    func storage(storage: AztecTextStorage, missingImageForAttachment: AztecTextAttachment) -> UIImage
+    func storage(storage: TextStorage, attachment: TextAttachment, imageForURL url: NSURL, onSuccess success: (UIImage) -> (), onFailure failure: () -> ()) -> UIImage
+    func storage(storage: TextStorage, missingImageForAttachment: TextAttachment) -> UIImage
 }
 
 /// Custom NSTextStorage
 ///
-public class AztecTextStorage: NSTextStorage {
+public class TextStorage: NSTextStorage {
 
     typealias ElementNode = Libxml2.ElementNode
     typealias TextNode = Libxml2.TextNode
@@ -54,11 +54,11 @@ public class AztecTextStorage: NSTextStorage {
 
     var imageProvider: TextStorageImageProvider?
 
-    public func aztecTextAttachments() -> [AztecTextAttachment] {
+    public func TextAttachments() -> [TextAttachment] {
         let range = NSMakeRange(0, length)
-        var attachments = [AztecTextAttachment]()
+        var attachments = [TextAttachment]()
         enumerateAttribute(NSAttachmentAttributeName, inRange: range, options: []) { (object, range, stop) in
-            if let attachment = object as? AztecTextAttachment {
+            if let attachment = object as? TextAttachment {
                 attachments.append(attachment)
             }
         }
@@ -66,11 +66,11 @@ public class AztecTextStorage: NSTextStorage {
         return attachments
     }
 
-    public func range(forAttachment attachment: AztecTextAttachment) -> NSRange? {
+    public func range(forAttachment attachment: TextAttachment) -> NSRange? {
 
         var range: NSRange?
 
-        textStore.enumerateAttachmentsOfType(AztecTextAttachment.self) { (currentAttachment, currentRange, stop) in
+        textStore.enumerateAttachmentsOfType(TextAttachment.self) { (currentAttachment, currentRange, stop) in
             if attachment == currentAttachment {
                 range = currentRange
                 stop.memory = true
@@ -277,12 +277,12 @@ public class AztecTextStorage: NSTextStorage {
         edited([.EditedCharacters], range: NSRange(location: 0, length: originalLength), changeInLength: textStore.length - originalLength)
         rootNode = output.rootNode
 
-        enumerateAttachmentsOfType(AztecTextAttachment.self) { [weak self] (attachment, range, stop) in
+        enumerateAttachmentsOfType(TextAttachment.self) { [weak self] (attachment, range, stop) in
             self?.loadImageForAttachment(attachment, inRange: range)
         }
     }
 
-    func loadImageForAttachment(attachment: AztecTextAttachment, inRange range: NSRange) {
+    func loadImageForAttachment(attachment: TextAttachment, inRange range: NSRange) {
 
         guard let imageProvider = imageProvider else {
             fatalError("The image provider should've been set at this point.")
@@ -305,7 +305,7 @@ public class AztecTextStorage: NSTextStorage {
         invalidateLayoutForAttachment(attachment)
     }
 
-    private func downloadSuccess(attachment: AztecTextAttachment, url: NSURL, image: UIImage) {
+    private func downloadSuccess(attachment: TextAttachment, url: NSURL, image: UIImage) {
 
         attachment.kind = .RemoteImageDownloaded(url: url, image: image)
 
@@ -313,7 +313,7 @@ public class AztecTextStorage: NSTextStorage {
         invalidateLayoutForAttachment(attachment)
     }
 
-    private func downloadFailure(attachment: AztecTextAttachment) {
+    private func downloadFailure(attachment: TextAttachment) {
         guard let imageProvider = imageProvider else {
             fatalError("The image provider should've been set at this point.")
         }
@@ -328,7 +328,7 @@ public class AztecTextStorage: NSTextStorage {
     ///
     /// I'm temporarily commenting out the breaking code, but leaving it in to see if we can fix it.
     ///
-    func invalidateLayoutForAttachment(attachment: AztecTextAttachment) {
+    func invalidateLayoutForAttachment(attachment: TextAttachment) {
 
         guard layoutManagers.count > 0 else {
             fatalError("This storage should have at least one layout manager assigned.")
@@ -347,7 +347,7 @@ public class AztecTextStorage: NSTextStorage {
 
 /// Convenience extension to group font trait related methods.
 ///
-public extension AztecTextStorage
+public extension TextStorage
 {
 
 

--- a/Aztec/Classes/Public/TextKit/TextView.swift
+++ b/Aztec/Classes/Public/TextKit/TextView.swift
@@ -36,14 +36,14 @@ public class TextView: UITextView {
 
     // MARK: - Properties: Text Storage
 
-    var storage: AztecTextStorage {
-        return textStorage as! AztecTextStorage
+    var storage: TextStorage {
+        return textStorage as! TextStorage
     }
 
     // MARK: - Init & deinit
 
     public init(defaultFont: UIFont, defaultMissingImage: UIImage) {
-        let storage = AztecTextStorage()
+        let storage = TextStorage()
         let layoutManager = NSLayoutManager()
         let container = NSTextContainer()
 
@@ -410,7 +410,7 @@ public class TextView: UITextView {
     ///
     public func insertImage(image: UIImage, index: Int) {
         let identifier = NSUUID().UUIDString
-        let attachment = AztecTextAttachment(identifier: identifier)
+        let attachment = TextAttachment(identifier: identifier)
         attachment.kind = .Image
         attachment.image = image
 
@@ -440,20 +440,20 @@ public class TextView: UITextView {
     // MARK - Inspect Within Range
 
 
-    /// Returns the associated AztecTextAttachment, at a given point, if any.
+    /// Returns the associated TextAttachment, at a given point, if any.
     ///
     /// - Parameters:
     ///     - point: The point on screen to check for attachments.
     ///
-    /// - Returns: The associated AztecTextAttachment.
+    /// - Returns: The associated TextAttachment.
     ///
-    public func attachmentAtPoint(point: CGPoint) -> AztecTextAttachment? {
+    public func attachmentAtPoint(point: CGPoint) -> TextAttachment? {
         let index = layoutManager.characterIndexForPoint(point, inTextContainer: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
         guard index <= textStorage.length else {
             return nil
         }
 
-        return textStorage.attribute(NSAttachmentAttributeName, atIndex: index, effectiveRange: nil) as? AztecTextAttachment
+        return textStorage.attribute(NSAttachmentAttributeName, atIndex: index, effectiveRange: nil) as? TextAttachment
     }
 
 
@@ -710,13 +710,13 @@ public class TextView: UITextView {
 
     // MARK: - Attachments
 
-    public func changeAlignment(forAttachment attachment: AztecTextAttachment, to alignment: AztecTextAttachment.Alignment) {
+    public func changeAlignment(forAttachment attachment: TextAttachment, to alignment: TextAttachment.Alignment) {
         attachment.alignment = alignment
 
         storage.invalidateLayoutForAttachment(attachment)
     }
 
-    public func changeSize(forAttachment attachment: AztecTextAttachment, to size: AztecTextAttachment.Size) {
+    public func changeSize(forAttachment attachment: TextAttachment, to size: TextAttachment.Size) {
         attachment.size = size
 
         storage.invalidateLayoutForAttachment(attachment)
@@ -727,7 +727,7 @@ public class TextView: UITextView {
 
 extension TextView: TextStorageImageProvider {
 
-    func storage(storage: AztecTextStorage, attachment: AztecTextAttachment, imageForURL url: NSURL, onSuccess success: (UIImage) -> (), onFailure failure: () -> ()) -> UIImage {
+    func storage(storage: TextStorage, attachment: TextAttachment, imageForURL url: NSURL, onSuccess success: (UIImage) -> (), onFailure failure: () -> ()) -> UIImage {
         if let mediaDelegate = mediaDelegate {
             let placeholderImage = mediaDelegate.image(forTextView: self, atUrl: url, onSuccess: success, onFailure: failure)
             return placeholderImage
@@ -736,7 +736,7 @@ extension TextView: TextStorageImageProvider {
         }
     }
 
-    func storage(storage: AztecTextStorage, missingImageForAttachment: AztecTextAttachment) -> UIImage {
+    func storage(storage: TextStorage, missingImageForAttachment: TextAttachment) -> UIImage {
         return defaultMissingImage
     }
 }

--- a/AztecTests/AztecVisualEditorTests.swift
+++ b/AztecTests/AztecVisualEditorTests.swift
@@ -32,7 +32,7 @@ class AztecVisualEditorTests: XCTestCase {
 
         XCTAssert(textView.textStorage == textView.layoutManager.textStorage)
         XCTAssert(textView.textStorage == textView.textContainer.layoutManager!.textStorage)
-        XCTAssert(textView.textStorage.isKindOfClass(AztecTextStorage))
+        XCTAssert(textView.textStorage.isKindOfClass(TextStorage))
     }
 
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Aztec
 
 
-class AztecTextStorageTests: XCTestCase
+class TextStorageTests: XCTestCase
 {
 
     override func setUp() {
@@ -22,7 +22,7 @@ class AztecTextStorageTests: XCTestCase
         let attributes = [
             NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
         ]
-        let storage = AztecTextStorage()
+        let storage = TextStorage()
         storage.appendAttributedString(NSAttributedString(string: "foo"))
         storage.appendAttributedString(NSAttributedString(string: "bar", attributes: attributes))
         storage.appendAttributedString(NSAttributedString(string: "baz"))
@@ -43,7 +43,7 @@ class AztecTextStorageTests: XCTestCase
         let attributes = [
             NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
         ]
-        let storage = AztecTextStorage()
+        let storage = TextStorage()
         storage.appendAttributedString(NSAttributedString(string: "foo"))
         storage.appendAttributedString(NSAttributedString(string: "bar", attributes: attributes))
         storage.appendAttributedString(NSAttributedString(string: "baz"))
@@ -57,7 +57,7 @@ class AztecTextStorageTests: XCTestCase
         let attributes = [
             NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
         ]
-        let storage = AztecTextStorage()
+        let storage = TextStorage()
         storage.appendAttributedString(NSAttributedString(string: "foo"))
         storage.appendAttributedString(NSAttributedString(string: "bar", attributes: attributes))
         storage.appendAttributedString(NSAttributedString(string: "baz"))

--- a/Example/Example/AttachmentDetailsViewController.swift
+++ b/Example/Example/AttachmentDetailsViewController.swift
@@ -6,8 +6,8 @@ class AttachmentDetailsViewController: UIViewController
 {
     @IBOutlet var alignmentSegmentedControl: UISegmentedControl!
     @IBOutlet var sizeSegmentedControl: UISegmentedControl!
-    var attachment: AztecTextAttachment?
-    var onUpdate: ((AztecTextAttachment.Alignment, AztecTextAttachment.Size) -> Void)?
+    var attachment: TextAttachment?
+    var onUpdate: ((TextAttachment.Alignment, TextAttachment.Size) -> Void)?
 
 
     override func viewDidLoad() {
@@ -65,11 +65,11 @@ private extension AttachmentDetailsViewController
 {
     /// Aliases
     ///
-    typealias AttachmentAlignment = AztecTextAttachment.Alignment
-    typealias AttachmentSize = AztecTextAttachment.Size
+    typealias AttachmentAlignment = TextAttachment.Alignment
+    typealias AttachmentSize = TextAttachment.Size
 
 
-    /// Maps an AztecTextAttachment.Alignment into a Integer based Enum, to aid in the mapping between
+    /// Maps an TextAttachment.Alignment into a Integer based Enum, to aid in the mapping between
     /// the Attachment's data and the Segmented Control.
     ///
     enum Alignment: Int {
@@ -98,7 +98,7 @@ private extension AttachmentDetailsViewController
     }
 
 
-    /// Maps an AztecTextAttachment.Size into a Integer based Enum, to aid in the mapping between
+    /// Maps an TextAttachment.Size into a Integer based Enum, to aid in the mapping between
     /// the Attachment's data and the Segmented Control.
     ///
     enum Size: Int {

--- a/Example/Example/DraggableDemoController.swift
+++ b/Example/Example/DraggableDemoController.swift
@@ -46,8 +46,8 @@ class DraggableDemoController: UIViewController
 
     func buildAttributedString() -> NSAttributedString {
         let lipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n"
-        let attachment1 = AztecTextAttachment(identifier: "foo")
-        let attachment2 = AztecTextAttachment(identifier: "bar")
+        let attachment1 = TextAttachment(identifier: "foo")
+        let attachment2 = TextAttachment(identifier: "bar")
 
         let attributes = [
             NSParagraphStyleAttributeName : NSParagraphStyle.defaultParagraphStyle(),
@@ -160,7 +160,7 @@ extension DraggableDemoController : NSLayoutManagerDelegate
 extension DraggableDemoController : AztecAttachmentManagerDelegate
 {
 
-    func attachmentManager(attachmentManager: AztecAttachmentManager, viewForAttachment attachment: AztecTextAttachment) -> UIView? {
+    func attachmentManager(attachmentManager: AztecAttachmentManager, viewForAttachment attachment: TextAttachment) -> UIView? {
         if let attachmentView = attachmentViewList[attachment.identifier] {
             return attachmentView
         }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -595,7 +595,7 @@ private extension EditorDemoController
         richTextView.insertImage(image, index: index)
     }
 
-    func displayDetailsForAttachment(attachment: AztecTextAttachment) {
+    func displayDetailsForAttachment(attachment: TextAttachment) {
         let detailsViewController = AttachmentDetailsViewController()
         detailsViewController.attachment = attachment
         detailsViewController.onUpdate = { [weak self] (alignment, size) in


### PR DESCRIPTION
Removes the Aztec prefix from several classes, since we already have the module prefix if we want to use it.

**How to test:**

1. Just make sure the app builds and the tests succeed.