### PR TITLE
Update of markers when editing text

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -295,8 +295,10 @@ extension NSAttributedString
 
         // Nuke the Marker
         var markerRange = NSRange()
-        if let _ = clean.attribute(TextListItemMarker.attributeName, atIndex: 0, longestEffectiveRange: &markerRange, inRange: range) {
-            clean.replaceCharactersInRange(markerRange, withString: String())
+        if clean.length > 0 {
+            if let _ = clean.attribute(TextListItemMarker.attributeName, atIndex: 0, longestEffectiveRange: &markerRange, inRange: range) {
+                clean.replaceCharactersInRange(markerRange, withString: String())
+            }
         }
 
         return clean

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -37,6 +37,35 @@ class TextListFormatter
         let listParagraphs = string.paragraphRanges(spanningRange: listRange)
         return applyList(ofStyle: style, toString: string, atRanges: listParagraphs)
     }
+
+    func refreshList(inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
+
+        var styleOptional: TextList.Style?
+        // Load Paragraph Ranges
+
+        let paragraphRanges = string.paragraphRanges(spanningRange: range)
+        guard let firstParagraphRange = paragraphRanges.first else {
+            if let paragraphRange = string.rangeOfLine(atIndex: range.location) {
+                return removeList(fromString: string, atRanges: [paragraphRange])
+            }
+            return nil
+        }
+        if let textList = string.attribute(TextList.attributeName, atIndex: firstParagraphRange.location, effectiveRange: nil) as? TextList {
+            styleOptional = textList.style
+        }
+
+        guard let style = styleOptional else {
+            return removeList(fromString: string, atRanges: [firstParagraphRange])
+        }
+
+
+        guard let listRange = string.rangeOfTextList(atIndex: firstParagraphRange.location) else {
+            return nil
+        }
+
+        let listParagraphs = string.paragraphRanges(spanningRange: listRange)
+        return applyList(ofStyle: style, toString: string, atRanges: listParagraphs)
+    }
 }
 
 

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -66,6 +66,10 @@ class TextListFormatter
         let listParagraphs = string.paragraphRanges(spanningRange: listRange)
         return applyList(ofStyle: style, toString: string, atRanges: listParagraphs)
     }
+
+    func removeList(inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
+        return removeList(fromString: string, atRanges: [range])
+    }
 }
 
 

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -38,7 +38,14 @@ class TextListFormatter
         return applyList(ofStyle: style, toString: string, atRanges: listParagraphs)
     }
 
