### PR TITLE
Adds copy / paste support for links.

### DIFF
--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -154,6 +154,8 @@ public class TextStorage: NSTextStorage {
                 switch (key) {
                 case NSFontAttributeName:
                     copyToDOM(fontAttributesSpanning: range, fromAttributeValue: value)
+                case NSLinkAttributeName:
+                    copyToDOM(linkAttributeSpanning: range, fromAttributeValue: value)
                 case NSStrikethroughStyleAttributeName:
                     copyToDOM(strikethroughStyleSpanning: range, fromAttributeValue: value)
                 case NSUnderlineStyleAttributeName:
@@ -173,6 +175,25 @@ public class TextStorage: NSTextStorage {
         }
         
         copyToDOM(fontAttributesSpanning: range, fromFont: font)
+    }
+    
+    private func copyToDOM(linkAttributeSpanning range: NSRange, fromAttributeValue value: AnyObject) {
+        
+        let linkURL: NSURL
+        
+        if let urlValue = value as? NSURL {
+            linkURL = urlValue
+        } else {
+            guard let stringValue = value as? String,
+                let stringValueURL = NSURL(string: stringValue) else {
+                    assertionFailure("Was expecting a NSString or NSURL object as the value for the link attribute.")
+                    return
+            }
+            
+            linkURL = stringValueURL
+        }
+        
+        setLinkInDOM(range, url: linkURL)
     }
     
     private func copyToDOM(fontAttributesSpanning range: NSRange, fromFont font: UIFont) {
@@ -298,14 +319,7 @@ public class TextStorage: NSTextStorage {
         }
         
         addAttribute(NSLinkAttributeName, value: url, range: effectiveRange)
-        
-        dispatch_async(domQueue) {
-            self.rootNode.wrapChildren(
-                intersectingRange: effectiveRange,
-                inNodeNamed: ElementTypes.link.rawValue,
-                withAttributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString!)],
-                equivalentElementNames: ElementTypes.link.equivalentNames)
-        }
+        setLinkInDOM(effectiveRange, url: url)
     }
 
     func removeLink(inRange range: NSRange){
@@ -429,6 +443,16 @@ public class TextStorage: NSTextStorage {
             ElementTypes.underline.rawValue,
             inRange: range,
             equivalentElementNames:  ElementTypes.striketrough.equivalentNames)
+    }
+    
+    private func setLinkInDOM(range: NSRange, url: NSURL) {
+        dispatch_async(domQueue) {
+            self.rootNode.wrapChildren(
+                intersectingRange: range,
+                inNodeNamed: ElementTypes.link.rawValue,
+                withAttributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString!)],
+                equivalentElementNames: ElementTypes.link.equivalentNames)
+        }
     }
 
     // MARK: - HTML Interaction


### PR DESCRIPTION
Adds copy paste support for links.  Closes #105.

**How to test:**

Copy a link and paste it at a different position.
Make sure the link is not lost.
Switch to HTML mode and back to check it.  Also try editing the pasted link.