### PR TITLE
Base work for copy / paste support.

### DIFF
--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -87,6 +87,15 @@ public class TextStorage: NSTextStorage {
         return textStore.attributesAtIndex(location, effectiveRange: range)
     }
 
+    override public func replaceCharactersInRange(range: NSRange, withString str: String) {
+        beginEditing()
+        textStore.replaceCharactersInRange(range, withString: str)
+        rootNode.replaceCharacters(inRange: range, withString: str)
+        endEditing()
+        
+        edited(.EditedCharacters, range: range, changeInLength: str.characters.count - range.length)
+    }
+    
     override public func replaceCharactersInRange(range: NSRange, withAttributedString attrString: NSAttributedString) {
         beginEditing()
         textStore.replaceCharactersInRange(range, withAttributedString: attrString)

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -87,13 +87,13 @@ public class TextStorage: NSTextStorage {
         return textStore.attributesAtIndex(location, effectiveRange: range)
     }
 
-    override public func replaceCharactersInRange(range: NSRange, withString str: String) {
+    override public func replaceCharactersInRange(range: NSRange, withAttributedString attrString: NSAttributedString) {
         beginEditing()
-        textStore.replaceCharactersInRange(range, withString: str)
-        rootNode.replaceCharacters(inRange: range, withString: str)
+        textStore.replaceCharactersInRange(range, withAttributedString: attrString)
+        rootNode.replaceCharacters(inRange: range, withString: attrString.string)
         endEditing()
 
-        edited(.EditedCharacters, range: range, changeInLength: str.characters.count - range.length)
+        edited([.EditedAttributes, .EditedCharacters], range: range, changeInLength: attrString.string.characters.count - range.length)
     }
 
     override public func setAttributes(attrs: [String : AnyObject]?, range: NSRange) {

--- a/Aztec/Classes/Public/TextKit/TextView.swift
+++ b/Aztec/Classes/Public/TextKit/TextView.swift
@@ -55,7 +55,8 @@ public class TextView: UITextView {
         container.widthTracksTextView = true
 
         super.init(frame: CGRect(x: 0, y: 0, width: 10, height: 10), textContainer: container)
-
+        
+        allowsEditingTextAttributes = true
         storage.imageProvider = self
     }
 
@@ -65,6 +66,8 @@ public class TextView: UITextView {
         defaultMissingImage = Gridicon.iconOfType(.Image)
 
         super.init(coder: aDecoder)
+        
+        allowsEditingTextAttributes = true
     }
 
 


### PR DESCRIPTION
This PR makes some base changes for copy / paste support.

We're replacing:

```switf
override public func replaceCharactersInRange(range: NSRange, withString str: String)
```

with its NSAttributedString counterpart:

```
override public func replaceCharactersInRange(range: NSRange, withAttributedString attrString: NSAttributedString)
```

We're also adding support in the rich text view for pasting styled text (which still doesn't affect HTML).

**How to test:**
1. Try pasting styled text in the text view and make sure it works (doesn't update the DOM yet).
2. Edit regular text and make sure everything works as expected.