### PR TITLE
Adds initial copy / paste support.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		59FEA0751D8BDFA700D138DF /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA0661D8BDFA700D138DF /* NodeTests.swift */; };
 		59FEA0781D8BDFA700D138DF /* HTMLToAttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06A1D8BDFA700D138DF /* HTMLToAttributedStringTests.swift */; };
 		59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */; };
+		F11904A51D9D857500BFF9A1 /* TextNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -134,6 +135,7 @@
 		59FEA06B1D8BDFA700D138DF /* InAttributeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAttributeConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InHTMLConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
+		F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextNodeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -417,6 +419,7 @@
 			children = (
 				59FEA0651D8BDFA700D138DF /* ElementNodeTests.swift */,
 				59FEA0661D8BDFA700D138DF /* NodeTests.swift */,
+				F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */,
 			);
 			path = HTML;
 			sourceTree = "<group>";
@@ -586,6 +589,7 @@
 				59FEA0751D8BDFA700D138DF /* NodeTests.swift in Sources */,
 				59FEA0781D8BDFA700D138DF /* HTMLToAttributedStringTests.swift in Sources */,
 				594C9D731D8BE6C300D74542 /* InAttributeConverterTests.swift in Sources */,
+				F11904A51D9D857500BFF9A1 /* TextNodeTests.swift in Sources */,
 				59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */,
 				594C9D721D8BE6BC00D74542 /* OutNodeConverterTests.swift in Sources */,
 				599F25951D8BDCFC002871D6 /* AztecVisualEditorTests.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		59FEA0781D8BDFA700D138DF /* HTMLToAttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06A1D8BDFA700D138DF /* HTMLToAttributedStringTests.swift */; };
 		59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */; };
 		F11904A51D9D857500BFF9A1 /* TextNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */; };
+		F126D66F1DA0911C00B37AC9 /* NSRange+Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = F126D66E1DA0911C00B37AC9 /* NSRange+Comparison.swift */; };
 		F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */; };
 /* End PBXBuildFile section */
 
@@ -137,6 +138,7 @@
 		59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InHTMLConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
 		F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextNodeTests.swift; sourceTree = "<group>"; };
+		F126D66E1DA0911C00B37AC9 /* NSRange+Comparison.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRange+Comparison.swift"; sourceTree = "<group>"; };
 		F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeafNode.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -340,6 +342,7 @@
 				599F25251D8BC9A1002871D6 /* NSAttributedString+Helpers.swift */,
 				599F25261D8BC9A1002871D6 /* String+RangeConversion.swift */,
 				599F25271D8BC9A1002871D6 /* UITextView+Helpers.swift */,
+				F126D66E1DA0911C00B37AC9 /* NSRange+Comparison.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -558,6 +561,7 @@
 				599F25481D8BC9A1002871D6 /* Metrics.swift in Sources */,
 				599F253B1D8BC9A1002871D6 /* InNodesConverter.swift in Sources */,
 				F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */,
+				F126D66F1DA0911C00B37AC9 /* NSRange+Comparison.swift in Sources */,
 				599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */,
 				599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */,
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,

--- a/Aztec/Classes/Private/Libxml2/Data/EditableNode.swift
+++ b/Aztec/Classes/Private/Libxml2/Data/EditableNode.swift
@@ -1,8 +1,16 @@
 import Foundation
 
 protocol EditableNode {
-    func deleteCharacters(inRange range: NSRange);
-    func replaceCharacters(inRange range: NSRange, withString string: String);
-    func split(forRange range: NSRange);
-    func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Libxml2.Attribute]);
+    func deleteCharacters(inRange range: NSRange)
+    func replaceCharacters(inRange range: NSRange, withString string: String)
+    
+    /// Should split the node at the specified text location.  The receiver will become the node before the specified
+    /// location and a new node will be created to contain whatever comes after it.
+    ///
+    /// - Parameters:
+    ///     - location: the text location to split the node at.
+    ///
+    func split(atLocation location: Int)
+    func split(forRange range: NSRange)
+    func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Libxml2.Attribute])
 }

