### PR TITLE
Lists: Matching Calypso's Behavior

### DIFF
--- a/Aztec/Classes/Public/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Public/Extensions/NSAttributedString+Lists.swift
@@ -13,7 +13,7 @@ extension NSAttributedString
     ///     - ranges: Ranges to be filtered
     ///     - style: Style to be matched
     ///
-    /// - Returns: Returns: A subset of the input ranges that don't contain TextLists matching the input style.
+    /// - Returns: A subset of the input ranges that don't contain TextLists matching the input style.
     ///
     func filterListRanges(ranges: [NSRange], notMatchingStyle style: TextList.Style) -> [NSRange] {
         return ranges.filter { range in

--- a/Aztec/Classes/Public/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Public/Extensions/NSAttributedString+Lists.swift
@@ -6,15 +6,14 @@ import UIKit
 //
 extension NSAttributedString
 {
-    /// Given a collection of NSRange's, this method will filter all of those who contain a TextList, and
-    /// doesn't match the specified Style.
+    /// Given a collection of NSRange's, this method will filter all of those that contain a TextList, and
+    /// don't match the specified Style.
     ///
     /// - Parameters:
     ///     - ranges: Ranges to be filtered
     ///     - style: Style to be matched
     ///
-    /// - Returns: A collection of NSRange's, guarranteed to either *NOT* contain TextLists, or contain TextLists
-    ///   with a style matching the one specified.
+    /// - Returns: Returns: A subset of the input ranges that don't contain TextLists matching the input style.
     ///
     func filterListRanges(ranges: [NSRange], notMatchingStyle style: TextList.Style) -> [NSRange] {
         return ranges.filter { range in

--- a/Aztec/Classes/Public/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Public/Extensions/NSAttributedString+Lists.swift
@@ -6,6 +6,23 @@ import UIKit
 //
 extension NSAttributedString
 {
+    /// Given a collection of NSRange's, this method will filter all of those who contain a TextList, and
+    /// doesn't match the specified Style.
+    ///
+    /// - Parameters:
+    ///     - ranges: Ranges to be filtered
+    ///     - style: Style to be matched
+    ///
+    /// - Returns: A collection of NSRange's, guarranteed to either *NOT* contain TextLists, or contain TextLists
+    ///   with a style matching the one specified.
+    ///
+    func filterListRanges(ranges: [NSRange], notMatchingStyle style: TextList.Style) -> [NSRange] {
+        return ranges.filter { range in
+            let list = textListAttribute(spanningRange: range)
+            return list == nil || list?.style == style
+        }
+    }
+
     /// Get the range of a TextList containing the specified index.
     ///
     /// - Parameter index: An index intersecting a TextList.

--- a/Aztec/Classes/Public/Extensions/NSRange+Helpers.swift
+++ b/Aztec/Classes/Public/Extensions/NSRange+Helpers.swift
@@ -34,6 +34,12 @@ extension NSRange
         }
     }
 
+    /// Returns the maximum Location.
+    ///
+    var lastLocation: Int {
+        return location + length
+    }
+
     /// Returns a NSRange instance with location = 0 + length = 0
     ///
     static var zero: NSRange {

--- a/Aztec/Classes/Public/Extensions/NSRange+Helpers.swift
+++ b/Aztec/Classes/Public/Extensions/NSRange+Helpers.swift
@@ -36,7 +36,7 @@ extension NSRange
 
     /// Returns the maximum Location.
     ///
-    var lastLocation: Int {
+    var endLocation: Int {
         return location + length
     }
 

--- a/Aztec/Classes/Public/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Public/Formatters/TextListFormatter.swift
@@ -194,7 +194,7 @@ private extension TextListFormatter
         var last: NSRange?
 
         for range in ranges {
-            if let lastLocation = last?.lastLocation where range.location != lastLocation {
+            if let endLocation = last?.endLocation where range.location != endLocation {
                 grouped.append(current)
                 current.removeAll()
                 last = nil

--- a/Aztec/Classes/Public/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Public/Formatters/TextListFormatter.swift
@@ -16,18 +16,25 @@ class TextListFormatter
     /// - Returns: An NSRange representing the change to the attributed string.
     ///
     func toggleList(ofStyle style: TextList.Style, inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
-        let ranges = string.paragraphRanges(spanningRange: range)
-        guard let firstRange = ranges.first else {
+        // Load Paragraph Ranges
+        let paragraphRanges = string.paragraphRanges(spanningRange: range)
+        guard paragraphRanges.isEmpty == false else {
             return nil
         }
 
-        // Existing list: Same kind? > remove. Else > Apply!
-        if let list = string.textListAttribute(atIndex: firstRange.location) where list.style == style {
-            return removeList(fromString: string, atRanges: ranges)
+        // 1st Paragraph: No List >> Apply
+        guard let listRange = string.rangeOfTextList(atIndex: paragraphRanges[0].location) else {
+            return applyList(ofStyle: style, toString: string, atRanges: paragraphRanges)
         }
 
-        // Check the paragraphs at each range. If any have the opposite list style remove that range.
-        return applyList(ofStyle: style, toString: string, atRanges: ranges)
+        // 1st Paragraph: Matching List Style >> Remove
+        guard let listAttribute = string.textListAttribute(spanningRange: listRange) where listAttribute.style != style else {
+            return removeList(fromString: string, atRanges: paragraphRanges)
+        }
+
+        // 1st Paragraph: Non Matching Style >> Update!
+        let listParagraphs = string.paragraphRanges(spanningRange: listRange)
+        return applyList(ofStyle: style, toString: string, atRanges: listParagraphs)
     }
 }
 

--- a/Aztec/Classes/Public/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Public/Formatters/TextListFormatter.swift
@@ -83,9 +83,6 @@ private extension TextListFormatter
         // Done Editing!
         string.endEditing()
 
-        // Update the (SUCCEDING) List, if needed.
-        updateList(inString: string, succeedingRange: listRange)
-
         return listRange
     }
 

--- a/Aztec/Classes/Public/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Public/Formatters/TextListFormatter.swift
@@ -24,7 +24,7 @@ class TextListFormatter
 
         // 1st Paragraph: No List >> Apply, skipping paragraphs that currently contain TextLists
         guard let listRange = string.rangeOfTextList(atIndex: paragraphRanges[0].location) else {
-            let filtered = filterListRanges(paragraphRanges, fromString: string, notMatchingStyle: style)
+            let filtered = string.filterListRanges(paragraphRanges, notMatchingStyle: style)
             return applyLists(ofStyle: style, toString: string, atNonContiguousRanges: filtered)
         }
 
@@ -44,7 +44,12 @@ class TextListFormatter
 //
 private extension TextListFormatter
 {
+    /// Applies a TextList attribute to the specified non contiguous ranges.
     ///
+    /// - Parameters:
+    ///     - style: Style of TextList to be applied.
+    ///     - string: Target String.
+    ///     - ranges: Segments of the receiver string to be transformed into lists.
     ///
     func applyLists(ofStyle style: TextList.Style, toString string: NSMutableAttributedString, atNonContiguousRanges ranges: [NSRange]) -> NSRange? {
         guard let first = ranges.first else {
@@ -177,17 +182,11 @@ private extension TextListFormatter
 //
 private extension TextListFormatter
 {
+    /// This helper groups contiguous ranges, and returns each group inside their own array.
     ///
+    /// - Parameter ranges: The ranges to be grouped.
     ///
-    func filterListRanges(ranges: [NSRange], fromString string: NSAttributedString, notMatchingStyle style: TextList.Style) -> [NSRange] {
-        return ranges.filter { range in
-            let list = string.textListAttribute(spanningRange: range)
-            return list == nil || list?.style == style
-        }
-    }
-
-
-    ///
+    /// - Returns: An array of grouped contiguous-ranges.
     ///
     func groupContiguousRanges(ranges: [NSRange]) -> [[NSRange]] {
         var grouped = [[NSRange]]()

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -72,7 +72,170 @@ class TextListFormatterTests: XCTestCase
         }
     }
 
+
     // Scenario 1:
+    // ===========
+    //
+    //  Line 1:       [Text]            1 [Text]
+    //  Line 2:       [Text]              [Text]
+    //  Line 3:       [Text]    > > >     [Text]
+    //  Line 4:       [Text]              [Text]
+    //  Line 5:       [Text]              [Text]
+    //
+    // Toggling "Ordered List" on Line 1 should switch its style, and maintain lines 2-5 unaffected.
+    //
+    func testApplyingOrderedListOnFirstParagraphAppliesOrderedList() {
+        let string = NSMutableAttributedString(string: plainText)
+
+        let formatter = TextListFormatter()
+        formatter.toggleList(ofStyle: .Ordered, inString: string, atRange: NSRange(location: 0, length: 1))
+
+        let ranges = paragraphRanges(inString: string)
+        let lists = textListAttributes(inString: string, atRanges: ranges)
+        let items = textListItemAttributes(inString: string, atRanges: ranges)
+
+        XCTAssert(lists.count == 1)
+        XCTAssert(items.count == 1)
+
+        XCTAssert(lists[0].style == .Ordered)
+        XCTAssert(items[0].number == 1)
+    }
+
+
+    // Scenario 2: (Mark I)
+    // ===========
+    //
+    //  Line 1:     1 [Text]              [Text]
+    //  Line 2:       [Text]              [Text]
+    //  Line 3:       [Text]    > > >     [Text]
+    //  Line 4:       [Text]              [Text]
+    //  Line 5:       [Text]              [Text]
+    //
+    // Toggling "Ordered List" on Line 1 should nuke it's list, and keep lines 2-5 unaffected.
+    //
+    func testRemovingOrderedListOnFirstParagraphEffectivelyNukesAnyLists() {
+        let string = NSMutableAttributedString(string: plainText)
+
+        let formatter = TextListFormatter()
+
+        // Toggle the 1st line as an Ordered List
+        formatter.toggleList(ofStyle: .Ordered, inString: string, atRange: NSRange(location: 0, length: 1))
+
+        // And... undo?
+        formatter.toggleList(ofStyle: .Ordered, inString: string, atRange: NSRange(location: 0, length: 1))
+
+        let ranges = paragraphRanges(inString: string)
+        let lists = textListAttributes(inString: string, atRanges: ranges)
+        let items = textListItemAttributes(inString: string, atRanges: ranges)
+
+        XCTAssert(lists.count == 0)
+        XCTAssert(items.count == 0)
+    }
+
+
+    // Scenario 2: (Mark II)
+    // ===========
+    //
+    //  Line 1:     1 [Text]              [Text]
+    //  Line 2:     2 [Text]            1 [Text]
+    //  Line 3:     3 [Text]    > > >   2 [Text]
+    //  Line 4:     4 [Text]            3 [Text]
+    //  Line 5:     5 [Text]            4 [Text]
+    //
+    // Toggling "Ordered List" on Line 1 should update Line 2-5.
+    //
+    func testToggleOrderedListOnFirstOrderedListItemUpdatesTheRemainingItemNumbers() {
+        let list = listWithOrderedStyle
+        let ranges = paragraphRanges(inString: list)
+
+        let formatter = TextListFormatter()
+        formatter.toggleList(ofStyle: .Ordered, inString: list, atRange: ranges[0])
+
+        let lists = textListAttributes(inString: list, atRanges: ranges)
+        let items = textListItemAttributes(inString: list, atRanges: ranges)
+
+        XCTAssert(lists.count == 4)
+        XCTAssert(items.count == 4)
+
+        for list in lists {
+            XCTAssert(list.style == .Ordered)
+        }
+
+        for (index, item) in items.enumerate() {
+            XCTAssert(item.number == index + 1)
+        }
+    }
+
+
+    // Scenario 2: (Mark III)
+    // ===========
+    //
+    //  Line 1:     - [Text]            - [Text]
+    //  Line 2:     1 [Text]            1 [Text]
+    //  Line 3:     - [Text]    > > >     [Text]
+    //  Line 4:     1 [Text]            1 [Text]
+    //  Line 5:     - [Text]            - [Text]
+    //
+    // Toggling "Unordered List" on Line 3 should nuke it's list, and keep lines 2-5 unaffected.
+    //
+    func testToggleListUpdatesStyleWhenThereWasAnExistingListWithDifferentStyles() {
+        let list = listWithAlternatedStyle
+        let ranges = paragraphRanges(inString: list)
+
+        // Toggle Ordered List on the first line
+        let formatter = TextListFormatter()
+        formatter.toggleList(ofStyle: .Unordered, inString: list, atRange: ranges[2])
+
+        //
+        let lists = textListAttributes(inString: list, atRanges: ranges)
+        let listItems = textListItemAttributes(inString: list, atRanges: ranges)
+
+        XCTAssert(lists.count == 4)
+        XCTAssert(listItems.count == 4)
+
+        XCTAssert(lists[0].style == .Unordered)
+        XCTAssert(lists[1].style == .Ordered)
+        XCTAssert(lists[2].style == .Ordered)
+        XCTAssert(lists[3].style == .Unordered)
+
+        XCTAssert(listItems[1].number == 1)
+        XCTAssert(listItems[2].number == 1)
+    }
+
+
+    // Scenario 3: (Mark I)
+    // ===========
+    //
+    //  Line 1:     1 [Text]            - [Text]
+    //  Line 2:     2 [Text]            - [Text]
+    //  Line 3:     3 [Text]    > > >   - [Text]
+    //  Line 4:     4 [Text]            - [Text]
+    //  Line 5:     5 [Text]            - [Text]
+    //
+    // Toggling "Unordered List" on Line 1 should switch everything to an Unordered List
+    //
+    func testToggleUnorderedListOnFirstOrderedListItemUpdatesTheRemainingItemNumbers() {
+        let list = listWithOrderedStyle
+        let ranges = paragraphRanges(inString: list)
+
+        let formatter = TextListFormatter()
+        formatter.toggleList(ofStyle: .Unordered, inString: list, atRange: ranges[0])
+
+        let lists = textListAttributes(inString: list, atRanges: ranges)
+        let items = textListItemAttributes(inString: list, atRanges: ranges)
+
+        XCTAssert(lists.count == 5)
+        XCTAssert(items.count == 5)
+
+        XCTAssert(lists[0].style == .Unordered)
+        XCTAssert(lists[1].style == .Unordered)
+        XCTAssert(lists[2].style == .Unordered)
+        XCTAssert(lists[3].style == .Unordered)
+        XCTAssert(lists[4].style == .Unordered)
+    }
+
+
+    // Scenario 3: (Mark II)
     // ===========
     //
     //  Line 1:     - [Text]            1 [Text]
@@ -81,7 +244,8 @@ class TextListFormatterTests: XCTestCase
     //  Line 4:     1 [Text]            1 [Text]
     //  Line 5:     - [Text]            - [Text]
     //
-    // Toggling "Ordered List" on Line 1 should switch its style, and update Line 2's value.
+    // Toggling "Ordered List" on Line 1 should switch the list to which it's associated. Since the
+    // "lower" neighbor has the same type, they should be merged.
     //
     func testToggleOrderedListOnFirstItem() {
         let list = listWithAlternatedStyle
@@ -110,42 +274,7 @@ class TextListFormatterTests: XCTestCase
     }
 
 
-    // Scenario 2:
-    // ===========
-    //
-    //  Line 1:     - [Text]            - [Text]
-    //  Line 2:     1 [Text]            1 [Text]
-    //  Line 3:     - [Text]    > > >     [Text]
-    //  Line 4:     1 [Text]            1 [Text]
-    //  Line 5:     - [Text]            - [Text]
-    //
-    // Toggling "Unordered List" on Line 3 should leave Lines 1, 2, 4, 5 untouched.
-    //
-    func testToggleListUpdatesStyleWhenThereWasAnExistingListWithDifferentStyles() {
-        let list = listWithAlternatedStyle
-        let ranges = paragraphRanges(inString: list)
-
-        // Toggle Ordered List on the first line
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .Unordered, inString: list, atRange: ranges[2])
-
-        //
-        let lists = textListAttributes(inString: list, atRanges: ranges)
-        let listItems = textListItemAttributes(inString: list, atRanges: ranges)
-
-        XCTAssert(lists.count == 4)
-        XCTAssert(listItems.count == 4)
-
-        XCTAssert(lists[0].style == .Unordered)
-        XCTAssert(lists[1].style == .Ordered)
-        XCTAssert(lists[2].style == .Ordered)
-        XCTAssert(lists[3].style == .Unordered)
-
-        XCTAssert(listItems[1].number == 1)
-        XCTAssert(listItems[2].number == 1)
-    }
-
-    // Scenario 3:
+    // Scenario 3: (Mark III)
     // ===========
     //
     //  Line 1:     - [Text]            1 [Text]
@@ -179,98 +308,8 @@ class TextListFormatterTests: XCTestCase
         XCTAssert(items[3].number == 1)
     }
 
+
     // Scenario 4:
-    // ===========
-    //
-    //  Line 1:     - [Text]              [Text]
-    //  Line 2:     1 [Text]              [Text]
-    //  Line 3:     - [Text]    > > >     [Text]
-    //  Line 4:     1 [Text]              [Text]
-    //  Line 5:     - [Text]              [Text]
-    //
-    // Toggling "Unordered List" on Lines 1-5 should remove all of the lists / items.
-    //
-    func testToggleListRemovesAllOfTheListAttributesWhenTheFirstRangeStyleMatchesTheSuppliedStyle() {
-        let list = listWithAlternatedStyle
-
-        // Toggle Ordered List on the full string's range
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .Unordered, inString: list, atRange: list.rangeOfEntireString)
-
-        // Verify we got a single big orderedList
-        let ranges = paragraphRanges(inString: list)
-        let lists = textListAttributes(inString: list, atRanges: ranges)
-        let items = textListItemAttributes(inString: list, atRanges: ranges)
-
-        XCTAssert(lists.count == 0)
-        XCTAssert(items.count == 0)
-    }
-
-    // Scenario 5:
-    // ===========
-    //
-    //  Line 1:     1 [Text]              [Text]
-    //  Line 2:     2 [Text]            1 [Text]
-    //  Line 3:     3 [Text]    > > >   2 [Text]
-    //  Line 4:     4 [Text]            3 [Text]
-    //  Line 5:     5 [Text]            4 [Text]
-    //
-    // Toggling "Ordered List" on Line 1 should update Line 2-5.
-    //
-    func testToggleOrderedListOnFirstOrderedListItemUpdatesTheRemainingItemNumbers() {
-        let list = listWithOrderedStyle
-        let ranges = paragraphRanges(inString: list)
-
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .Ordered, inString: list, atRange: ranges[0])
-
-        let lists = textListAttributes(inString: list, atRanges: ranges)
-        let items = textListItemAttributes(inString: list, atRanges: ranges)
-
-        XCTAssert(lists.count == 4)
-        XCTAssert(items.count == 4)
-
-        for list in lists {
-            XCTAssert(list.style == .Ordered)
-        }
-
-        for (index, item) in items.enumerate() {
-            XCTAssert(item.number == index + 1)
-        }
-    }
-
-    // Scenario 6:
-    // ===========
-    //
-    //  Line 1:     1 [Text]            - [Text]
-    //  Line 2:     2 [Text]            - [Text]
-    //  Line 3:     3 [Text]    > > >   - [Text]
-    //  Line 4:     4 [Text]            - [Text]
-    //  Line 5:     5 [Text]            - [Text]
-    //
-    // Toggling "Unordered List" on Line 1 should switch everything to an Unordered List
-    //
-    func testToggleUnorderedListOnFirstOrderedListItemUpdatesTheRemainingItemNumbers() {
-        let list = listWithOrderedStyle
-        let ranges = paragraphRanges(inString: list)
-
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .Unordered, inString: list, atRange: ranges[0])
-
-        let lists = textListAttributes(inString: list, atRanges: ranges)
-        let items = textListItemAttributes(inString: list, atRanges: ranges)
-
-        XCTAssert(lists.count == 5)
-        XCTAssert(items.count == 5)
-
-        XCTAssert(lists[0].style == .Unordered)
-        XCTAssert(lists[1].style == .Unordered)
-        XCTAssert(lists[2].style == .Unordered)
-        XCTAssert(lists[3].style == .Unordered)
-        XCTAssert(lists[4].style == .Unordered)
-    }
-
-    // Scenario 7:
     // ===========
     //
     //  Line 1:       [Text]            1 [Text]
@@ -305,6 +344,80 @@ class TextListFormatterTests: XCTestCase
 
             XCTAssert(item?.number == index + 1)
         }
+    }
+
+
+    // Scenario 5:
+    // ===========
+    //
+    //  Line 1:       [Text]            1 [Text]
+    //  Line 2:       [Text]            2 [Text]
+    //  Line 3:     - [Text]    > > >   - [Text]
+    //  Line 4:       [Text]            1 [Text]
+    //  Line 5:       [Text]            2 [Text]
+    //
+    // Toggling "Ordered List" on lines 1-5 creates new lists on the selected paragraphs, skipping any lists
+    // that don't match the new style.
+    //
+    func testToggleOrderedListOnParagraphIntersectingUnorderedListEffectivelySkipsListWithNoMatchingStyle() {
+        let string = NSMutableAttributedString(string: plainText)
+        let formatter = TextListFormatter()
+
+        // Line 3 > Unordered List
+        let ranges = paragraphRanges(inString: string)
+        formatter.toggleList(ofStyle: .Unordered, inString: string, atRange: ranges[2])
+
+        // Entire Text > Ordered List
+        formatter.toggleList(ofStyle: .Ordered, inString: string, atRange: string.rangeOfEntireString)
+
+        // Verify
+        let paragraphs = paragraphRanges(inString: string)
+        for (index, range) in paragraphs.enumerate() {
+            guard let list = string.textListAttribute(spanningRange: range),
+                let item = string.textListItemAttribute(spanningRange: range) else
+            {
+                XCTFail()
+                return
+            }
+
+            if index == 2 {
+                XCTAssert(list.style == .Unordered)
+                continue
+            }
+
+            // Map (0, 1) > (1, 2) and (3, 4) > (1, 2)
+            let number = (index < 2) ? (index + 1) : (index - 2)
+            XCTAssert(item.number == number)
+            XCTAssert(list.style == .Ordered)
+        }
+    }
+
+
+    // Scenario 6:
+    // ===========
+    //
+    //  Line 1:     - [Text]              [Text]
+    //  Line 2:     1 [Text]              [Text]
+    //  Line 3:     - [Text]    > > >     [Text]
+    //  Line 4:     1 [Text]              [Text]
+    //  Line 5:     - [Text]              [Text]
+    //
+    // Toggling "Unordered List" on Lines 1-5 should remove all of the lists / items.
+    //
+    func testToggleListRemovesAllOfTheListAttributesWhenTheFirstParagraphListStyleMatchesTheSuppliedStyle() {
+        let list = listWithAlternatedStyle
+
+        // Toggle Ordered List on the full string's range
+        let formatter = TextListFormatter()
+        formatter.toggleList(ofStyle: .Unordered, inString: list, atRange: list.rangeOfEntireString)
+
+        // Verify we got a single big orderedList
+        let ranges = paragraphRanges(inString: list)
+        let lists = textListAttributes(inString: list, atRanges: ranges)
+        let items = textListItemAttributes(inString: list, atRanges: ranges)
+
+        XCTAssert(lists.count == 0)
+        XCTAssert(items.count == 0)
     }
 }
 

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -318,7 +318,7 @@ class TextListFormatterTests: XCTestCase
     //  Line 4:     2 [Text]            4 [Text]
     //  Line 5:     3 [Text]            5 [Text]
     //
-    // Toggling "Ordered List" on lines 1-5 converts the text into a single list.
+    // Toggling "Ordered List" on lines 1-2 converts the text into a single list.
     //
     func testToggleOrderedListOnPlainTextFollowedByOrderedListUpdatesAllOfTheItemNumbers() {
         let string = NSMutableAttributedString(string: plainText)

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -419,6 +419,44 @@ class TextListFormatterTests: XCTestCase
         XCTAssert(lists.count == 0)
         XCTAssert(items.count == 0)
     }
+
+
+    // Scenario 7:
+    // ===========
+    //
+    //  Line 1:     - [Text]            1 [Text]
+    //  Line 2:     - [Text]            2 [Text]
+    //  Line 3:       [Text]    > > >     [Text]
+    //  Line 4:       [Text]              [Text]
+    //  Line 5:       [Text]              [Text]
+    //
+    // Toggling "Ordered List" on Lines 1-5 should only switch Lines 1 and 2 to Ordered Lists.
+    //
+    func testToggleListChangesTheStyleWhenTheFirstTwoSelectedParagraphsHaveDifferentStyles() {
+        let list = NSMutableAttributedString(string: plainText)
+        let plainRanges = plainTextParagraphRanges
+        let formatter = TextListFormatter()
+
+        // First TWO lines: Unordered List
+        let length = plainRanges[1].location + plainRanges[1].length
+        let range = NSRange(location: 0, length: length)
+
+        formatter.toggleList(ofStyle: .Unordered, inString: list, atRange: range)
+
+        // Verify
+        XCTAssert(textListItemAttributes(inString: list, atRanges: paragraphRanges(inString: list)).count == 2)
+
+        // Toggle
+        formatter.toggleList(ofStyle: .Ordered, inString: list, atRange: list.rangeOfEntireString)
+
+        // Verify
+        let items = textListItemAttributes(inString: list, atRanges: paragraphRanges(inString: list))
+
+        XCTAssert(items.count == 2)
+
+        XCTAssert(items[0].number == 1)
+        XCTAssert(items[1].number == 2)
+    }
 }
 
 

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -283,6 +283,43 @@ class TextListFormatterTests: XCTestCase
         XCTAssert(items[3].number == 3)
         XCTAssert(items[4].number == 4)
     }
+
+    // Scenario 7:
+    // ===========
+    //
+    //  Line 1:       [Text]            1 [Text]
+    //  Line 2:       [Text]            2 [Text]
+    //  Line 3:     1 [Text]    > > >   3 [Text]
+    //  Line 4:     2 [Text]            4 [Text]
+    //  Line 5:     3 [Text]            5 [Text]
+    //
+    // Toggling "Ordered List" on lines 1-5 converts the text into a single list.
+    //
+    func testToggleOrderedListOnPlainTextFollowedByOrderedListUpdatesAllOfTheItemNumbers() {
+        let string = NSMutableAttributedString(string: plainText)
+        let formatter = TextListFormatter()
+
+        // Apply the Ordered List style to the last three paragraphs
+        for (index, range) in paragraphRanges(inString: string).enumerate() where index >= 2 {
+            formatter.toggleList(ofStyle: .Ordered, inString: string, atRange: range)
+        }
+
+        // Now... toggle an Ordered List on the full text
+        formatter.toggleList(ofStyle: .Ordered, inString: string, atRange: string.rangeOfEntireString)
+
+        // Verify
+        let paragraphs = paragraphRanges(inString: string)
+        for (index, range) in paragraphs.enumerate() {
+            let list = string.textListAttribute(spanningRange: range)
+            XCTAssertNotNil(list)
+            XCTAssert(list!.style == .Ordered)
+
+            let item = string.textListItemAttribute(spanningRange: range)
+            XCTAssertNotNil(item)
+
+            XCTAssert(item?.number == index + 1)
+        }
+    }
 }
 
 


### PR DESCRIPTION
### Details:
I've updated Issue #34's **Toolbar** section's Test Cases. You can find Unit Tests for each one of those in `TextListFormatterTests` (each test has a comment referencing to the matching scenario).

Lists should, effectively, behave the same was as Calypso does, as of now.

### Testing:
- Verify that the Unit Tests run correctly
- Manually verify Scenarios 1-7
- Be happy!!

Needs Review: @diegoreymendez 
cc @aerych 
