### PR TITLE
Fix insertion of characters between images.

### DIFF
--- a/Aztec/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Aztec/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -286,7 +286,10 @@ extension Libxml2 {
             enumerateLowestBlockLevelElements(intersectingRange: targetRange) { result in
                 results.append(result)
             }
-
+            let intersectionRange = targetRange.intersect(withRange: NSMakeRange(0, length()))
+            if results.isEmpty && intersectionRange != nil{
+                results.append((self, intersectionRange!))
+            }
             return results
         }
 


### PR DESCRIPTION
How to test:
 - Put the cursor at the beginning of the editor
 - Insert one image by using the media picker
 - Insert another image by using the media picker
 - Put the cursor between images and try to write
 - No crash should happen
 - Run the unit tests just to check if everything is alright.