### PR TITLE
Improve image handling

### DIFF
--- a/Aztec/Classes/Public/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/Public/TextKit/TextAttachment.swift
@@ -55,7 +55,7 @@ public class TextAttachment: NSTextAttachment
             let targetWidth = onScreenWidth(containerWidth)
             let scale = targetWidth / image.size.width
 
-            return image.size.height * scale
+            return floor(image.size.height * scale)
         } else {
             return 0
         }
@@ -65,9 +65,9 @@ public class TextAttachment: NSTextAttachment
         if let image = image {
             switch (size) {
             case .Maximum:
-                return min(image.size.width, containerWidth)
+                return floor(min(image.size.width, containerWidth))
             default:
-                return min(size.width, containerWidth)
+                return floor(min(size.width, containerWidth))
             }
         } else {
             return 0

--- a/Aztec/Classes/Public/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/Public/TextKit/TextAttachment.swift
@@ -21,6 +21,8 @@ public class TextAttachment: NSTextAttachment
     ///
     public var size: Size = .Maximum
 
+    private var glyphImage: UIImage?
+
     /// Designed Initializer
     ///
     public init(identifier: String) {
@@ -81,11 +83,13 @@ public class TextAttachment: NSTextAttachment
             return nil
         }
 
+        if let cachedImage = glyphImage where CGSizeEqualToSize(imageBounds.size, cachedImage.size) {
+            return cachedImage
+        }
         let containerWidth = imageBounds.size.width
         let origin = CGPoint(x: xPosition(forContainerWidth: imageBounds.size.width), y: 0)
         let size = CGSize(width: onScreenWidth(containerWidth), height: onScreenHeight(containerWidth))
         let scale = UIScreen.mainScreen().scale
-        let glyphImage: UIImage?
 
         UIGraphicsBeginImageContextWithOptions(imageBounds.size, false, scale)
 

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -314,9 +314,10 @@ public class TextStorage: NSTextStorage {
     ///
     /// - parameter url: the source URL of the image
     /// - parameter position: the position to insert the image
-    /// - placeHolderImage: an image to display while the image from sourceURL is being prepared
+    /// - parameter placeHolderImage: an image to display while the image from sourceURL is being prepared
     ///
     /// - returns: the identifier of the image
+    ///
     func insertImage(sourceURL url: NSURL, atPosition position:Int, placeHolderImage: UIImage) -> String {
         let identifier = NSUUID().UUIDString
         let attachment = TextAttachment(identifier: identifier)

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -457,6 +457,7 @@ public class TextStorage: NSTextStorage {
         }
     }
 
+    // MARK: - Image Handling
     func loadImageForAttachment(attachment: TextAttachment, inRange range: NSRange) {
 
         guard let imageProvider = imageProvider else {

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -314,6 +314,7 @@ public class TextStorage: NSTextStorage {
     ///
     /// - parameter url: the source URL of the image
     /// - parameter position: the position to insert the image
+    /// - placeHolderImage: an image to display while the image from sourceURL is being prepared
     ///
     /// - returns: the identifier of the image
     func insertImage(sourceURL url: NSURL, atPosition position:Int, placeHolderImage: UIImage) -> String {

--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -309,12 +309,31 @@ public class TextStorage: NSTextStorage {
         }
     }
 
-    func insertImage(url: NSURL, forRange range: NSRange) {
+
+    /// Insert Image Element at the specified range using url as source
+    ///
+    /// - parameter url: the source URL of the image
+    /// - parameter position: the position to insert the image
+    ///
+    /// - returns: the identifier of the image
+    func insertImage(sourceURL url: NSURL, atPosition position:Int, placeHolderImage: UIImage) -> String {
+        let identifier = NSUUID().UUIDString
+        let attachment = TextAttachment(identifier: identifier)
+        attachment.kind = .RemoteImageDownloaded(url: url, image:placeHolderImage)
+        attachment.image = placeHolderImage
+
+        // Inject the Attachment and Layout
+        let insertionRange = NSMakeRange(position, 0)
+        let attachmentString = NSAttributedString(attachment: attachment)
+        replaceCharactersInRange(insertionRange, withAttributedString: attachmentString)
+        let wrappingRange = NSMakeRange(position, attachmentString.length)
+
         dispatch_async(domQueue) {
-            self.rootNode.replaceCharacters(inRange: range,
+            self.rootNode.replaceCharacters(inRange: wrappingRange,
                                        withNodeNamed: ElementTypes.img.rawValue,
                                        withAttributes: [Libxml2.StringAttribute(name:"src", value: url.absoluteString!)])
         }
+        return identifier
     }
 
     private func toggleAttribute(attributeName: String, value: AnyObject, range: NSRange, onEnable: (NSRange) -> Void, onDisable: (NSRange) -> Void) {

--- a/Aztec/Classes/Public/TextKit/TextView.swift
+++ b/Aztec/Classes/Public/TextKit/TextView.swift
@@ -430,6 +430,8 @@ public class TextView: UITextView {
     ///
     public func insertImage(sourceURL url: NSURL, atPosition position: Int, placeHolderImage: UIImage?) {
         storage.insertImage(sourceURL: url, atPosition: position, placeHolderImage: placeHolderImage ?? defaultMissingImage)
+        let length = NSAttributedString(attachment:NSTextAttachment()).length
+        selectedRange = NSMakeRange(position+length, 0)
     }
 
 

--- a/Aztec/Classes/Public/TextKit/TextView.swift
+++ b/Aztec/Classes/Public/TextKit/TextView.swift
@@ -425,24 +425,11 @@ public class TextView: UITextView {
     ///
     /// - Parameters:
     ///     - image: the image object to be inserted.
-    ///     - wihtUrl: The url of the image to be inserted.
-    ///     - atPosition: The character index at which to insert the image.
+    ///     - sourceURL: The url of the image to be inserted.
+    ///     - position: The character index at which to insert the image.
     ///
-    public func insert(image image:UIImage, withURL url: NSURL, atPosition position: Int) {
-        let identifier = NSUUID().UUIDString
-        let attachment = TextAttachment(identifier: identifier)
-        attachment.kind = .RemoteImageDownloaded(url: url, image:image)
-        attachment.image = image
-
-        // Inject the Attachment and Layout
-        let insertionRange = NSMakeRange(position, 0)
-        let attachmentString = NSAttributedString(attachment: attachment)
-        textStorage.replaceCharactersInRange(insertionRange, withAttributedString: attachmentString)
-        let wrappingRange = NSMakeRange(position, attachmentString.length)
-        storage.insertImage(url, forRange:wrappingRange)
-        // Move the cursor after the attachment
-        let selectionRange = NSMakeRange(position + attachmentString.length, 0)
-        selectedRange = selectionRange
+    public func insertImage(sourceURL url: NSURL, atPosition position: Int, placeHolderImage: UIImage?) {
+        storage.insertImage(sourceURL: url, atPosition: position, placeHolderImage: placeHolderImage ?? defaultMissingImage)
     }
 
 

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 				PROVISIONING_PROFILE = "1aa23f94-9d95-4000-a0a6-8b0a49a2eb62";
 				PROVISIONING_PROFILE_SPECIFIER = "Aztec Example Development";
 				SWIFT_VERSION = 2.3;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -545,6 +546,7 @@
 				PROVISIONING_PROFILE = "839aa3fc-0198-4ea8-bb9b-58c5e9b3e71c";
 				PROVISIONING_PROFILE_SPECIFIER = "Aztec Example Ad Hoc";
 				SWIFT_VERSION = 2.3;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -636,6 +638,7 @@
 				PROVISIONING_PROFILE = "1aa23f94-9d95-4000-a0a6-8b0a49a2eb62";
 				PROVISIONING_PROFILE_SPECIFIER = "Aztec Example Development";
 				SWIFT_VERSION = 2.3;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Profiling;
 		};
@@ -717,6 +720,7 @@
 				PROVISIONING_PROFILE = "3e277507-6579-4f06-95c1-93e8cd30fbe3";
 				PROVISIONING_PROFILE_SPECIFIER = "Aztec Example Alpha Distribution";
 				SWIFT_VERSION = 2.3;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Release-Alpha";
 		};

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -560,7 +560,7 @@ extension EditorDemoController: TextViewMediaDelegate
 
         }
 
-        return Gridicon.iconOfType(.Attachment)
+        return Gridicon.iconOfType(.Image)
     }
 }
 
@@ -600,7 +600,7 @@ private extension EditorDemoController
         }
 
         data.writeToURL(fileURL, atomically:true)
-        richTextView.insert(image: image, withURL: fileURL, atPosition: index)
+        richTextView.insertImage(sourceURL: fileURL, atPosition: index, placeHolderImage: image)
     }
 
     func displayDetailsForAttachment(attachment: TextAttachment) {


### PR DESCRIPTION
This PR refactor some code around attachment:

 - Refactor the code to insertImage to storage, where it makes more sense.
 - Caches the glyph images to improve perfomance while scrolling.
 - Refactor method names to be more Swift 3.0 and clear.
 - Add support for iPad on the Demo app.