### PR TITLE
Fixes attributes removal.

### DIFF
--- a/Aztec/Classes/Libxml2/DocumentObjectModel.swift
+++ b/Aztec/Classes/Libxml2/DocumentObjectModel.swift
@@ -97,8 +97,16 @@ extension Libxml2 {
         }
         
         func setAttributes(attrs: [String : AnyObject]?, range: NSRange) {
+            guard let attrs = attrs else {
+                return
+            }
+            
+            setAttributes(attrs, range: range)
+        }
+        
+        func setAttributes(attrs: [String : AnyObject], range: NSRange) {
             dispatch_async(domQueue) { [weak self] in
-                guard let strongSelf = self, attrs = attrs else {
+                guard let strongSelf = self else {
                     return
                 }
                 
@@ -351,7 +359,7 @@ extension Libxml2 {
         /// - Parameters:
         ///     - range: the range to remove the style from.
         ///
-        private func removeBold(spanning range: NSRange) {
+        func removeBold(spanning range: NSRange) {
             dispatch_async(domQueue) {
                 self.rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.b.equivalentNames)
             }
@@ -362,7 +370,7 @@ extension Libxml2 {
         /// - Parameters:
         ///     - range: the range to remove the style from.
         ///
-        private func removeItalic(spanning range: NSRange) {
+        func removeItalic(spanning range: NSRange) {
             dispatch_async(domQueue) {
                 self.rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.i.equivalentNames)
             }
@@ -373,7 +381,7 @@ extension Libxml2 {
         /// - Parameters:
         ///     - range: the range to remove the style from.
         ///
-        private func removeStrikethrough(spanning range: NSRange) {
+        func removeStrikethrough(spanning range: NSRange) {
             dispatch_async(domQueue) {
                 self.rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.s.equivalentNames)
             }
@@ -384,7 +392,7 @@ extension Libxml2 {
         /// - Parameters:
         ///     - range: the range to remove the style from.
         ///
-        private func removeUnderline(spanning range: NSRange) {
+        func removeUnderline(spanning range: NSRange) {
             dispatch_async(domQueue) {
                 self.rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.u.equivalentNames)
             }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -170,7 +170,6 @@ public class TextStorage: NSTextStorage {
     }
     
     override public func removeAttribute(name: String, range: NSRange) {
-        // dom.removeAttribute(name, range: range)
         super.removeAttribute(name, range: range)
     }
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -168,6 +168,11 @@ public class TextStorage: NSTextStorage {
         
         endEditing()
     }
+    
+    override public func removeAttribute(name: String, range: NSRange) {
+        // dom.removeAttribute(name, range: range)
+        super.removeAttribute(name, range: range)
+    }
 
     override public func setAttributes(attrs: [String : AnyObject]?, range: NSRange) {
         beginEditing()
@@ -184,6 +189,13 @@ public class TextStorage: NSTextStorage {
     func toggleBold(range: NSRange) {
 
         let enable = !fontTrait(.TraitBold, spansRange: range)
+        
+        /// We should be calculating what attributes to remove in `TextStorage.setAttributes()`
+        /// but since that may take a while to implement, we need this workaround until it's ready.
+        ///
+        if !enable {
+            dom.removeBold(spanning: range)
+        }
 
         modifyTrait(.TraitBold, range: range, enable: enable)
     }
@@ -192,6 +204,13 @@ public class TextStorage: NSTextStorage {
 
         let enable = !fontTrait(.TraitItalic, spansRange: range)
 
+        /// We should be calculating what attributes to remove in `TextStorage.setAttributes()`
+        /// but since that may take a while to implement, we need this workaround until it's ready.
+        ///
+        if !enable {
+            dom.removeItalic(spanning: range)
+        }
+        
         modifyTrait(.TraitItalic, range: range, enable: enable)
     }
 
@@ -302,12 +321,28 @@ public class TextStorage: NSTextStorage {
     private func toggleAttribute(attributeName: String, value: AnyObject, range: NSRange) {
 
         var effectiveRange = NSRange()
-        let enable = attribute(attributeName, atIndex: range.location, effectiveRange: &effectiveRange) == nil
-            || !NSEqualRanges(range, effectiveRange)
-
+        let enable: Bool
+        
+        if attribute(attributeName, atIndex: range.location, effectiveRange: &effectiveRange) != nil {
+            let intersection = range.intersect(withRange: effectiveRange)
+            
+            if let intersection = intersection {
+                enable = !NSEqualRanges(range, intersection)
+            } else {
+                enable = true
+            }
+        } else {
+            enable = true
+        }
+        
         if enable {
             addAttribute(attributeName, value: value, range: range)
         } else {
+            /// We should be calculating what attributes to remove in `TextStorage.setAttributes()`
+            /// but since that may take a while to implement, we need this workaround until it's ready.
+            ///
+            dom.removeUnderline(spanning: range)
+            
             removeAttribute(attributeName, range: range)
         }
     }


### PR DESCRIPTION
Fixes the removal of attributes, which was broken in [this PR](https://github.com/wordpress-mobile/WordPress-Aztec-iOS/pull/130).

**How to test:**

1. Add and remove styles.
2. Make sure to user partial selection ranges in the tests too.
3. Switch to HTML mode and make sure styles are removing accordingly.