### PR TITLE
Fixes a crashing bug when inserting images.

### DIFF
--- a/Aztec/Classes/Public/TextKit/TextStorage.swift
+++ b/Aztec/Classes/Public/TextKit/TextStorage.swift
@@ -416,6 +416,7 @@ public class TextStorage: NSTextStorage {
     ///
     func insertImage(sourceURL url: NSURL, atPosition position:Int, placeHolderImage: UIImage) -> String {
         let attachment = TextAttachment()
+        attachment.imageProvider = self
         attachment.url = url
         attachment.image = placeHolderImage
 


### PR DESCRIPTION
Inserting images was broken as a result of [this PR](https://github.com/wordpress-mobile/WordPress-Aztec-iOS/pull/123).

This PR fixes it.

**How to test:**

Just insert an image and make sure the app doesn't crash.