### PR TITLE
Make list markers non selectable

### DIFF
--- a/Aztec/Classes/Public/TextKit/TextView.swift
+++ b/Aztec/Classes/Public/TextKit/TextView.swift
@@ -74,6 +74,8 @@ public class TextView: UITextView {
         previousSelectedRange = selectedRange
     }
 
+    //MARK: - Selection Logic
+
     public override var selectedTextRange: UITextRange? {
         didSet {
             selectionChanged()

--- a/Aztec/Classes/Public/TextKit/TextView.swift
+++ b/Aztec/Classes/Public/TextKit/TextView.swift
@@ -96,10 +96,8 @@ public class TextView: UITextView {
 
         let newRange = rangeIgnoringListMarkersWhile(movingForward: movingForward, growing: growing)
 
-        if selectedRange.location != newRange.location || selectedRange.length != newRange.length {
-            previousSelectedRange = newRange
-            selectedRange = newRange
-        }
+        previousSelectedRange = newRange
+        selectedRange = newRange
     }
 
     private func rangeIgnoringListMarkersWhile(movingForward movingForward:Bool, growing:Bool) -> NSRange {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -270,6 +270,7 @@ extension EditorDemoController : UITextViewDelegate
 {
     func textViewDidChangeSelection(textView: UITextView) {
         updateFormatBar()
+        richTextView.selectionChanged()
     }
 }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -269,8 +269,7 @@ class EditorDemoController: UIViewController {
 extension EditorDemoController : UITextViewDelegate
 {
     func textViewDidChangeSelection(textView: UITextView) {
-        updateFormatBar()
-        richTextView.selectionChanged()
+        updateFormatBar()        
     }
 }
 


### PR DESCRIPTION
Refs #34 

Implements the cursor requirements:

> If the current selection intersects a list marker, adjust the selection so it does not intersect the marker. Move the cursor forward or backward depending on the previous cursor location.

Note: It still allows deletion of part of the markers that will be tackled next.