### PR TITLE
Fixes a crash when editing between img nodes.

### DIFF
--- a/Aztec/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Aztec/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -367,7 +367,9 @@ extension Libxml2 {
                     
                     let intersectionInChildCoordinates = NSRange(location: intersection.location - offset, length: intersection.length)
 
-                    if let childElement = child as? ElementNode {
+                    if let childElement = child as? ElementNode
+                        where checkCondition(element: childElement) {
+                        
                         childElement.enumerateLowestElements(
                             intersectingRange: intersectionInChildCoordinates,
                             fulfillingCondition: checkCondition,

--- a/Aztec/Classes/Private/Libxml2/Data/ElementNode.swift
+++ b/Aztec/Classes/Private/Libxml2/Data/ElementNode.swift
@@ -344,7 +344,8 @@ extension Libxml2 {
         ///     - targetRange: the range we're intersecting the child nodes with.  The range is in
         ///             this node's coordinates (the parent node's coordinates, from the children
         ///             PoV).
-        ///     - bailCondition: a condition that makes the search bail.
+        ///     - bailCondition: a condition that makes the search bail from a specific tree search 
+        ///             branch.
         ///     - matchNotFound: the closure to execute for any subrange of `targetRange` that
         ///             doesn't have a block-level node intersecting it.
         ///     - matchFound: the closure to execute for each child element intersecting


### PR DESCRIPTION
Fixes #112.

Supersedes #104.

**Information:**

When we introduced [this change](https://github.com/wordpress-mobile/WordPress-Aztec-iOS/pull/96/commits/3a9d89b8ac65d97aa8077d2c7aad524a5e2e5e07) we lost some of the logic in the process.  The change was fine, but there was an unintentional change in the logic too.

I reintroduced the lost logic in this PR.

I renamed the condition check parameter to make it clear what it's supposed to do.

**How to test:**

Add two images in HTML mode.
Switch to visual mode, and try adding a character between them.
Make sure the app doesn't crash, and editing works.