### PR TITLE
Adds node descriptors.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		F11904A51D9D857500BFF9A1 /* TextNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */; };
 		F1288BAF1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1288BAD1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift */; };
 		F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1288BAE1DD0B1EF00E67ABC /* HTMLToAttributedString.swift */; };
+		F15C9B881DD58D8B00833C39 /* ElementNodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15C9B871DD58D8B00833C39 /* ElementNodeDescriptor.swift */; };
 		F18733C81DA09737005AEB80 /* NSRangeComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */; };
 		F1CF272A1DBA8CDB0001C61D /* DocumentObjectModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF27291DBA8CDB0001C61D /* DocumentObjectModel.swift */; };
 		F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */; };
@@ -162,6 +163,7 @@
 		F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextNodeTests.swift; sourceTree = "<group>"; };
 		F1288BAD1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLNodeToNSAttributedString.swift; sourceTree = "<group>"; };
 		F1288BAE1DD0B1EF00E67ABC /* HTMLToAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLToAttributedString.swift; sourceTree = "<group>"; };
+		F15C9B871DD58D8B00833C39 /* ElementNodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ElementNodeDescriptor.swift; path = Descriptors/ElementNodeDescriptor.swift; sourceTree = "<group>"; };
 		F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRange+Helpers.swift"; sourceTree = "<group>"; };
 		F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSRangeComparisonTests.swift; path = Extensions/NSRangeComparisonTests.swift; sourceTree = "<group>"; };
 		F1CF27291DBA8CDB0001C61D /* DocumentObjectModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentObjectModel.swift; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				599F25081D8BC9A1002871D6 /* Converters */,
+				F15C9B891DD58D8F00833C39 /* Descriptors */,
 				599F25131D8BC9A1002871D6 /* DOM */,
 				599F251A1D8BC9A1002871D6 /* Libxml2.swift */,
 				F1CF27291DBA8CDB0001C61D /* DocumentObjectModel.swift */,
@@ -470,6 +473,14 @@
 			path = Converters;
 			sourceTree = "<group>";
 		};
+		F15C9B891DD58D8F00833C39 /* Descriptors */ = {
+			isa = PBXGroup;
+			children = (
+				F15C9B871DD58D8B00833C39 /* ElementNodeDescriptor.swift */,
+			);
+			name = Descriptors;
+			sourceTree = "<group>";
+		};
 		F18733C61DA0970E005AEB80 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -613,6 +624,7 @@
 				599F25541D8BC9A1002871D6 /* TextView.swift in Sources */,
 				E1C163A51DB6056B00E66A83 /* BlockquoteFormatter.swift in Sources */,
 				599F254A1D8BC9A1002871D6 /* NSAttributedString+Attachments.swift in Sources */,
+				F15C9B881DD58D8B00833C39 /* ElementNodeDescriptor.swift in Sources */,
 				599F254C1D8BC9A1002871D6 /* UITextView+Helpers.swift in Sources */,
 				599F25451D8BC9A1002871D6 /* Libxml2.swift in Sources */,
 				B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */,

--- a/Aztec/Classes/Libxml2/DOM/EditableNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/EditableNode.swift
@@ -21,5 +21,7 @@ protocol EditableNode {
     ///
     func split(atLocation location: Int)
     func split(forRange range: NSRange)
-    func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Libxml2.Attribute], equivalentElementNames: [String])
+    //func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Libxml2.Attribute], equivalentElementNames: [String])
+    
+    func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor)
 }

--- a/Aztec/Classes/Libxml2/DOM/EditableNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/EditableNode.swift
@@ -20,6 +20,6 @@ protocol EditableNode {
     ///     - location: the text location to split the node at.
     ///
     func split(atLocation location: Int)
-    func split(forRange range: NSRange)    
+    func split(forRange range: NSRange)
     func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor)
 }

--- a/Aztec/Classes/Libxml2/DOM/EditableNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/EditableNode.swift
@@ -20,8 +20,6 @@ protocol EditableNode {
     ///     - location: the text location to split the node at.
     ///
     func split(atLocation location: Int)
-    func split(forRange range: NSRange)
-    //func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Libxml2.Attribute], equivalentElementNames: [String])
-    
+    func split(forRange range: NSRange)    
     func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor)
 }

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1386,7 +1386,7 @@ extension Libxml2 {
                     return
                 }
             }
-            
+
             forceWrapChildren(intersectingRange: targetRange, inElement: elementDescriptor)
         }
 

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -42,8 +42,8 @@ extension Libxml2 {
             }
         }
         