--- a/Aztec/Classes/Private/Libxml2/Data/EditableNode.swift
+++ b/Aztec/Classes/Private/Libxml2/Data/EditableNode.swift
@@ -2,7 +2,16 @@ import Foundation
 
 protocol EditableNode {
     func deleteCharacters(inRange range: NSRange)
-    func replaceCharacters(inRange range: NSRange, withString string: String)
+    
+    /// Replaces the specified range with a new string.
+    ///
+    /// - Parameters:
+    ///     - range: the range of the original string to replace.
+    ///     - string: the new string to replace the original text with.
+    ///     - inheritStyle: If `true` the new string will inherit the style information from the first position in
+    ///             the specified range.  If `false`, the new sting will have no associated style.
+    ///
+    func replaceCharacters(inRange range: NSRange, withString string: String, inheritStyle: Bool)
 
     /// Should split the node at the specified text location.  The receiver will become the node before the specified
     /// location and a new node will be created to contain whatever comes after it.

--- a/Aztec/Classes/Private/Libxml2/Data/TextNode.swift
+++ b/Aztec/Classes/Private/Libxml2/Data/TextNode.swift
@@ -24,6 +24,10 @@ extension Libxml2 {
         }
 
         // MARK: - EditableNode
+        
+        func append(string: String) {
+            text.appendContentsOf(string)
+        }
 
         func deleteCharacters(inRange range: NSRange) {
 
@@ -32,6 +36,10 @@ extension Libxml2 {
             }
 
             text.removeRange(textRange)
+        }
+        
+        func prepend(string: String) {
+            text = "\(string)\(text)"
         }
 
         func replaceCharacters(inRange range: NSRange, withString string: String) {
@@ -43,6 +51,27 @@ extension Libxml2 {
             text.replaceRange(textRange, with: string)
         }
 
+        func split(atLocation location: Int) {
+            
+            let index = text.startIndex.advancedBy(location)
+            
+            guard let parent = parent,
+                let nodeIndex = parent.children.indexOf(self) else {
+                    
+                    fatalError("This scenario should not be possible. Review the logic.")
+            }
+            
+            let preRange = text.startIndex ..< index
+            let postRange = index ..< text.endIndex
+            
+            if preRange.count > 0 && postRange.count > 0 {
+                let newNode = TextNode(text: text.substringWithRange(postRange))
+                
+                text.removeRange(postRange)
+                parent.insert(newNode, at: nodeIndex + 1)
+            }
+        }
+        
         func split(forRange range: NSRange) {
 
             guard let swiftRange = text.rangeFromNSRange(range) else {

--- a/Aztec/Classes/Private/Libxml2/Data/TextNode.swift
+++ b/Aztec/Classes/Private/Libxml2/Data/TextNode.swift
@@ -42,7 +42,7 @@ extension Libxml2 {
             contents = "\(string)\(contents)"
         }
 
-        func replaceCharacters(inRange range: NSRange, withString string: String) {
+        func replaceCharacters(inRange range: NSRange, withString string: String, inheritStyle: Bool) {
 
             guard let textRange = contents.rangeFromNSRange(range) else {
                 fatalError("The specified range is out of bounds.")
@@ -53,12 +53,13 @@ extension Libxml2 {
 
         func split(atLocation location: Int) {
             
-            guard location != 0 && location != length() - 1 else {
+            guard location != 0 && location != length() else {
                 // Nothing to split, move along...
+                
                 return
             }
             
-            guard location > 0 && location < length() - 1 else {
+            guard location > 0 && location < length() else {
                 fatalError("Out of bounds!")
             }
             

--- a/Aztec/Classes/Public/Extensions/NSRange+Comparison.swift
+++ b/Aztec/Classes/Public/Extensions/NSRange+Comparison.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension NSRange {
+    
+    /// Returns the intersection between the receiver and the specified range.
+    ///
+    /// - Important: the main difference with NSIntersectionRange is that this method considers any contact (even a
+    ///         zero-length contact) as an intersection.  Another difference is that this method returns `nil`
+    ///         when there's absolutely no contact.
+    ///
+    /// - Parameters:
+    ///     - range: the range to compare the receiver against.
+    ///
+    /// - Returns: the interesection if there's any, or `nil` otherwise.
+    ///
+    func intersect(withRange target: NSRange) -> NSRange? {
+        
+        let endLocation = location + length
+        let targetEndLocation = target.location + target.length
+        
+        if target.location >= location && targetEndLocation <= endLocation {
+            return target
+        } else if target.location < location && targetEndLocation >= location && targetEndLocation <= endLocation {
+            return NSRange(location: location, length: targetEndLocation - location)
+        } else if target.location >= location && target.location <= endLocation && targetEndLocation > endLocation {
+            return NSRange(location: target.location, length: endLocation - target.location)
+        } else if target.location < location && targetEndLocation > endLocation {
+            return self
+        }else {
+            return nil
+        }
+    }
+}

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -89,7 +89,7 @@ public class TextStorage: NSTextStorage {
     override public func replaceCharactersInRange(range: NSRange, withString str: String) {
         beginEditing()
         textStore.replaceCharactersInRange(range, withString: str)
-        rootNode.replaceCharacters(inRange: range, withString: str)
+        rootNode.replaceCharacters(inRange: range, withString: str, inheritStyle: true)
         endEditing()
         
         edited(.EditedCharacters, range: range, changeInLength: str.characters.count - range.length)
@@ -98,7 +98,9 @@ public class TextStorage: NSTextStorage {
     override public func replaceCharactersInRange(range: NSRange, withAttributedString attrString: NSAttributedString) {
         beginEditing()
         textStore.replaceCharactersInRange(range, withAttributedString: attrString)
-        rootNode.replaceCharacters(inRange: range, withString: attrString.string)
+        rootNode.replaceCharacters(inRange: range, withString: attrString.string, inheritStyle: false)
+        
+        // remove all styles for the specified range here!
         
         let finalRange = NSRange(location: range.location, length: attrString.length)
         copyStylesToDOM(spanning: finalRange)

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -188,7 +188,7 @@ public class TextStorage: NSTextStorage {
         case .StyleSingle:
             enableStrikethroughInDOM(range)
         default:
-            // We don't support anything more than single-line underline for now
+            // We don't support anything more than single-line strikethrough for now
             break
         }
     }

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -123,6 +123,8 @@ public class TextStorage: NSTextStorage {
 
             for (key, value) in attributes {
                 switch (key) {
+                case NSFontAttributeName:
+                    copyFontAttributesToDOM(spanning: range, attributeValue: value)
                 case NSStrikethroughStyleAttributeName:
                     copyStrikethroughStyleToDOM(spanning: range, attributeValue: value)
                 case NSUnderlineStyleAttributeName:
@@ -134,15 +136,38 @@ public class TextStorage: NSTextStorage {
         }
     }
     
+    private func copyFontAttributesToDOM(spanning range: NSRange, attributeValue value: AnyObject) {
+        
+        guard let font = value as? UIFont else {
+            assertionFailure("Was expecting a UIFont object as the value for the font attribute.")
+            return
+        }
+        
+        copyFontAttributesToDOM(spanning: range, font: font)
+    }
+    
+    private func copyFontAttributesToDOM(spanning range: NSRange, font: UIFont) {
+        
+        let fontTraits = font.fontDescriptor().symbolicTraits
+        
+        if fontTraits.contains(.TraitBold) {
+            enableBoldInDOM(range)
+        }
+        
+        if fontTraits.contains(.TraitItalic) {
+            enableItalicInDOM(range)
+        }
+    }
+    
     private func copyStrikethroughStyleToDOM(spanning range: NSRange, attributeValue value: AnyObject) {
         
         guard let intValue = value as? Int else {
-            assertionFailure("The underline style is always expected to be an Int.")
+            assertionFailure("The strikethrough style is always expected to be an Int.")
             return
         }
         
         guard let style = NSUnderlineStyle(rawValue: intValue) else {
-            assertionFailure("The underline style value is not-known.")
+            assertionFailure("The strikethrough style value is not-known.")
             return
         }
         

--- a/AztecTests/AztecVisualEditorTests.swift
+++ b/AztecTests/AztecVisualEditorTests.swift
@@ -15,7 +15,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     // Confirm the composed textView is property configured.
-/*
+
     func testTextViewReferencesStorage() {
 
         let textView = Aztec.TextView(defaultFont: UIFont.systemFontOfSize(14), defaultMissingImage: Gridicon.iconOfType(.Attachment))
@@ -34,10 +34,10 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(textView.textStorage == textView.textContainer.layoutManager!.textStorage)
         XCTAssert(textView.textStorage.isKindOfClass(TextStorage))
     }
-*/
+
 
     // MARK: - Test Index Wrangling
-/*
+
     func testMaxIndex() {
         let textView = Aztec.TextView(defaultFont: UIFont.systemFontOfSize(14), defaultMissingImage: Gridicon.iconOfType(.Attachment))
 
@@ -67,8 +67,6 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(0 == textView.adjustedIndex(1))
         XCTAssert(1 == textView.adjustedIndex(2))
     }
- */
-
 
     // MARK: - Retrieve Format Identifiers
 
@@ -169,7 +167,7 @@ class AztecVisualEditorTests: XCTestCase {
 
         XCTAssert(editor.strikethroughFormattingSpansRange(range))
     }
-/*
+
     func testToggleBlockquote() {
         let editor = editorConfiguredWithParagraphs()
         let range = NSRange(location: 0, length: 1)
@@ -185,7 +183,6 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.formattingAtIndexContainsBlockquote(1))
         XCTAssert(!editor.blockquoteFormattingSpansRange(NSRange(location: 0, length: length)))
     }
- */
 
     func testToggleOrderedList() {
         // TODO
@@ -244,7 +241,7 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.strikethroughFormattingSpansRange(NSRange(location: 2, length: 3)))
         XCTAssert(!editor.strikethroughFormattingSpansRange(NSRange(location: 4, length: 3)))
     }
-/*
+
     func testBlockquoteSpansRange() {
         let editor = editorConfiguredWithParagraphs()
         let range = NSRange(location: 0, length: 1)
@@ -256,7 +253,6 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.blockquoteFormattingSpansRange(NSRange(location: 0, length: length + 1)))
         XCTAssert(!editor.blockquoteFormattingSpansRange(NSRange(location: 1, length: length)))
     }
- */
 
     func testBoldAtIndex() {
         let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
@@ -301,7 +297,7 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.formattingAtIndexContainsStrikethrough(2))
         XCTAssert(!editor.formattingAtIndexContainsStrikethrough(6))
     }
-/*
+
     func testBlockquoteAtIndex() {
         let editor = editorConfiguredWithParagraphs()
         let range = NSRange(location: 0, length: 1)
@@ -316,7 +312,6 @@ class AztecVisualEditorTests: XCTestCase {
 
         XCTAssert(!editor.formattingAtIndexContainsBlockquote(1))
     }
- */
 
     // MARK: - Helpers
 

--- a/AztecTests/AztecVisualEditorTests.swift
+++ b/AztecTests/AztecVisualEditorTests.swift
@@ -15,7 +15,7 @@ class AztecVisualEditorTests: XCTestCase {
     }
 
     // Confirm the composed textView is property configured.
-
+/*
     func testTextViewReferencesStorage() {
 
         let textView = Aztec.TextView(defaultFont: UIFont.systemFontOfSize(14), defaultMissingImage: Gridicon.iconOfType(.Attachment))
@@ -34,10 +34,10 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(textView.textStorage == textView.textContainer.layoutManager!.textStorage)
         XCTAssert(textView.textStorage.isKindOfClass(TextStorage))
     }
-
+*/
 
     // MARK: - Test Index Wrangling
-
+/*
     func testMaxIndex() {
         let textView = Aztec.TextView(defaultFont: UIFont.systemFontOfSize(14), defaultMissingImage: Gridicon.iconOfType(.Attachment))
 
@@ -67,6 +67,7 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(0 == textView.adjustedIndex(1))
         XCTAssert(1 == textView.adjustedIndex(2))
     }
+ */
 
 
     // MARK: - Retrieve Format Identifiers
@@ -168,7 +169,7 @@ class AztecVisualEditorTests: XCTestCase {
 
         XCTAssert(editor.strikethroughFormattingSpansRange(range))
     }
-
+/*
     func testToggleBlockquote() {
         let editor = editorConfiguredWithParagraphs()
         let range = NSRange(location: 0, length: 1)
@@ -184,6 +185,7 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.formattingAtIndexContainsBlockquote(1))
         XCTAssert(!editor.blockquoteFormattingSpansRange(NSRange(location: 0, length: length)))
     }
+ */
 
     func testToggleOrderedList() {
         // TODO
@@ -242,7 +244,7 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.strikethroughFormattingSpansRange(NSRange(location: 2, length: 3)))
         XCTAssert(!editor.strikethroughFormattingSpansRange(NSRange(location: 4, length: 3)))
     }
-
+/*
     func testBlockquoteSpansRange() {
         let editor = editorConfiguredWithParagraphs()
         let range = NSRange(location: 0, length: 1)
@@ -254,6 +256,7 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.blockquoteFormattingSpansRange(NSRange(location: 0, length: length + 1)))
         XCTAssert(!editor.blockquoteFormattingSpansRange(NSRange(location: 1, length: length)))
     }
+ */
 
     func testBoldAtIndex() {
         let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
@@ -298,7 +301,7 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.formattingAtIndexContainsStrikethrough(2))
         XCTAssert(!editor.formattingAtIndexContainsStrikethrough(6))
     }
-
+/*
     func testBlockquoteAtIndex() {
         let editor = editorConfiguredWithParagraphs()
         let range = NSRange(location: 0, length: 1)
@@ -313,6 +316,7 @@ class AztecVisualEditorTests: XCTestCase {
 
         XCTAssert(!editor.formattingAtIndexContainsBlockquote(1))
     }
+ */
 
     // MARK: - Helpers
 

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1163,15 +1163,16 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(paragraph.children[0], textNode1)
         XCTAssertEqual(paragraph.children[1], boldNode)
     }
-/*
-    /// Tests replaceCharacters(inRange:withString:).
+
+    /// Tests `replaceCharacters(inRange:withString:)`.
     ///
-    /// Input HTML: <p>Click on this <a href="http://www.wordpress.com">link</a></p>
-    /// Range: (14...4)
-    /// New String: "link!"
+    /// Input HTML: `<p>Click on this <a href="http://www.wordpress.com">link</a></p>`
+    /// - Range: the range of the full contents of the `<a>` node.
+    /// - New String: "link!"
+    /// - Inherit Style: true
     ///
     /// Expected results:
-    ///     - Output: <p>Click on this <a href="http://www.wordpress.com">link!</a></p>
+    /// - Output: `<p>Click on this <a href="http://www.wordpress.com">link!</a></p>`
     ///
     func testReplaceCharactersInRangeWithString() {
         let linkText = TextNode(text: "link")
@@ -1182,7 +1183,7 @@ class ElementNodeTests: XCTestCase {
         let range = NSRange(location: 14, length: 4)
         let newString = "link!"
         
-        paragraph.replaceCharacters(inRange: range, withString: newString)
+        paragraph.replaceCharacters(inRange: range, withString: newString, inheritStyle: true)
         
         XCTAssertEqual(paragraph.children.count, 2)
         XCTAssertEqual(paragraph.children[0], preLinkText)
@@ -1197,5 +1198,81 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(link.children.count, 1)
         XCTAssertEqual(link.text(), newString)
     }
- */
+    
+    /// Tests `replaceCharacters(inRange:withString:)`.
+    ///
+    /// Input HTML: `<p>Click on this <a href="http://www.wordpress.com">link</a></p>`
+    /// - Range: the range of the full contents of the `<a>` node.
+    /// - New String: "link!"
+    /// - Inherit Style: false
+    ///
+    /// Expected results:
+    /// - Output: `<p>Click on this link!</p>`
+    ///
+    func testReplaceCharactersInRangeWithString2() {
+        let text1 = "Click on this "
+        let text2 = "link"
+        let linkText = TextNode(text: text2)
+        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText])
+        let preLinkText = TextNode(text: text1)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement])
+        
+        let range = NSRange(location: 14, length: 4)
+        let newString = "link!"
+        let finalText = "\(text1)\(text2)!"
+        
+        paragraph.replaceCharacters(inRange: range, withString: newString, inheritStyle: false)
+        
+        XCTAssertEqual(paragraph.children.count, 1)
+        
+        guard let textNode = paragraph.children[0] as? TextNode
+            where textNode.text() == finalText else {
+                
+                XCTFail("Expected a text node, with the full text.")
+                return
+        }
+    }
+    
+    /// Tests `replaceCharacters(inRange:withString:)`.
+    ///
+    /// Input HTML: `<div><p>Click on this <a href="http://www.wordpress.com">link</a></p></div>`
+    /// - Range: the range of the full contents of the `<a>` node.
+    /// - New String: "link!"
+    /// - Inherit Style: false
+    ///
+    /// Expected results:
+    /// - Output: `<div><p>Click on this link!</p></div>`
+    ///
+    func testReplaceCharactersInRangeWithString3() {
+        let text1 = "Click on this "
+        let text2 = "link"
+        let linkText = TextNode(text: text2)
+        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText])
+        let preLinkText = TextNode(text: text1)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        
+        let range = NSRange(location: 14, length: 4)
+        let newString = "link!"
+        let finalText = "\(text1)\(text2)!"
+        
+        div.replaceCharacters(inRange: range, withString: newString, inheritStyle: false)
+        
+        XCTAssertEqual(div.children.count, 1)
+        
+        guard let newParagraph = div.children[0] as? ElementNode
+            where newParagraph.name == "p" else {
+                XCTFail("Expected a paragraph.")
+                return
+        }
+        
+        XCTAssertEqual(newParagraph.children.count, 1)
+        
+        guard let textNode = newParagraph.children[0] as? TextNode
+            where textNode.text() == finalText else {
+                
+                XCTFail("Expected a text node, with the full text.")
+                return
+        }
+    }
 }

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -230,6 +230,47 @@ class ElementNodeTests: XCTestCase {
 
         XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: text1.length() - 1, length: 0)))
     }
+    
+    /// Tests that splitting an element node at a specified text location works fine.
+    ///
+    /// HTML string: <div><p>Hello World!</p></div>
+    /// Split target: the paragraph tag
+    /// Split Location: 5
+    ///
+    /// The results should be:
+    ///     - The output should be: <div><p>Hello</p><p> World!</p></div>
+    ///     - The original paragraph object should point to the first child paragraph.
+    ///
+    func testSplitAtLocation1() {
+        let text1 = "Hello"
+        let text2 = " World!"
+        
+        let textNode = TextNode(text: "\(text1)\(text2)")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        
+        let splitLocation = text1.characters.count
+        
+        paragraph.split(atLocation: splitLocation)
+        
+        XCTAssertEqual(div.children.count, 2)
+        
+        guard let newParagraph1 = div.children[0] as? ElementNode
+            where newParagraph1 == paragraph else {
+                XCTFail("Expected the first new paragraph to exist and be the same as the original paragraph.")
+                return
+        }
+        
+        guard let newParagraph2 = div.children[1] as? ElementNode
+            where newParagraph2.text() == text2 else {
+                XCTFail("Expected the first new paragraph to exist.")
+                return
+        }
+        
+        XCTAssertEqual(newParagraph1.children.count, 1)
+        
+        newParagraph1
+    }
 
     func testSplitWithFullRange() {
 
@@ -765,7 +806,6 @@ class ElementNodeTests: XCTestCase {
         XCTAssert(NSEqualRanges(childrenAndRanges[0].intersection, range))
     }
 
-
     /// Tests `childNodes(intersectingRange:)` with a zero-length range.
     ///
     /// Input HTML: <p><b>Hello</b><b>Hello again!</b></p>
@@ -800,5 +840,246 @@ class ElementNodeTests: XCTestCase {
 
         XCTAssertEqual(childrenAndRanges[0].child, bold2)
         XCTAssert(NSEqualRanges(childrenAndRanges[0].intersection, NSRange(location: 0, length: 0)))
+    }
+    
+    /// Tests `insert(string: String, at index: Int)`.
+    ///
+    /// Input HTML: <p><b>Hello1</b><b>Hello2</b></p>
+    /// String: "---"
+    /// Index: 0
+    ///
+    /// Expected results:
+    ///     - Output should be: <p>---<b>Hello1</b><b>Hello2</b></p>
+    ///
+    func testInsertStringAt1() {
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
+        
+        let textToInsert = "---"
+        
+        paragraph.insert(textToInsert, at: 0)
+        
+        XCTAssertEqual(paragraph.children.count, 3)
+        
+        guard let newTextNode = paragraph.children[0] as? TextNode
+            where newTextNode.text == textToInsert else {
+                XCTFail("Expected a text node here with the inserted text.")
+                return
+        }
+        
+        XCTAssertEqual(paragraph.children[1], boldNode1)
+        XCTAssertEqual(paragraph.children[2], boldNode2)
+    }
+    
+    /// Tests `insert(string: String, at index: Int)`.
+    ///
+    /// Input HTML: <p><b>Hello1</b><b>Hello2</b></p>
+    /// String: "---"
+    /// Index: 1
+    ///
+    /// Expected results:
+    ///     - Output should be: <p><b>Hello1</b>---<b>Hello2</b></p>
+    ///
+    func testInsertStringAt2() {
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
+        
+        let textToInsert = "---"
+        
+        paragraph.insert(textToInsert, at: 1)
+        
+        XCTAssertEqual(paragraph.children.count, 3)
+        
+        guard let newTextNode = paragraph.children[1] as? TextNode
+            where newTextNode.text == textToInsert else {
+                XCTFail("Expected a text node here with the inserted text.")
+                return
+        }
+        
+        XCTAssertEqual(paragraph.children[0], boldNode1)
+        XCTAssertEqual(paragraph.children[2], boldNode2)
+    }
+    
+    /// Tests `insert(string: String, at index: Int)`.
+    ///
+    /// Input HTML: <p><b>Hello1</b><b>Hello2</b></p>
+    /// String: "---"
+    /// Index: 2
+    ///
+    /// Expected results:
+    ///     - Output should be: <p><b>Hello1</b><b>Hello2</b>---</p>
+    ///
+    func testInsertStringAt3() {
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
+        
+        let textToInsert = "---"
+        
+        paragraph.insert(textToInsert, at: 2)
+
+        XCTAssertEqual(paragraph.children.count, 3)
+        
+        guard let newTextNode = paragraph.children[2] as? TextNode
+            where newTextNode.text == textToInsert else {
+                XCTFail("Expected a text node here with the inserted text.")
+                return
+        }
+        
+        XCTAssertEqual(paragraph.children[0], boldNode1)
+        XCTAssertEqual(paragraph.children[1], boldNode2)
+    }
+    
+    /// Tests `insert(string: String, at index: Int)`.
+    ///
+    /// Input HTML: <p>Hello1<b>Hello2</b>Hello3</p>
+    /// String: "---"
+    /// Index: 0
+    ///
+    /// Expected results:
+    ///     - Output should be: <p>---Hello1<b>Hello2</b>Hello3</p>
+    ///     - The string should be attached to the adjacent TextNode.
+    ///
+    func testInsertStringAt4() {
+        
+        let adjacentText = "Hello1"
+        
+        let textNode1 = TextNode(text: adjacentText)
+        let textNode2 = TextNode(text: "Hello2")
+        let textNode3 = TextNode(text: "Hello3")
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        
+        let textToInsert = "---"
+        
+        paragraph.insert(textToInsert, at: 0)
+        
+        XCTAssertEqual(paragraph.children.count, 3)
+        
+        guard let textNode = paragraph.children[0] as? TextNode
+            where textNode.text == "\(textToInsert)\(adjacentText)" else {
+                XCTFail("Expected a text node here with the inserted text.")
+                return
+        }
+        
+        XCTAssertEqual(paragraph.children[1], boldNode)
+        XCTAssertEqual(paragraph.children[2], textNode3)
+    }
+    
+    /// Tests `insert(string: String, at index: Int)`.
+    ///
+    /// Input HTML: <p>Hello1<b>Hello2</b>Hello3</p>
+    /// String: "---"
+    /// Index: 1
+    ///
+    /// Expected results:
+    ///     - Output should be: <p>Hello1---<b>Hello2</b>Hello3</p>
+    ///     - The string should be attached to the adjacent TextNode.
+    ///
+    func testInsertStringAt5() {
+        
+        let adjacentText = "Hello1"
+        
+        let textNode1 = TextNode(text: adjacentText)
+        let textNode2 = TextNode(text: "Hello2")
+        let textNode3 = TextNode(text: "Hello3")
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        
+        let textToInsert = "---"
+        
+        paragraph.insert(textToInsert, at: 1)
+        
+        XCTAssertEqual(paragraph.children.count, 3)
+        
+        guard let textNode = paragraph.children[0] as? TextNode
+            where textNode.text == "\(adjacentText)\(textToInsert)" else {
+                XCTFail("Expected a text node here with the inserted text.")
+                return
+        }
+        
+        XCTAssertEqual(paragraph.children[1], boldNode)
+        XCTAssertEqual(paragraph.children[2], textNode3)
+    }
+    
+    /// Tests `insert(string: String, at index: Int)`.
+    ///
+    /// Input HTML: <p>Hello1<b>Hello2</b>Hello3</p>
+    /// String: "---"
+    /// Index: 2
+    ///
+    /// Expected results:
+    ///     - Output should be: <p>Hello1<b>Hello2</b>---Hello3</p>
+    ///     - The string should be attached to the adjacent TextNode.
+    ///
+    func testInsertStringAt6() {
+        
+        let adjacentText = "Hello3"
+        
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let textNode3 = TextNode(text: adjacentText)
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        
+        let textToInsert = "---"
+        
+        paragraph.insert(textToInsert, at: 2)
+        
+        XCTAssertEqual(paragraph.children.count, 3)
+        
+        guard let textNode = paragraph.children[2] as? TextNode
+            where textNode.text == "\(textToInsert)\(adjacentText)" else {
+                XCTFail("Expected a text node here with the inserted text.")
+                return
+        }
+        
+        XCTAssertEqual(paragraph.children[0], textNode1)
+        XCTAssertEqual(paragraph.children[1], boldNode)
+    }
+    
+    
+    /// Tests `insert(string: String, at index: Int)`.
+    ///
+    /// Input HTML: <p>Hello1<b>Hello2</b>Hello3</p>
+    /// String: "---"
+    /// Index: 3
+    ///
+    /// Expected results:
+    ///     - Output should be: <p>Hello1<b>Hello2</b>Hello3---</p>
+    ///     - The string should be attached to the adjacent TextNode.
+    ///
+    func testInsertStringAt7() {
+        
+        let adjacentText = "Hello3"
+        
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let textNode3 = TextNode(text: adjacentText)
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        
+        let textToInsert = "---"
+        
+        paragraph.insert(textToInsert, at: 3)
+        
+        XCTAssertEqual(paragraph.children.count, 3)
+        
+        guard let textNode = paragraph.children[2] as? TextNode
+            where textNode.text == "\(adjacentText)\(textToInsert)" else {
+                XCTFail("Expected a text node here with the inserted text.")
+                return
+        }
+        
+        XCTAssertEqual(paragraph.children[0], textNode1)
+        XCTAssertEqual(paragraph.children[1], boldNode)
     }
 }

--- a/AztecTests/HTML/TextNodeTests.swift
+++ b/AztecTests/HTML/TextNodeTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import Aztec
+
+class TextNodeTests: XCTestCase {
+    
+    typealias ElementNode = Libxml2.ElementNode
+    typealias TextNode = Libxml2.TextNode
+    
+    /// Tests that splitting a text node at a specified text location works fine.
+    ///
+    /// HTML string: <p>Hello World!</p>
+    /// Split Location: 5
+    ///
+    /// The results should be:
+    ///     - After the split, the selected text node should contain: "Hello"
+    ///     - A new text node should exist immediately after, containing: " World!"
+    ///
+    func testSplitAtLocation1() {
+        let text1 = "Hello"
+        let text2 = " World!"
+
+        let textNode = TextNode(text: "\(text1)\(text2)")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        
+        let splitLocation = text1.characters.count
+        
+        textNode.split(atLocation: splitLocation)
+        
+        XCTAssertEqual(paragraph.children.count, 2)
+        
+        guard let newTextNode1 = paragraph.children[0] as? TextNode
+            where newTextNode1.text == text1 else {
+                XCTFail("Expected a text node here.")
+                return
+        }
+        
+        guard let newTextNode2 = paragraph.children[1] as? TextNode
+            where newTextNode2.text == text2 else {
+                XCTFail("Expected a text node here.")
+                return
+        }
+    }
+    
+    
+    /// Tests that splitting a text node at a specified text location works fine.
+    ///
+    /// HTML string: <p>Hello World!</p>
+    /// Split Location: 0
+    ///
+    /// The results should be:
+    ///     - No splitting should occur, the selected text node should match the whole string.
+    ///
+    func testSplitAtLocation2() {
+        let textNode = TextNode(text: "Hello World!")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        
+        let splitLocation = 0
+        
+        textNode.split(atLocation: splitLocation)
+        
+        XCTAssertEqual(paragraph.children.count, 1)
+        XCTAssertEqual(paragraph.children[0], textNode)
+    }
+    
+    /// Tests that splitting a text node at a specified text location works fine.
+    ///
+    /// HTML string: <p>Hello World!</p>
+    /// Split Location: full string length
+    ///
+    /// The results should be:
+    ///     - No splitting should occur, the selected text node should match the whole string.
+    ///
+    func testSplitAtLocation3() {
+        let textNode = TextNode(text: "Hello World!")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        
+        let splitLocation = textNode.length()
+        
+        textNode.split(atLocation: splitLocation)
+        
+        XCTAssertEqual(paragraph.children.count, 1)
+        XCTAssertEqual(paragraph.children[0], textNode)
+    }
+}

--- a/AztecTests/HTML/TextNodeTests.swift
+++ b/AztecTests/HTML/TextNodeTests.swift
@@ -74,7 +74,7 @@ class TextNodeTests: XCTestCase {
         let textNode = TextNode(text: "Hello World!")
         let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
         
-        let splitLocation = textNode.length() - 1
+        let splitLocation = textNode.length()
         
         textNode.split(atLocation: splitLocation)
         

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -17,7 +17,7 @@ class TextStorageTests: XCTestCase
     }
 
     // MARK: - Test Traits
-
+/*
     func testFontTraitExistsAtIndex() {
         let attributes = [
             NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
@@ -79,5 +79,5 @@ class TextStorageTests: XCTestCase
         // Confirm the trait was restored
         XCTAssert(storage.fontTrait(.TraitBold, spansRange: range))
     }
-
+*/
 }

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -17,7 +17,7 @@ class TextStorageTests: XCTestCase
     }
 
     // MARK: - Test Traits
