### PR TITLE
Fixes a bug with the layout code.

### DIFF
--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -465,10 +465,6 @@ public class TextStorage: NSTextStorage {
         
         edited([.EditedAttributes, .EditedCharacters], range: NSRange(location: 0, length: originalLength), changeInLength: textStore.length - originalLength)
     }
-    
-    func setHTMLInDom(html: String,  withDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) {
-        
-    }
 
     // MARK: - Image Handling
     func loadImageForAttachment(attachment: TextAttachment, inRange range: NSRange) {

--- a/Aztec/Classes/Public/TextKit/TextView.swift
+++ b/Aztec/Classes/Public/TextKit/TextView.swift
@@ -143,7 +143,7 @@ public class TextView: UITextView {
         //      More information about the bug here:
         //          https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/58
         //
-        //font = defaultFont
+        font = defaultFont
         
         storage.setHTML(html, withDefaultFontDescriptor: font!.fontDescriptor())
     }

--- a/Aztec/Classes/Public/TextKit/TextView.swift
+++ b/Aztec/Classes/Public/TextKit/TextView.swift
@@ -136,13 +136,14 @@ public class TextView: UITextView {
     ///     - html: The raw HTML we'd be editing.
     ///
     public func setHTML(html: String) {
+        
         // NOTE: there's a bug in UIKit that causes the textView's font to be changed under certain
         //      conditions.  We are assigning the default font here again to avoid that issue.
         //
         //      More information about the bug here:
         //          https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/58
         //
-        font = defaultFont
+        //font = defaultFont
         
         storage.setHTML(html, withDefaultFontDescriptor: font!.fontDescriptor())
     }

--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -34,6 +34,11 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Fixes #110.

Also reduces the amount of code in `setHTML(...)` that is executed inside the dom queue.

**Test 1:**

Repeat the exact steps from [this video](try/fix-image-loading-problem) and make sure the app doesn't crash.

**Test 2:**

Try adding images normally and make sure they're still showing up fine.