-        convenience init(descriptor: ElementNodeDescriptor) {
-            self.init(name: descriptor.name, attributes: [], children: [])
+        convenience init(descriptor: ElementNodeDescriptor, children: [Node] = []) {
+            self.init(name: descriptor.name, attributes: [], children: children)
         }
 
         override func customMirror() -> Mirror {
@@ -1537,9 +1537,7 @@ extension Libxml2 {
                 return result
             } else {
                 //REMOVE: let newNode = ElementNode(name: nodeName, attributes: attributes, children: childrenToWrap)
-                let newNode = ElementNode(descriptor: elementDescriptor)
-                
-                newNode.children = childrenToWrap
+                let newNode = ElementNode(descriptor: elementDescriptor, children: childrenToWrap)
                 
                 children.insert(newNode, atIndex: firstNodeIndex)
                 newNode.parent = self

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -915,10 +915,8 @@ extension Libxml2 {
                     let lastSwap = parent == self
                     
                     if let element = node as? ElementNode {
-                        //REMOVE: element.wrap(children: element.children, inNodeNamed: parent.name, withAttributes: parent.attributes, equivalentElementNames: [])
                         
                         let parentDescriptor = ElementNodeDescriptor(name: parent.name, attributes: parent.attributes)
-
                         element.wrap(children: element.children, inElement: parentDescriptor)
                     }
                     
@@ -990,10 +988,8 @@ extension Libxml2 {
                     let lastSwap = parent == self
                     
                     if let element = node as? ElementNode {
-                        //REMOVE: element.wrap(children: element.children, inNodeNamed: parent.name, withAttributes: parent.attributes, equivalentElementNames: [])
                         
                         let parentDescriptor = ElementNodeDescriptor(name: parent.name, attributes: parent.attributes)
-                        
                         element.wrap(children: element.children, inElement: parentDescriptor)
                     }
                     
@@ -1220,10 +1216,8 @@ extension Libxml2 {
         ///
         /// - Parameters:
         ///     - targetRange: the range that must be wrapped.
-        ///     - nodeName: the name of the node to wrap the range in.
-        ///     - attributes: the attributes the wrapping node will have when created.
+        ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        //REMOVE: func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) {
         func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor) {
 
             let mustFindLowestBlockLevelElements = !elementDescriptor.isBlockLevel()
@@ -1236,19 +1230,9 @@ extension Libxml2 {
                     let element = elementAndIntersection.element
                     let intersection = elementAndIntersection.intersection
                     
-                    /*
-                     //REMOVE:
-                    element.forceWrapChildren(
-                        intersectingRange: intersection,
-                        inNodeNamed: nodeName,
-                        withAttributes: attributes,
-                        equivalentElementNames: equivalentElementNames)
-                    */
-                    
                     element.forceWrapChildren(intersectingRange: intersection, inElement: elementDescriptor)
                 }
             } else {
-                //REMOVE: forceWrap(range: targetRange, inNodeNamed: nodeName, withAttributes: attributes, equivalentElementNames: equivalentElementNames)
                 forceWrap(range: targetRange, inElement: elementDescriptor)
             }
         }
@@ -1286,15 +1270,11 @@ extension Libxml2 {
 
                 if range.location > 0 {
                     let preRange = NSRange(location: 0, length: range.location)
-
-                    //REMOVE: wrap(range: preRange, inNodeNamed: name, withAttributes: attributes, equivalentElementNames: [])
                     wrap(range: preRange, inElement: elementDescriptor)
                 }
 
                 if rangeEndLocation < myLength {
                     let postRange = NSRange(location: rangeEndLocation, length: myLength - rangeEndLocation)
-
-                    //REMOVE: wrap(range: postRange, inNodeNamed: name, withAttributes: attributes, equivalentElementNames: [])
                     wrap(range: postRange, inElement: elementDescriptor)
                 }
 
@@ -1371,27 +1351,15 @@ extension Libxml2 {
             
             unwrap(range: targetRange, fromElementsNamed: elementNamesToRemove)
 
-            let mustFindLowestBlockLevelElements = !elementDescriptor.isBlockLevel() //REMOVE: !StandardElementType.isBlockLevelNodeName(nodeName)
+            let mustFindLowestBlockLevelElements = !elementDescriptor.isBlockLevel()
 
             if mustFindLowestBlockLevelElements {
                 let elementsAndIntersections = lowestBlockLevelElements(intersectingRange: targetRange)
 
                 for (element, intersection) in elementsAndIntersections {
-
-                    /*
-                     //REMOVE:
-                    element.forceWrapChildren(
-                        intersectingRange: intersection,
-                        inNodeNamed: nodeName,
-                        withAttributes: attributes,
-                        equivalentElementNames: equivalentElementNames)
-                    */
-                    
                     element.forceWrapChildren(intersectingRange: intersection, inElement: elementDescriptor)
                 }
             } else {
-                //forceWrapChildren(intersectingRange: targetRange, inNodeNamed: nodeName, withAttributes: attributes, equivalentElementNames: equivalentElementNames)
-                
                 forceWrapChildren(intersectingRange: targetRange, inElement: elementDescriptor)
             }
         }
@@ -1405,27 +1373,22 @@ extension Libxml2 {
         ///
         /// - Parameters:
         ///     - targetRange: the range that must be wrapped.
-        ///     - nodeName: the name of the node to wrap the range in.
-        ///     - attributes: the attributes the wrapping node will have when created.
+        ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        //func forceWrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) {
         func forceWrap(range targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
             
             if NSEqualRanges(targetRange, range()) {
                 
                 let receiverIsBlockLevel = isBlockLevelElement()
-                let newNodeIsBlockLevel = elementDescriptor.isBlockLevel() //REMOVE: StandardElementType(rawValue: nodeName)?.isBlockLevelNodeName() ?? false
+                let newNodeIsBlockLevel = elementDescriptor.isBlockLevel()
                 
                 let canWrapReceiverInNewNode = newNodeIsBlockLevel || !receiverIsBlockLevel
                 
                 if canWrapReceiverInNewNode {
-                    //REMOVE: wrap(inNodeNamed: nodeName, withAttributes: attributes)
                     wrap(inElement: elementDescriptor)
                     return
                 }
             }
-
-            //REMOVE: forceWrapChildren(intersectingRange: targetRange, inNodeNamed: nodeName, withAttributes: attributes, equivalentElementNames: equivalentElementNames)
             
             forceWrapChildren(intersectingRange: targetRange, inElement: elementDescriptor)
         }
@@ -1439,10 +1402,8 @@ extension Libxml2 {
         ///
         /// - Parameters:
         ///     - targetRange: the range that must be wrapped.
-        ///     - nodeName: the name of the node to wrap the range in.
-        ///     - attributes: the attributes the wrapping node will have when created.
+        ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        //REMOVE: private func forceWrapChildren(intersectingRange targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) {
         private func forceWrapChildren(intersectingRange targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
                 
             let childNodesAndRanges = childNodes(intersectingRange: targetRange)
@@ -1468,7 +1429,6 @@ extension Libxml2 {
                 return child
             })
             
-            //REMOVE: wrap(children: children, inNodeNamed: nodeName, withAttributes: attributes, equivalentElementNames: equivalentElementNames)
             wrap(children: children, inElement: elementDescriptor)
         }
 
@@ -1477,12 +1437,10 @@ extension Libxml2 {
         ///
         /// - Parameters:
         ///     - children: the children nodes to wrap in a new node.
-        ///     - nodeName: the name of the new node.
-        ///     - attributes: the attributes for the newly created node.
+        ///     - elementDescriptor: the descriptor for the element to wrap the children in.
         ///
         /// - Returns: the newly created `ElementNode`.
         ///
-        //REMOVE: func wrap(children newChildren: [Node], inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) -> ElementNode {
         func wrap(children newChildren: [Node], inElement elementDescriptor: ElementNodeDescriptor) -> ElementNode {
 
             guard newChildren.count > 0 else {
@@ -1536,7 +1494,6 @@ extension Libxml2 {
             if let result = result {
                 return result
             } else {
-                //REMOVE: let newNode = ElementNode(name: nodeName, attributes: attributes, children: childrenToWrap)
                 let newNode = ElementNode(descriptor: elementDescriptor, children: childrenToWrap)
                 
                 children.insert(newNode, atIndex: firstNodeIndex)

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1333,11 +1333,8 @@ extension Libxml2 {
         ///
         /// - Parameters:
         ///     - targetRange: the range that must be wrapped.
-        ///     - nodeName: the name of the node to wrap the range in.
-        ///     - attributes: the attributes the wrapping node will have when created.
-        ///     - equivalentElementNames: equivalent node names to check for collisions.
+        ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        //func wrapChildren(intersectingRange targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) {
         func wrapChildren(intersectingRange targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
             
             // Before wrapping a range in a new node, we make sure equivalent element nodes wrapping that range are

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -43,7 +43,7 @@ extension Libxml2 {
         }
         
         convenience init(descriptor: ElementNodeDescriptor, children: [Node] = []) {
-            self.init(name: descriptor.name, attributes: [], children: children)
+            self.init(name: descriptor.name, attributes: descriptor.attributes, children: children)
         }
 
         override func customMirror() -> Mirror {
@@ -1123,25 +1123,31 @@ extension Libxml2 {
 
         /// Replace characters in targetRange by a node with the name in nodeName and attributes
         ///
-        /// - parameter targetRange: the range to replace
-        /// - parameter nodeName:    the name of the new node to create
-        /// - parameter attributes:  the attributes for the new node.
-        func replaceCharacters(inRange targetRange: NSRange, withNodeNamed nodeName: String, withAttributes attributes:[Attribute]) {
+        /// - parameter targetRange:        The range to replace
+        /// - parameter elementDescriptor:  The descriptor for the element to replace the text with.
+        ///
+        func replaceCharacters(inRange targetRange: NSRange, withElement elementDescriptor: ElementNodeDescriptor) {
+            
             guard let textNode = lowestTextNodeWrapping(targetRange) else {
                 return
             }
+            
             let absoluteLocation = textNode.absoluteLocation()
-            let localRange = NSRange(location:targetRange.location - absoluteLocation, length: targetRange.length)
+            let localRange = NSRange(location: targetRange.location - absoluteLocation, length: targetRange.length)
             textNode.split(forRange: localRange)
-            let imgNode = ElementNode(name: nodeName, attributes: attributes, children: [])
+            
+            let imgNode = ElementNode(descriptor: elementDescriptor)
+            
             guard let index = textNode.parent?.children.indexOf(textNode) else {
                 assertionFailure("Can't remove a node that's not a child.")
                 return
             }
+            
             guard let textNodeParent = textNode.parent else {
                 return
             }
-            textNodeParent.insert(imgNode, at:index)
+            
+            textNodeParent.insert(imgNode, at: index)
             textNodeParent.remove(textNode)
         }
 

--- a/Aztec/Classes/Libxml2/DOM/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Node.swift
@@ -122,7 +122,7 @@ extension Libxml2 {
         /// the parent and child node references.
         ///
         /// - Parameters:
-        ///     - elementDescriptor: the descriptor for the element to wrap the range in.
+        ///     - elementDescriptor: the descriptor for the element to wrap the receiver in.
         ///
         /// - Returns: the newly created element.
         ///

--- a/Aztec/Classes/Libxml2/DOM/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Node.swift
@@ -122,18 +122,15 @@ extension Libxml2 {
         /// the parent and child node references.
         ///
         /// - Parameters:
-        ///     - nodeName: the new node name.
-        ///     - attributes: the new node attributes.
+        ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
         /// - Returns: the newly created element.
         ///
-        //REMOVE: func wrap(inNodeNamed nodeName: String, withAttributes attributes: [Attribute] = []) -> ElementNode {
         func wrap(inElement elementDescriptor: ElementNodeDescriptor) -> ElementNode {
 
             let originalParent = parent
             let originalIndex = parent?.children.indexOf(self)
 
-            //REMOVE: let newNode = ElementNode(name: descriptor.name, attributes: descriptor.attributes, children: [self])
             let newNode = ElementNode(descriptor: elementDescriptor)
 
             if let parent = originalParent {

--- a/Aztec/Classes/Libxml2/DOM/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Node.swift
@@ -127,12 +127,14 @@ extension Libxml2 {
         ///
         /// - Returns: the newly created element.
         ///
-        func wrap(inNodeNamed nodeName: String, withAttributes attributes: [Attribute] = []) -> ElementNode {
+        //REMOVE: func wrap(inNodeNamed nodeName: String, withAttributes attributes: [Attribute] = []) -> ElementNode {
+        func wrap(inElement elementDescriptor: ElementNodeDescriptor) -> ElementNode {
 
             let originalParent = parent
             let originalIndex = parent?.children.indexOf(self)
 
-            let newNode = ElementNode(name: nodeName, attributes: attributes, children: [self])
+            //REMOVE: let newNode = ElementNode(name: descriptor.name, attributes: descriptor.attributes, children: [self])
+            let newNode = ElementNode(descriptor: elementDescriptor)
 
             if let parent = originalParent {
                 guard let index = originalIndex else {

--- a/Aztec/Classes/Libxml2/DOM/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/TextNode.swift
@@ -116,20 +116,16 @@ extension Libxml2 {
         ///
         /// - Parameters:
         ///     - targetRange: the range that must be wrapped.
-        ///     - nodeName: the name of the node to wrap the range in.
-        ///     - attributes: the attributes the wrapping node will have when created.
+        ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        //REMOVE: func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) {
         func wrap(range targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
 
             guard !NSEqualRanges(targetRange, NSRange(location: 0, length: length())) else {
-                //wrap(inNodeNamed: nodeName, withAttributes: attributes)
                 wrap(inElement: elementDescriptor)
                 return
             }
 
             split(forRange: targetRange)
-            //wrap(inNodeNamed: nodeName, withAttributes: attributes)
             wrap(inElement: elementDescriptor)
         }
         

--- a/Aztec/Classes/Libxml2/DOM/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/TextNode.swift
@@ -119,15 +119,18 @@ extension Libxml2 {
         ///     - nodeName: the name of the node to wrap the range in.
         ///     - attributes: the attributes the wrapping node will have when created.
         ///
-        func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) {
+        //REMOVE: func wrap(range targetRange: NSRange, inNodeNamed nodeName: String, withAttributes attributes: [Attribute], equivalentElementNames: [String]) {
+        func wrap(range targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
 
             guard !NSEqualRanges(targetRange, NSRange(location: 0, length: length())) else {
-                wrap(inNodeNamed: nodeName, withAttributes: attributes)
+                //wrap(inNodeNamed: nodeName, withAttributes: attributes)
+                wrap(inElement: elementDescriptor)
                 return
             }
 
             split(forRange: targetRange)
-            wrap(inNodeNamed: nodeName, withAttributes: attributes)
+            //wrap(inNodeNamed: nodeName, withAttributes: attributes)
+            wrap(inElement: elementDescriptor)
         }
         
         // MARK: - LeadNode

--- a/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
+++ b/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
@@ -19,8 +19,8 @@ extension Libxml2 {
             self.matchingNames = matchingNames
         }
 
-        convenience init(elementType: StandardElementType, attributes: [Attribute] = [], matchingNames: [String] = []) {
-            self.init(name: elementType.rawValue, attributes: attributes, matchingNames: matchingNames)
+        convenience init(elementType: StandardElementType, attributes: [Attribute] = []) {
+            self.init(name: elementType.rawValue, attributes: attributes, matchingNames: elementType.equivalentNames)
         }
         
         // MARK: - CustomReflectable

--- a/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
+++ b/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
@@ -7,7 +7,7 @@ extension Libxml2 {
     /// - Searching for a matching element node, or
     /// - Creating it.
     ///
-    class ElementNodeDescriptor {
+    class ElementNodeDescriptor: CustomReflectable {
         
         let name: String
         let attributes: [Attribute]
@@ -22,6 +22,14 @@ extension Libxml2 {
         convenience init(elementType: StandardElementType, attributes: [Attribute] = [], matchingNames: [String] = []) {
             self.init(name: elementType.rawValue, attributes: attributes, matchingNames: matchingNames)
         }
+        
+        // MARK: - CustomReflectable
+        
+        func customMirror() -> Mirror {
+            return Mirror(self, children: ["name": name, "attributes": attributes, "matchingNames": matchingNames])
+        }
+        
+        // MARK: - Introspection
         
         func isBlockLevel() -> Bool {
             return StandardElementType.isBlockLevelNodeName(name)

--- a/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
+++ b/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
@@ -13,7 +13,7 @@ extension Libxml2 {
         let attributes: [Attribute]
         let matchingNames: [String]
         
-        init(name: String, attributes: [Attribute], matchingNames: [String] = []) {
+        init(name: String, attributes: [Attribute] = [], matchingNames: [String] = []) {
             self.name = name
             self.attributes = attributes
             self.matchingNames = matchingNames

--- a/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
+++ b/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
@@ -18,6 +18,10 @@ extension Libxml2 {
             self.attributes = attributes
             self.matchingNames = matchingNames
         }
+
+        convenience init(elementType: StandardElementType, attributes: [Attribute] = [], matchingNames: [String] = []) {
+            self.init(name: elementType.rawValue, attributes: attributes, matchingNames: matchingNames)
+        }
         
         func isBlockLevel() -> Bool {
             return StandardElementType.isBlockLevelNodeName(name)

--- a/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
+++ b/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+extension Libxml2 {
+    
+    /// This class describes an element node for the purpose of either:
+    ///
+    /// - Searching for a matching element node, or
+    /// - Creating it.
+    ///
+    class ElementNodeDescriptor {
+        
+        let name: String
+        let attributes: [Attribute]
+        let matchingNames: [String]
+        
+        init(name: String, attributes: [Attribute], matchingNames: [String] = []) {
+            self.name = name
+            self.attributes = attributes
+            self.matchingNames = matchingNames
+        }
+        
+        func isBlockLevel() -> Bool {
+            return StandardElementType.isBlockLevelNodeName(name)
+        }
+    }
+}

--- a/Aztec/Classes/Libxml2/DocumentObjectModel.swift
+++ b/Aztec/Classes/Libxml2/DocumentObjectModel.swift
@@ -337,11 +337,20 @@ extension Libxml2 {
         // MARK: - Links
         
         private func setLinkInDOM(range: NSRange, url: NSURL) {
+            /*
+            //REMOVE:
             rootNode.wrapChildren(
                 intersectingRange: range,
                 inNodeNamed: StandardElementType.a.rawValue,
                 withAttributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString!)],
                 equivalentElementNames: StandardElementType.a.equivalentNames)
+ */
+            
+            let elementDescriptor = ElementNodeDescriptor(name: StandardElementType.a.rawValue,
+                                                          attributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString!)],
+                                                          matchingNames: StandardElementType.a.equivalentNames)
+            
+            rootNode.wrapChildren(intersectingRange: range, inElement: elementDescriptor)
         }
         
         // MARK: Font Styles
@@ -446,11 +455,18 @@ extension Libxml2 {
         ///     - range: the range to apply the bold style to.
         ///
         private func applyElement(elementName: String, spanning range: NSRange, equivalentElementNames: [String]) {
-            rootNode.wrapChildren(
+            /*
+             //REMOVE:
+             rootNode.wrapChildren(
                 intersectingRange: range,
                 inNodeNamed: elementName,
                 withAttributes: [],
                 equivalentElementNames: equivalentElementNames)
+            */
+            
+            let elementDescriptor = ElementNodeDescriptor(name: elementName, attributes: [], matchingNames: equivalentElementNames)
+            
+            rootNode.wrapChildren(intersectingRange: range, inElement: elementDescriptor)
         }
         
         // MARK: - Candidates for removal

--- a/Aztec/Classes/Libxml2/DocumentObjectModel.swift
+++ b/Aztec/Classes/Libxml2/DocumentObjectModel.swift
@@ -329,9 +329,10 @@ extension Libxml2 {
         
         private func setImageURLStringInDOM(imageURLString: String, forRange range: NSRange) {
             
-            rootNode.replaceCharacters(inRange: range,
-                                       withNodeNamed: StandardElementType.img.rawValue,
-                                       withAttributes: [Libxml2.StringAttribute(name:"src", value: imageURLString)])
+            let elementDescriptor = ElementNodeDescriptor(elementType: .img,
+                                                          attributes: [Libxml2.StringAttribute(name:"src", value: imageURLString)])
+            
+            rootNode.replaceCharacters(inRange: range, withElement: elementDescriptor)
         }
         
         // MARK: - Links

--- a/Aztec/Classes/Libxml2/DocumentObjectModel.swift
+++ b/Aztec/Classes/Libxml2/DocumentObjectModel.swift
@@ -337,14 +337,6 @@ extension Libxml2 {
         // MARK: - Links
         
         private func setLinkInDOM(range: NSRange, url: NSURL) {
-            /*
-            //REMOVE:
-            rootNode.wrapChildren(
-                intersectingRange: range,
-                inNodeNamed: StandardElementType.a.rawValue,
-                withAttributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString!)],
-                equivalentElementNames: StandardElementType.a.equivalentNames)
- */
             
             let elementDescriptor = ElementNodeDescriptor(name: StandardElementType.a.rawValue,
                                                           attributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString!)],
@@ -455,17 +447,8 @@ extension Libxml2 {
         ///     - range: the range to apply the bold style to.
         ///
         private func applyElement(elementName: String, spanning range: NSRange, equivalentElementNames: [String]) {
-            /*
-             //REMOVE:
-             rootNode.wrapChildren(
-                intersectingRange: range,
-                inNodeNamed: elementName,
-                withAttributes: [],
-                equivalentElementNames: equivalentElementNames)
-            */
             
             let elementDescriptor = ElementNodeDescriptor(name: elementName, attributes: [], matchingNames: equivalentElementNames)
-            
             rootNode.wrapChildren(intersectingRange: range, inElement: elementDescriptor)
         }
         

--- a/Aztec/Classes/Libxml2/DocumentObjectModel.swift
+++ b/Aztec/Classes/Libxml2/DocumentObjectModel.swift
@@ -339,9 +339,8 @@ extension Libxml2 {
         
         private func setLinkInDOM(range: NSRange, url: NSURL) {
             
-            let elementDescriptor = ElementNodeDescriptor(name: StandardElementType.a.rawValue,
-                                                          attributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString!)],
-                                                          matchingNames: StandardElementType.a.equivalentNames)
+            let elementDescriptor = ElementNodeDescriptor(elementType: .a,
+                                                          attributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString!)])
             
             rootNode.wrapChildren(intersectingRange: range, inElement: elementDescriptor)
         }
@@ -398,10 +397,7 @@ extension Libxml2 {
         ///     - range: the range to apply the style to.
         ///
         private func applyBold(spanning range: NSRange) {
-            applyElement(
-                StandardElementType.b.rawValue,
-                spanning: range,
-                equivalentElementNames: StandardElementType.b.equivalentNames)
+            applyElement(.b, spanning: range)
         }
         
         /// Applies italic to the specified range.
@@ -410,10 +406,7 @@ extension Libxml2 {
         ///     - range: the range to apply the style to.
         ///
         private func applyItalic(spanning range: NSRange) {
-            applyElement(
-                StandardElementType.i.rawValue,
-                spanning: range,
-                equivalentElementNames: StandardElementType.i.equivalentNames)
+            applyElement(.i, spanning: range)
         }
         
         /// Applies strikethrough to the specified range.
@@ -422,10 +415,7 @@ extension Libxml2 {
         ///     - range: the range to apply the style to.
         ///
         private func applyStrikethrough(spanning range: NSRange) {
-            applyElement(
-                StandardElementType.s.rawValue,
-                spanning: range,
-                equivalentElementNames:  StandardElementType.s.equivalentNames)
+            applyElement(.s, spanning: range)
         }
         
         /// Applies underline to the specified range.
@@ -434,18 +424,32 @@ extension Libxml2 {
         ///     - range: the range to apply the style to.
         ///
         private func applyUnderline(spanning range: NSRange) {
-            applyElement(
-                StandardElementType.u.rawValue,
-                spanning: range,
-                equivalentElementNames:  StandardElementType.u.equivalentNames)
+            applyElement(.u, spanning: range)
         }
         
         // MARK: - Styles to HTML elements
         
-        /// Applies an HTML element to the specified range.
+        /// Applies a standard HTML element to the specified range.
+        ///
+        /// Whenever applying a standard element type, use this method.
         ///
         /// - Parameters:
+        ///     - elementType: the standard element type to apply.
         ///     - range: the range to apply the bold style to.
+        ///
+        private func applyElement(elementType: StandardElementType, spanning range: NSRange) {
+            applyElement(elementType.rawValue, spanning: range, equivalentElementNames: elementType.equivalentNames)
+        }
+        
+        /// Applies an HTML element to the specified range.
+        ///
+        /// Use this method directly only when applying custom element types (non standard).
+        ///
+        /// - Parameters:
+        ///     - elementName: the element name to apply
+        ///     - range: the range to apply the bold style to.
+        ///     - equivalentElementNames: equivalent element names to look for before applying
+        ///             the specified one.
         ///
         private func applyElement(elementName: String, spanning range: NSRange, equivalentElementNames: [String]) {
             

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -658,7 +658,8 @@ class ElementNodeTests: XCTestCase {
         
         let wrapRange = NSRange(location: 0, length: text1.characters.count)
         
-        paragraph.forceWrap(range: wrapRange, inElement: ElementNodeDescriptor(name: "b"))
+        let boldElementDescriptor = ElementNodeDescriptor(elementType: .b)
+        paragraph.forceWrap(range: wrapRange, inElement: boldElementDescriptor)
         
         XCTAssertEqual(paragraph.children.count, 2)
         
@@ -692,7 +693,8 @@ class ElementNodeTests: XCTestCase {
         
         let wrapRange = NSRange(location: 0, length: fullText.characters.count)
         
-        paragraph.forceWrap(range: wrapRange, inElement: ElementNodeDescriptor(name: "b"))
+        let boldElementDescriptor = ElementNodeDescriptor(elementType: .b)
+        paragraph.forceWrap(range: wrapRange, inElement: boldElementDescriptor)
         
         XCTAssertEqual(paragraph.children.count, 1)
         
@@ -721,8 +723,9 @@ class ElementNodeTests: XCTestCase {
         let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode, textNode2])
 
         let wrapRange = NSRange(location: text1.characters.count, length: text2.characters.count)
-
-        paragraph.forceWrap(range: wrapRange, inElement: ElementNodeDescriptor(name: "b"))
+        
+        let boldElementDescriptor = ElementNodeDescriptor(elementType: .b)
+        paragraph.forceWrap(range: wrapRange, inElement: boldElementDescriptor)
 
         XCTAssertEqual(paragraph.children.count, 1)
 
@@ -888,7 +891,8 @@ class ElementNodeTests: XCTestCase {
         
         let range = NSRange(location: 0, length: 11)
         
-        divNode.wrapChildren(intersectingRange: range, inElement: ElementNodeDescriptor(name: "b"))
+        let boldElementDescriptor = ElementNodeDescriptor(elementType: .b)
+        divNode.wrapChildren(intersectingRange: range, inElement: boldElementDescriptor)
         
         XCTAssertEqual(divNode.children.count, 1)
         

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -7,6 +7,7 @@ class ElementNodeTests: XCTestCase {
     typealias ElementNode = Libxml2.ElementNode
     typealias ElementNodeDescriptor = Libxml2.ElementNodeDescriptor
     typealias RootNode = Libxml2.RootNode
+    typealias StandardElementType = Libxml2.StandardElementType
     typealias StringAttribute = Libxml2.StringAttribute
     typealias TextNode = Libxml2.TextNode
 
@@ -748,7 +749,7 @@ class ElementNodeTests: XCTestCase {
     ///
     func testWrapChildrenInNewBNode1() {
 
-        let boldNodeName = "b"
+        let boldElementType = StandardElementType.b
         let range = NSRange(location: 0, length: 6)
 
         let textPart1 = "Hello "
@@ -760,13 +761,13 @@ class ElementNodeTests: XCTestCase {
         let em = ElementNode(name: "em", attributes: [], children: [textNode1])
         let div = ElementNode(name: "div", attributes: [], children: [em, textNode2])
 
-        div.wrapChildren(intersectingRange: range, inElement: ElementNodeDescriptor(name: boldNodeName))
+        div.wrapChildren(intersectingRange: range, inElement: ElementNodeDescriptor(elementType: boldElementType))
 
         XCTAssertEqual(div.children.count, 2)
         XCTAssertEqual(div.children[1], textNode2)
         
         guard let newBoldNode = div.children[0] as? ElementNode
-            where newBoldNode.name == "b" else {
+            where newBoldNode.name == boldElementType.rawValue else {
                 XCTFail("Expected a bold node here.")
                 return
         }
@@ -1410,10 +1411,13 @@ class ElementNodeTests: XCTestCase {
         let paragraph = ElementNode(name: "p", attributes: [], children: [paragraphText])
 
         let range = NSRange(location: startText.characters.count, length: middleText.characters.count)
-        let imgNodeName = "img"
         let imgSrc = "https://httpbin.org/image/jpeg"
 
-        paragraph.replaceCharacters(inRange: range, withNodeNamed: imgNodeName, withAttributes:[Libxml2.StringAttribute(name:"src", value: imgSrc)])
+        let elementType = StandardElementType.img
+        let imgNodeName = elementType.rawValue
+        let elementDescriptor = ElementNodeDescriptor(elementType: elementType, attributes: [Libxml2.StringAttribute(name:"src", value: imgSrc)])
+        
+        paragraph.replaceCharacters(inRange: range, withElement: elementDescriptor)
 
         XCTAssertEqual(paragraph.children.count, 3)
 

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -5,6 +5,7 @@ class ElementNodeTests: XCTestCase {
 
     typealias Attribute = Libxml2.Attribute
     typealias ElementNode = Libxml2.ElementNode
+    typealias ElementNodeDescriptor = Libxml2.ElementNodeDescriptor
     typealias RootNode = Libxml2.RootNode
     typealias StringAttribute = Libxml2.StringAttribute
     typealias TextNode = Libxml2.TextNode
@@ -657,7 +658,7 @@ class ElementNodeTests: XCTestCase {
         
         let wrapRange = NSRange(location: 0, length: text1.characters.count)
         
-        paragraph.forceWrap(range: wrapRange, inNodeNamed: "b", withAttributes: [], equivalentElementNames: [])
+        paragraph.forceWrap(range: wrapRange, inElement: ElementNodeDescriptor(name: "b"))
         
         XCTAssertEqual(paragraph.children.count, 2)
         
@@ -691,7 +692,7 @@ class ElementNodeTests: XCTestCase {
         
         let wrapRange = NSRange(location: 0, length: fullText.characters.count)
         
-        paragraph.forceWrap(range: wrapRange, inNodeNamed: "b", withAttributes: [], equivalentElementNames: [])
+        paragraph.forceWrap(range: wrapRange, inElement: ElementNodeDescriptor(name: "b"))
         
         XCTAssertEqual(paragraph.children.count, 1)
         
@@ -721,7 +722,7 @@ class ElementNodeTests: XCTestCase {
 
         let wrapRange = NSRange(location: text1.characters.count, length: text2.characters.count)
 
-        paragraph.forceWrap(range: wrapRange, inNodeNamed: "b", withAttributes: [], equivalentElementNames: [])
+        paragraph.forceWrap(range: wrapRange, inElement: ElementNodeDescriptor(name: "b"))
 
         XCTAssertEqual(paragraph.children.count, 1)
 
@@ -756,7 +757,7 @@ class ElementNodeTests: XCTestCase {
         let em = ElementNode(name: "em", attributes: [], children: [textNode1])
         let div = ElementNode(name: "div", attributes: [], children: [em, textNode2])
 
-        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [], equivalentElementNames: [])
+        div.wrapChildren(intersectingRange: range, inElement: ElementNodeDescriptor(name: boldNodeName))
 
         XCTAssertEqual(div.children.count, 2)
         XCTAssertEqual(div.children[1], textNode2)
@@ -801,7 +802,7 @@ class ElementNodeTests: XCTestCase {
         let underline = ElementNode(name: "u", attributes: [], children: [textNode2])
         let div = ElementNode(name: "div", attributes: [], children: [em, underline])
 
-        div.wrapChildren(intersectingRange: div.range(), inNodeNamed: boldNodeName, withAttributes: [], equivalentElementNames: [])
+        div.wrapChildren(intersectingRange: div.range(), inElement: ElementNodeDescriptor(name: boldNodeName))
 
         XCTAssertEqual(div.children.count, 1)
 
@@ -846,7 +847,7 @@ class ElementNodeTests: XCTestCase {
 
         let range = NSRange(location: 2, length: 8)
 
-        div.wrapChildren(intersectingRange: range, inNodeNamed: boldNodeName, withAttributes: [], equivalentElementNames: [])
+        div.wrapChildren(intersectingRange: range, inElement: ElementNodeDescriptor(name: boldNodeName))
 
         XCTAssertEqual(div.children.count, 3)
 
@@ -887,7 +888,7 @@ class ElementNodeTests: XCTestCase {
         
         let range = NSRange(location: 0, length: 11)
         
-        divNode.wrapChildren(intersectingRange: range, inNodeNamed: "b", withAttributes: [], equivalentElementNames: [])
+        divNode.wrapChildren(intersectingRange: range, inElement: ElementNodeDescriptor(name: "b"))
         
         XCTAssertEqual(divNode.children.count, 1)
         


### PR DESCRIPTION
This is part of my cleanup work before I start implementing undo/redo.  The reason I'm tackling this is that I want to make sure our methods don't pass an enormous amount of parameters around.

This PR introduces the concept of node descriptors to simplify `ElementNode` searching and creation, while simplifying our calls.

**Known issues:**

While implementing this feature I noticed an issue with styles not being properly removed from the HTML source anymore.  This issue however was not introduced by this PR, so I opened a separate issue to fix it.

I uploaded a video of the problem [here](https://cloudup.com/cngEAn9uNba).

**How to test:**

Test the editor normally.  Try to come up with edge scenarios and make sure nothing breaks.
Run the unit tests.