### PR TITLE
Add test for crash on newline after div

### DIFF
--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1376,7 +1376,16 @@ class ElementNodeTests: XCTestCase {
     }
 
     // MARK: - Bug fixes
-    // https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/90
+
+    /// Test that inserting a new line after a DIV tag doesn't crash
+    /// See https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/90
+    ///
+    /// Input HTML: `<div>This is a paragraph in a div</div>\nThis is some unwrapped text`
+    /// - location: the location after the div tag.
+    ///
+    /// Expected results:
+    /// - Output: `<div>This is a paragraph in a div</div>\n\nThis is some unwrapped text`
+    ///
     func testInsertNewlineAfterDivShouldNotCrash() {
         let text1 = "This is a paragraph in a div"
         let text2 = "\nThis is some unwrapped text"

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1374,4 +1374,18 @@ class ElementNodeTests: XCTestCase {
         }
 
     }
+
+    // MARK: - Bug fixes
+    // https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/90
+    func testInsertNewlineAfterDivShouldNotCrash() {
+        let text1 = "This is a paragraph in a div"
+        let text2 = "\nThis is some unwrapped text"
+        let divText = TextNode(text: text1)
+        let div = ElementNode(name: "div", attributes: [], children: [divText])
+        let unwrappedText = TextNode(text: text2)
+        let rootNode = RootNode(children: [div, unwrappedText])
+        let location = text1.characters.count
+
+        rootNode.insert("\n", atLocation: location)
+    }
 }


### PR DESCRIPTION
Fixes #90, which was actually fixed by #84. This just adds a unit test

Needs Review: @diegoreymendez 