### PR TITLE
Fix cursor caret on end of text

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -152,8 +152,10 @@ public class TextView: UITextView {
         let glyphIndex = layoutManager.glyphIndexForCharacterAtIndex(characterIndex)
         let usedLineFragment = layoutManager.lineFragmentUsedRectForGlyphAtIndex(glyphIndex, effectiveRange: nil)
         var caretRect = super.caretRectForPosition(position)
-        caretRect.origin.y = usedLineFragment.origin.y + textContainerInset.top
-        caretRect.size.height = usedLineFragment.size.height
+        if !CGRectIsEmpty(usedLineFragment) {
+            caretRect.origin.y = usedLineFragment.origin.y + textContainerInset.top
+            caretRect.size.height = usedLineFragment.size.height
+        }
         return caretRect
     }
 


### PR DESCRIPTION
The cursor caret was disappearing when it was moved to the end of the text on a text view. This PR fix this issue.

How to text:
- Open the demo app
- Select the editor demo
- Move the cursor to the end of the text
- Check if the cursor is visible and on the right position.