-    func refreshList(inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
+    /// Updates the list attributes on the specified range
+    ///
+    /// - Parameters:
+    ///   - string: the string to update
+    ///   - range: the range where to check for list
+    /// - Returns: the total range that was affected by the method
+    ///
+    func updatesList(inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
 
         var styleOptional: TextList.Style?
         // Load Paragraph Ranges
@@ -67,6 +74,15 @@ class TextListFormatter
         return applyList(ofStyle: style, toString: string, atRanges: listParagraphs)
     }
 
+
+    /// Removes any list attributes on the provided string that exist on the specified range.
+    /// This method also updates any surrounding lists of the specified range
+    ///
+    /// - Parameters:
+    ///   - string: the string to update
+    ///   - range: the range to where remove the list attributes
+    /// - Returns: the total range that was affected by this method
+    ///
     func removeList(inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
         return removeList(fromString: string, atRanges: [range])
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -157,11 +157,11 @@ public class TextStorage: NSTextStorage {
         // TODO: Evaluate moving this process to `Aztec.TextView.paste()`.
         //      I didn't do it with the initial implementation as it was non-trivial. (DRM)
         //
-        let attrString = preprocessAttachments(forAttributedString: attrString)
-        
+        let processedString = NSMutableAttributedString(attributedString:preprocessAttachments(forAttributedString: attrString))
+
         beginEditing()
-        textStore.replaceCharactersInRange(range, withAttributedString: attrString)
-        
+
+        textStore.replaceCharactersInRange(range, withAttributedString: processedString)
         edited([.EditedAttributes, .EditedCharacters], range: range, changeInLength: attrString.string.characters.count - range.length)
 
         dom.replaceCharacters(inRange: range, withAttributedString: attrString, inheritStyle: false)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -88,13 +88,13 @@ public class TextView: UITextView {
     public override func cut(sender: AnyObject?) {
         let originalRange = selectedRange
         super.cut(sender)
-        refreshListsIfOnePrecedes(range: originalRange)
+        refreshListsOnlyIfListExists(atRange: originalRange)
     }
 
     public override func paste(sender: AnyObject?) {
         let originalRange = selectedRange
         super.paste(sender)
-        refreshListsIfOnePrecedes(range: originalRange)
+        refreshListsOnlyIfListExists(atRange: originalRange)
     }
 
     // MARK: - Intersect keyboard operations
@@ -491,7 +491,7 @@ public class TextView: UITextView {
     private func refreshListIfNewLinesOn(text text:String, range:NSRange) {
         // check if are doing two empy list items in a row
         if text != "\n" {
-            refreshListsIfOnePrecedes(range: range)
+            refreshListsOnlyIfListExists(atRange: range)
             return
         }
         var afterRange = range
@@ -510,7 +510,7 @@ public class TextView: UITextView {
         }
 
         if !(isBegginingOfListItem && afterString == "\n") {
-            refreshListsIfOnePrecedes(range: range)
+            refreshListsOnlyIfListExists(atRange: range)
         } else {
             var lineMovedRange = afterRange
             lineMovedRange.location += 1
@@ -523,7 +523,8 @@ public class TextView: UITextView {
     /// Refresh the list attributes in the specified range but only if a list is already present on the line
     ///
     /// - Parameter range: the range to where to update the list attributes
-    private func refreshListsIfOnePrecedes(range range:NSRange) {
+    ///
+    private func refreshListsOnlyIfListExists(atRange range:NSRange) {
 
         if storage.attribute(TextListItem.attributeName,
                              atIndex:max(range.location-1,0),

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -104,6 +104,7 @@ public class TextView: UITextView {
             var newSelectionRange = selectedRange
             newSelectionRange.location = selectedRange.location - expandedRange.length
             selectedRange = newSelectionRange
+            refreshList(range:selectedRange)
         }
     }
 
@@ -453,6 +454,16 @@ public class TextView: UITextView {
         selectedRange = NSRange(location:selectionStartRange.location, length: selectionEndRange.location - selectionStartRange.location)
     }
 
+    public func refreshList(range range: NSRange) {
+        let appliedRange = rangeForTextList(range)
+        let formatter = TextListFormatter()
+
+        markCurrentSelection()
+
+        formatter.refreshList(inString: storage, atRange: range)
+
+        restoreMarkedSelection()
+    }
     /// Adds or removes a ordered list style from the specified range.
     ///
     /// - Parameter range: The NSRange to edit.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -456,8 +456,7 @@ public class TextView: UITextView {
         selectedRange = NSRange(location:selectionStartRange.location, length: selectionEndRange.location - selectionStartRange.location)
     }
 
-    public func refreshList(range range: NSRange) {
-        let appliedRange = rangeForTextList(range)
+    public func refreshList(range range: NSRange) {        
         let formatter = TextListFormatter()
 
         markCurrentSelection()


### PR DESCRIPTION
Refs #146 and #147 

This PR implement support for updating/removing lists while editing text inside the list, specially when deleting around markers and entering new lines.

How to test:

- Start the editor demo
- Create a new ordered list spreading across several lines
- Try the following:
  - Break lines in middle and see if the markers are update correctly
  - Try Delete marker using the delete key or cutting a selection and see if markers are updated correctly
 - Enter two new empty lines in the end of the list and see if the list is interrupted.
  - Enter two new empty new lines in a go in the middle of a list and see if the list is split int half