-/*
+
     func testFontTraitExistsAtIndex() {
         let attributes = [
             NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
@@ -38,7 +38,7 @@ class TextStorageTests: XCTestCase
         XCTAssert(!storage.fontTrait(.TraitBold, existsAtIndex: 6))
         XCTAssert(!storage.fontTrait(.TraitBold, existsAtIndex: 8))
     }
-    
+
     func testFontTraitSpansRange() {
         let attributes = [
             NSFontAttributeName: UIFont.boldSystemFontOfSize(10)
@@ -79,5 +79,4 @@ class TextStorageTests: XCTestCase
         // Confirm the trait was restored
         XCTAssert(storage.fontTrait(.TraitBold, spansRange: range))
     }
-*/
 }


### PR DESCRIPTION
Related to #75.

Adds initial copy / paste support.  This PR is a bit large but at least half of the added lines are unit tests.

**Known limitations:**

When copy-pasting styles, there's some HTML node duplication (example: `<b>hello</b><b> there</b>`).  This'll be addressed in an upcoming PR, so please ignore for now.

**How to test:**

Run the unit tests... then:

1. Launch the example app.
2. Copy styled text.
3. Paste it into the editor.
4. Switch to HTML mode and make sure the tags are there (the supported ones are: bold, strike, underline, italic).