### PR TITLE
Adds a method to compare ranges.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		59FEA0751D8BDFA700D138DF /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA0661D8BDFA700D138DF /* NodeTests.swift */; };
 		59FEA0781D8BDFA700D138DF /* HTMLToAttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06A1D8BDFA700D138DF /* HTMLToAttributedStringTests.swift */; };
 		59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */; };
+		F18733C51DA096EE005AEB80 /* NSRange+Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C41DA096EE005AEB80 /* NSRange+Comparison.swift */; };
+		F18733C81DA09737005AEB80 /* NSRange_ComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C71DA09737005AEB80 /* NSRange_ComparisonTests.swift */; };
 		F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */; };
 /* End PBXBuildFile section */
 
@@ -135,6 +137,8 @@
 		59FEA06B1D8BDFA700D138DF /* InAttributeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAttributeConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InHTMLConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
+		F18733C41DA096EE005AEB80 /* NSRange+Comparison.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRange+Comparison.swift"; sourceTree = "<group>"; };
+		F18733C71DA09737005AEB80 /* NSRange_ComparisonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSRange_ComparisonTests.swift; path = Extensions/NSRange_ComparisonTests.swift; sourceTree = "<group>"; };
 		F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeafNode.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -196,6 +200,7 @@
 				599F25921D8BDCFC002871D6 /* TextStorageTests.swift */,
 				599F25931D8BDCFC002871D6 /* AztecVisualEditorTests.swift */,
 				59FEA05D1D8BDFA700D138DF /* Exporter */,
+				F18733C61DA0970E005AEB80 /* Extensions */,
 				59FEA0641D8BDFA700D138DF /* HTML */,
 				59FEA0691D8BDFA700D138DF /* Importer */,
 			);
@@ -336,6 +341,7 @@
 			isa = PBXGroup;
 			children = (
 				599F25251D8BC9A1002871D6 /* NSAttributedString+Helpers.swift */,
+				F18733C41DA096EE005AEB80 /* NSRange+Comparison.swift */,
 				599F25261D8BC9A1002871D6 /* String+RangeConversion.swift */,
 				599F25271D8BC9A1002871D6 /* UITextView+Helpers.swift */,
 			);
@@ -433,6 +439,14 @@
 				59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */,
 			);
 			path = Importer;
+			sourceTree = "<group>";
+		};
+		F18733C61DA0970E005AEB80 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				F18733C71DA09737005AEB80 /* NSRange_ComparisonTests.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -555,6 +569,7 @@
 				599F25481D8BC9A1002871D6 /* Metrics.swift in Sources */,
 				599F253B1D8BC9A1002871D6 /* InNodesConverter.swift in Sources */,
 				F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */,
+				F18733C51DA096EE005AEB80 /* NSRange+Comparison.swift in Sources */,
 				599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */,
 				599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */,
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,
@@ -589,6 +604,7 @@
 				594C9D741D8BE6C700D74542 /* InNodeConverterTests.swift in Sources */,
 				59FEA0751D8BDFA700D138DF /* NodeTests.swift in Sources */,
 				59FEA0781D8BDFA700D138DF /* HTMLToAttributedStringTests.swift in Sources */,
+				F18733C81DA09737005AEB80 /* NSRange_ComparisonTests.swift in Sources */,
 				594C9D731D8BE6C300D74542 /* InAttributeConverterTests.swift in Sources */,
 				59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */,
 				594C9D721D8BE6BC00D74542 /* OutNodeConverterTests.swift in Sources */,

--- a/Aztec/Classes/Public/Extensions/NSRange+Comparison.swift
+++ b/Aztec/Classes/Public/Extensions/NSRange+Comparison.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension NSRange {
+    
+    /// Returns the intersection between the receiver and the specified range.
+    ///
+    /// - Important: the main difference with NSIntersectionRange is that this method considers any contact (even a
+    ///         zero-length contact) as an intersection.  Another difference is that this method returns `nil`
+    ///         when there's absolutely no contact.
+    ///
+    /// - Parameters:
+    ///     - range: the range to compare the receiver against.
+    ///
+    /// - Returns: the interesection if there's any, or `nil` otherwise.
+    ///
+    func intersect(withRange target: NSRange) -> NSRange? {
+        
+        let endLocation = location + length
+        let targetEndLocation = target.location + target.length
+        
+        if target.location >= location && targetEndLocation <= endLocation {
+            return target
+        } else if target.location < location && targetEndLocation >= location && targetEndLocation <= endLocation {
+            return NSRange(location: location, length: targetEndLocation - location)
+        } else if target.location >= location && target.location <= endLocation && targetEndLocation > endLocation {
+            return NSRange(location: target.location, length: endLocation - target.location)
+        } else if target.location < location && targetEndLocation > endLocation {
+            return self
+        }else {
+            return nil
+        }
+    }
+}

--- a/AztecTests/Extensions/NSRange_ComparisonTests.swift
+++ b/AztecTests/Extensions/NSRange_ComparisonTests.swift
@@ -117,11 +117,11 @@ class NSRange_ComparisonTests: XCTestCase {
     /// Tests that `intersect(withRange:)` works.
     ///
     /// Set up:
-    /// - Receiver range: (loc: 0, len: 5)
-    /// - Target range: (loc: 1, len: 2)
+    /// - Receiver range: (loc: 1, len: 3)
+    /// - Target range: (loc: 0, len: 5)
     ///
     /// Expected result:
-    /// - (loc: 1, len: 2)
+    /// - (loc: 1, len: 3)
     ///
     func testIntersectWithRange6() {
         let receiver = NSRange(location: 1, length: 3)

--- a/AztecTests/Extensions/NSRange_ComparisonTests.swift
+++ b/AztecTests/Extensions/NSRange_ComparisonTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import Aztec
+
+class NSRange_ComparisonTests: XCTestCase {
+    
+    /// Tests that `intersect(withRange:)` works.
+    ///
+    /// Set up:
+    /// - Receiver range: (loc: 0, len: 10)
+    /// - Target range: (loc: 0, len: 10)
+    ///
+    /// Expected result:
+    /// - (loc: 0, len: 10)
+    ///
+    func testIntersectWithRange() {
+        let receiver = NSRange(location: 0, length: 10)
+        let target = NSRange(location: 0, length: 10)
+        
+        guard let result = receiver.intersect(withRange: target) else {
+            XCTFail("Expected a non nil result.")
+            return
+        }
+        
+        XCTAssertEqual(result.location, 0)
+        XCTAssertEqual(result.length, 10)
+    }
+    
+    /// Tests that `intersect(withRange:)` works.
+    ///
+    /// Set up:
+    /// - Receiver range: (loc: 0, len: 5)
+    /// - Target range: (loc: 5, len: 5)
+    ///
+    /// Expected result:
+    /// - (loc: 5, len: 0)
+    ///
+    func testIntersectWithRange2() {
+        let receiver = NSRange(location: 0, length: 5)
+        let target = NSRange(location: 5, length: 5)
+        
+        guard let result = receiver.intersect(withRange: target) else {
+            XCTFail("Expected a non nil result.")
+            return
+        }
+        
+        XCTAssertEqual(result.location, 5)
+        XCTAssertEqual(result.length, 0)
+    }
+    
+    /// Tests that `intersect(withRange:)` works.
+    ///
+    /// Set up:
+    /// - Receiver range: (loc: 0, len: 5)
+    /// - Target range: (loc: 2, len: 5)
+    ///
+    /// Expected result:
+    /// - (loc: 2, len: 3)
+    ///
+    func testIntersectWithRange3() {
+        let receiver = NSRange(location: 0, length: 5)
+        let target = NSRange(location: 2, length: 5)
+        
+        guard let result = receiver.intersect(withRange: target) else {
+            XCTFail("Expected a non nil result.")
+            return
+        }
+        
+        XCTAssertEqual(result.location, 2)
+        XCTAssertEqual(result.length, 3)
+    }
+    
+    /// Tests that `intersect(withRange:)` works.
+    ///
+    /// Set up:
+    /// - Receiver range: (loc: 3, len: 5)
+    /// - Target range: (loc: 0, len: 5)
+    ///
+    /// Expected result:
+    /// - (loc: 3, len: 2)
+    ///
+    func testIntersectWithRange4() {
+        let receiver = NSRange(location: 3, length: 5)
+        let target = NSRange(location: 0, length: 5)
+        
+        guard let result = receiver.intersect(withRange: target) else {
+            XCTFail("Expected a non nil result.")
+            return
+        }
+        
+        XCTAssertEqual(result.location, 3)
+        XCTAssertEqual(result.length, 2)
+    }
+    
+    
+    /// Tests that `intersect(withRange:)` works.
+    ///
+    /// Set up:
+    /// - Receiver range: (loc: 0, len: 5)
+    /// - Target range: (loc: 1, len: 2)
+    ///
+    /// Expected result:
+    /// - (loc: 1, len: 2)
+    ///
+    func testIntersectWithRange5() {
+        let receiver = NSRange(location: 0, length: 5)
+        let target = NSRange(location: 1, length: 2)
+        
+        guard let result = receiver.intersect(withRange: target) else {
+            XCTFail("Expected a non nil result.")
+            return
+        }
+        
+        XCTAssertEqual(result.location, 1)
+        XCTAssertEqual(result.length, 2)
+    }
+    
+    /// Tests that `intersect(withRange:)` works.
+    ///
+    /// Set up:
+    /// - Receiver range: (loc: 0, len: 5)
+    /// - Target range: (loc: 1, len: 2)
+    ///
+    /// Expected result:
+    /// - (loc: 1, len: 2)
+    ///
+    func testIntersectWithRange6() {
+        let receiver = NSRange(location: 1, length: 3)
+        let target = NSRange(location: 0, length: 5)
+        
+        guard let result = receiver.intersect(withRange: target) else {
+            XCTFail("Expected a non nil result.")
+            return
+        }
+        
+        XCTAssertEqual(result.location, 1)
+        XCTAssertEqual(result.length, 3)
+    }
+    
+    /// Tests that `intersect(withRange:)` works.
+    ///
+    /// Set up:
+    /// - Receiver range: (loc: 0, len: 3)
+    /// - Target range: (loc: 5, len: 5)
+    ///
+    /// Expected result:
+    /// - `nil`
+    ///
+    func testIntersectWithRange7() {
+        let receiver = NSRange(location: 0, length: 3)
+        let target = NSRange(location: 5, length: 5)
+        
+        let result = receiver.intersect(withRange: target)
+        
+        XCTAssertNil(result)
+    }
+}


### PR DESCRIPTION
Adds a method to compare ranges, that will be used in the upcoming copy / paste support PR.

**How to test:**
Since it's not hooked up, please review the unit tests with documentation.
Also run them to make sure they're working as expected.