### PR TITLE
Improved parsing of html

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -119,30 +119,11 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             content.appendAttributedString(childContent)
         }
 
-        return implicitRepresentation(forNode: node, childContent: content, attributes:childAttributes)
-    }
-
-    private func implicitRepresentation(forNode node: ElementNode, childContent: NSAttributedString, attributes:[String:AnyObject]) -> NSAttributedString {
-
-        guard let nodeType = StandardElementType(rawValue:node.name.lowercaseString) else {
-            return childContent
+        if let nodeType = node.standardName {
+            return nodeType.implicitRepresentation(forContent: content, attributes: childAttributes)
         }
 
-        let resultString = NSMutableAttributedString(attributedString: childContent)
-        switch nodeType {
-        case .img:
-            return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)), attributes: attributes)
-        case .br:
-            return NSAttributedString(string: "\n", attributes: attributes)
-        case .p:
-            resultString.appendAttributedString(NSAttributedString(string: "\n", attributes: attributes))
-        case .li:
-            resultString.appendAttributedString(NSAttributedString(string: "\n", attributes: attributes))
-        default:
-            return resultString
-        }
-        return resultString
-
+        return content
     }
 
     // MARK: - String attributes

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -118,14 +118,8 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             content.appendAttributedString(childContent)
         }
 
-        if node.isBlockLevelElement() {
-            var isLastChildBlockLevelNode = false
-            if let lastChild = node.children.last as? ElementNode {
-                isLastChildBlockLevelNode = lastChild.isBlockLevelElement()
-            }
-            if !isLastChildBlockLevelNode {
-                content.appendAttributedString(NSMutableAttributedString(string: "\n", attributes: childAttributes))
-            }
+        if node.isBlockLevelElement() && !node.isLastChildBlockLevelElement() {
+            content.appendAttributedString(NSMutableAttributedString(string: "\n", attributes: childAttributes))
         }
 
         if let nodeType = node.standardName {

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -120,6 +120,17 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         }
 
         if let nodeType = node.standardName {
+
+            if nodeType.isBlockLevelNodeName() {
+                var isLastChildBlockLevelNode = false
+                if let lastChild = node.children.last as? ElementNode {
+                    isLastChildBlockLevelNode = lastChild.isBlockLevelElement()
+                }
+                if !isLastChildBlockLevelNode {
+                    content.appendAttributedString(NSMutableAttributedString(string: "\n", attributes: childAttributes))
+                }
+            }
+
             return nodeType.implicitRepresentation(forContent: content, attributes: childAttributes)
         }
 

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -131,28 +131,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         let resultString = NSMutableAttributedString(attributedString: childContent)
         switch nodeType {
         case .img:
-            let url: NSURL?
-
-            if let urlString = node.valueForStringAttribute(named: "src") {
-                url = NSURL(string: urlString)
-            } else {
-                url = nil
-            }
-
-            let attachment = TextAttachment(url: url)
-
-            if let elementClass = node.valueForStringAttribute(named: "class") {
-                let classAttributes = elementClass.componentsSeparatedByString(" ")
-                for classAttribute in classAttributes {
-                    if let alignment = TextAttachment.Alignment.fromHTML(string: classAttribute) {
-                        attachment.alignment = alignment
-                    }
-                    if let size = TextAttachment.Size.fromHTML(string: classAttribute) {
-                        attachment.size = size
-                    }
-                }
-            }
-            return NSAttributedString(attachment: attachment)
+            return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)), attributes: attributes)
         case .br:
             return NSAttributedString(string: "\n", attributes: attributes)
         case .p:
@@ -216,12 +195,36 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             attributes[NSUnderlineStyleAttributeName] = NSUnderlineStyle.StyleSingle.rawValue
         }
 
-
         if isBlockquote(node) {
             let formatter = BlockquoteFormatter()
             for (key, value) in formatter.attributes {
                 attributes[key] = value
             }
+        }
+
+        if isImage(node) {
+            let url: NSURL?
+
+            if let urlString = node.valueForStringAttribute(named: "src") {
+                url = NSURL(string: urlString)
+            } else {
+                url = nil
+            }
+
+            let attachment = TextAttachment(url: url)
+
+            if let elementClass = node.valueForStringAttribute(named: "class") {
+                let classAttributes = elementClass.componentsSeparatedByString(" ")
+                for classAttribute in classAttributes {
+                    if let alignment = TextAttachment.Alignment.fromHTML(string: classAttribute) {
+                        attachment.alignment = alignment
+                    }
+                    if let size = TextAttachment.Size.fromHTML(string: classAttribute) {
+                        attachment.size = size
+                    }
+                }
+            }
+            attributes[NSAttachmentAttributeName] = attachment
         }
 
         return attributes
@@ -281,5 +284,9 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
     private func isBlockquote(node: ElementNode) -> Bool {
         return node.name == StandardElementType.blockquote.rawValue
+    }
+
+    private func isImage(node: ElementNode) -> Bool {
+        return node.name == StandardElementType.img.rawValue
     }
 }

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -98,8 +98,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
     // MARK: - Node Styling
 
-    /// Returns an attributed string representing the specified non-empty node.  Non-empty means
-    /// the received node has children.
+    /// Returns an attributed string representing the specified node.
     ///
     /// - Parameters:
     ///     - node: the element node to generate a representation string of.
@@ -119,18 +118,17 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             content.appendAttributedString(childContent)
         }
 
-        if let nodeType = node.standardName {
-
-            if nodeType.isBlockLevelNodeName() {
-                var isLastChildBlockLevelNode = false
-                if let lastChild = node.children.last as? ElementNode {
-                    isLastChildBlockLevelNode = lastChild.isBlockLevelElement()
-                }
-                if !isLastChildBlockLevelNode {
-                    content.appendAttributedString(NSMutableAttributedString(string: "\n", attributes: childAttributes))
-                }
+        if node.isBlockLevelElement() {
+            var isLastChildBlockLevelNode = false
+            if let lastChild = node.children.last as? ElementNode {
+                isLastChildBlockLevelNode = lastChild.isBlockLevelElement()
             }
+            if !isLastChildBlockLevelNode {
+                content.appendAttributedString(NSMutableAttributedString(string: "\n", attributes: childAttributes))
+            }
+        }
 
+        if let nodeType = node.standardName {
             return nodeType.implicitRepresentation(forContent: content, attributes: childAttributes)
         }
 

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -110,7 +110,7 @@ extension Libxml2.In {
         ///
         private func createTextNode(rawNode: xmlNode) -> TextNode {
             let text = String(CString: UnsafePointer<Int8>(rawNode.content), encoding: NSUTF8StringEncoding)!
-            let cleanText = text.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+            let cleanText = text.stringByTrimmingCharactersInSet(NSCharacterSet.newlineCharacterSet())
             let node = TextNode(text: cleanText)
 
             return node

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -110,7 +110,7 @@ extension Libxml2.In {
         ///
         private func createTextNode(rawNode: xmlNode) -> TextNode {
             let text = String(CString: UnsafePointer<Int8>(rawNode.content), encoding: NSUTF8StringEncoding)!
-            let cleanText = text.stringByTrimmingCharactersInSet(NSCharacterSet.newlineCharacterSet())
+            let cleanText = text.stringByReplacingOccurrencesOfString("\n", withString: "")
             let node = TextNode(text: cleanText)
 
             return node

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -110,7 +110,8 @@ extension Libxml2.In {
         ///
         private func createTextNode(rawNode: xmlNode) -> TextNode {
             let text = String(CString: UnsafePointer<Int8>(rawNode.content), encoding: NSUTF8StringEncoding)!
-            let node = TextNode(text: text)
+            let cleanText = text.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+            let node = TextNode(text: cleanText)
 
             return node
         }

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -607,34 +607,13 @@ extension Libxml2 {
                 text = text + child.text()
             }
 
-            text = implicitRepresentation(forNode:self, childContent: text)
+            if let nodeType = standardName {
+                text = nodeType.implicitRepresentation(forContent: text)
+            }
 
             return text
         }
 
-        private func implicitRepresentation(forNode node: ElementNode, childContent: String) -> String {
-
-            guard let nodeType = node.standardName else {
-                return childContent
-            }
-
-            var resultString = childContent
-            switch nodeType {
-            case .img:
-                return String(UnicodeScalar(NSAttachmentCharacter))
-            case .br:
-                return "\n"
-            case .p:
-                resultString = resultString + "\n"
-            case .li:
-                resultString = resultString + "\n"
-            default:
-                return resultString
-            }
-            return resultString
-        }
-
-        
         /// Returns the plain visible text for a specified range.
         ///
         /// - Parameters:

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -607,16 +607,17 @@ extension Libxml2 {
                 text = text + child.text()
             }
 
-            if let nodeType = standardName {
-                if nodeType.isBlockLevelNodeName() {
-                    var isLastChildBlockLevelNode = false
-                    if let lastChild = children.last as? ElementNode {
-                        isLastChildBlockLevelNode = lastChild.isBlockLevelElement()
-                    }
-                    if !isLastChildBlockLevelNode {
-                        text += "\n"
-                    }
+            if isBlockLevelElement() {
+                var isLastChildBlockLevelNode = false
+                if let lastChild = children.last as? ElementNode {
+                    isLastChildBlockLevelNode = lastChild.isBlockLevelElement()
                 }
+                if !isLastChildBlockLevelNode {
+                    text += "\n"
+                }
+            }
+
+            if let nodeType = standardName {
                 text = nodeType.implicitRepresentation(forContent: text)
             }
 

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -86,6 +86,17 @@ extension Libxml2 {
             attributes.append(StringAttribute(name: attributeName, value: value))
         }
 
+        /// Check if the last of this children element is a block level element
+        ///
+        /// - Returns: true if the last child of this element is a block level element, false otherwise
+        ///
+        func isLastChildBlockLevelElement() -> Bool {
+            if let lastChild = children.last as? ElementNode {
+               return lastChild.isBlockLevelElement()
+            }
+            return false
+        }
+
         /// Find out if this is a block-level element.
         ///
         /// - Returns: `true` if this is a block-level element.  `false` otherwise.
@@ -608,11 +619,7 @@ extension Libxml2 {
             }
 
             if isBlockLevelElement() {
-                var isLastChildBlockLevelNode = false
-                if let lastChild = children.last as? ElementNode {
-                    isLastChildBlockLevelNode = lastChild.isBlockLevelElement()
-                }
-                if !isLastChildBlockLevelNode {
+                if !isLastChildBlockLevelElement() {
                     text += "\n"
                 }
             }

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -20,7 +20,7 @@ extension Libxml2 {
         private(set) var attributes = [Attribute]()
         private(set) var children: [Node]
 
-        private var standardName: StandardElementType? {
+        internal var standardName: StandardElementType? {
             get {
                 return StandardElementType(rawValue: name)
             }
@@ -601,18 +601,39 @@ extension Libxml2 {
         }
         
         override func text() -> String {
+
             var text = ""
-            
-            if let representation = standardName?.defaultVisualRepresentation() {
-                text = representation
-            }
-            
             for child in children {
                 text = text + child.text()
             }
-            
+
+            text = implicitRepresentation(forNode:self, childContent: text)
+
             return text
         }
+
+        private func implicitRepresentation(forNode node: ElementNode, childContent: String) -> String {
+
+            guard let nodeType = node.standardName else {
+                return childContent
+            }
+
+            var resultString = childContent
+            switch nodeType {
+            case .img:
+                return String(UnicodeScalar(NSAttachmentCharacter))
+            case .br:
+                return "\n"
+            case .p:
+                resultString = resultString + "\n"
+            case .li:
+                resultString = resultString + "\n"
+            default:
+                return resultString
+            }
+            return resultString
+        }
+
         
         /// Returns the plain visible text for a specified range.
         ///

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -618,10 +618,8 @@ extension Libxml2 {
                 text = text + child.text()
             }
 
-            if isBlockLevelElement() {
-                if !isLastChildBlockLevelElement() {
-                    text += "\n"
-                }
+            if isBlockLevelElement() && !isLastChildBlockLevelElement() {
+                text += "\n"
             }
 
             if let nodeType = standardName {

--- a/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
@@ -50,7 +50,7 @@ extension Libxml2 {
         /// Returns an array with all block-level elements.
         ///
         static var blockLevelNodeNames: [StandardElementType] {
-            return [.address, .blockquote, .div, .dl, .fieldset, .form, .h1, .h2, .h3, .h4, .h5, .h6,.hr, .noscript, .ol, .p, .pre, .table, .ul]
+            return [.address, .blockquote, .div, .dl, .fieldset, .form, .h1, .h2, .h3, .h4, .h5, .h6,.hr, .li, .noscript, .ol, .p, .pre, .table, .ul]
         }
 
         static func isBlockLevelNodeName(name: String) -> Bool {
@@ -85,15 +85,9 @@ extension Libxml2 {
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)), attributes: attributes)
             case .br:
                 return NSAttributedString(string: "\n", attributes: attributes)
-            case .p:
-                resultString.appendAttributedString(NSAttributedString(string: "\n", attributes: attributes))
-            case .li:
-                resultString.appendAttributedString(NSAttributedString(string: "\n", attributes: attributes))
             default:
                 return resultString
             }
-            return resultString
-            
         }
 
 

--- a/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
@@ -61,19 +61,6 @@ extension Libxml2 {
             return self.dynamicType.blockLevelNodeNames.contains(self)
         }
 
-        /// Some nodes have a default representation that needs to be taken in account when checking the length
-        ///
-        func defaultVisualRepresentation() -> String? {
-            switch self {
-            case .img:
-                return String(UnicodeScalar(NSAttachmentCharacter))
-            case .br:
-                return String("\n")
-            default:
-                return nil
-            }
-        }
-
         var equivalentNames: [String] {
             get {
                 switch self {

--- a/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
@@ -73,6 +73,29 @@ extension Libxml2 {
             }
         }
 
+        func implicitRepresentation(forContent content: String) -> String {
+            return implicitRepresentation(forContent: NSAttributedString(string:content), attributes: [:] ).string
+        }
+
+        func implicitRepresentation(forContent content: NSAttributedString, attributes:[String:AnyObject]) -> NSAttributedString {
+
+            let resultString = NSMutableAttributedString(attributedString: content)
+            switch self {
+            case .img:
+                return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)), attributes: attributes)
+            case .br:
+                return NSAttributedString(string: "\n", attributes: attributes)
+            case .p:
+                resultString.appendAttributedString(NSAttributedString(string: "\n", attributes: attributes))
+            case .li:
+                resultString.appendAttributedString(NSAttributedString(string: "\n", attributes: attributes))
+            default:
+                return resultString
+            }
+            return resultString
+            
+        }
+
 
     }
 }

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -621,27 +621,27 @@ class ElementNodeTests: XCTestCase {
     ///     - (node: p, range: (0...6))
     ///     - (node: div, range: (6...6))
     ///
-//    func testLowestBlockLevelElements3() {
-//
-//        let textPart1 = "Hello "
-//        let textPart2 = "there!"
-//
-//        let textNode1 = TextNode(text: textPart1)
-//        let textNode2 = TextNode(text: textPart2)
-//
-//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1])
-//        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2])
-//
-//        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
-//
-//        XCTAssertEqual(results.count, 2)
-//        XCTAssertEqual(results[0].element.name, "p")
-//        XCTAssertEqual(results[0].intersection.location, 0)
-//        XCTAssertEqual(results[0].intersection.length, 6)
-//        XCTAssertEqual(results[1].element.name, "div")
-//        XCTAssertEqual(results[1].intersection.location, 6)
-//        XCTAssertEqual(results[1].intersection.length, 6)
-//    }
+    func testLowestBlockLevelElements3() {
+
+        let textPart1 = "Hello "
+        let textPart2 = "there!"
+
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2])
+
+        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].element.name, "p")
+        XCTAssertEqual(results[0].intersection.location, 0)
+        XCTAssertEqual(results[0].intersection.length, 6)
+        XCTAssertEqual(results[1].element.name, "div")
+        XCTAssertEqual(results[1].intersection.location, 7)
+        XCTAssertEqual(results[1].intersection.length, 6)
+    }
 
     /// Tests force-wrapping child nodes intersecting a certain range in a new node.
     ///

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -176,25 +176,25 @@ class ElementNodeTests: XCTestCase {
         XCTAssert(NSEqualRanges(nodesAndRanges[2].range, NSRange(location: 0, length: text3.length())))
     }
 
-    func testLeafNodesWrappingRange2() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
-
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
-        let range = NSRange(location: 0, length: mainNode.length() - 1)
-
-        let nodesAndRanges = mainNode.leafNodesWrapping(range)
-
-        XCTAssertEqual(nodesAndRanges.count, 3)
-        XCTAssertEqual(nodesAndRanges[0].node as? TextNode, text1)
-        XCTAssertEqual(nodesAndRanges[1].node as? TextNode, text2)
-        XCTAssertEqual(nodesAndRanges[2].node as? TextNode, text3)
-
-        XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: 0, length: text1.length())))
-        XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text2.length())))
-        XCTAssert(NSEqualRanges(nodesAndRanges[2].range, NSRange(location: 0, length: text3.length() - 1)))
-    }
+//    func testLeafNodesWrappingRange2() {
+//        let text1 = TextNode(text: "text1 goes here")
+//        let text2 = TextNode(text: "text2 goes here.")
+//        let text3 = TextNode(text: "text3 goes here..")
+//
+//        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+//        let range = NSRange(location: 0, length: mainNode.length() - 1)
+//
+//        let nodesAndRanges = mainNode.leafNodesWrapping(range)
+//
+//        XCTAssertEqual(nodesAndRanges.count, 3)
+//        XCTAssertEqual(nodesAndRanges[0].node as? TextNode, text1)
+//        XCTAssertEqual(nodesAndRanges[1].node as? TextNode, text2)
+//        XCTAssertEqual(nodesAndRanges[2].node as? TextNode, text3)
+//
+//        XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: 0, length: text1.length())))
+//        XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text2.length())))
+//        XCTAssert(NSEqualRanges(nodesAndRanges[2].range, NSRange(location: 0, length: text3.length() - 1)))
+//    }
 
     func testLeafNodesWrappingRange3() {
         let text1 = TextNode(text: "text1 goes here")
@@ -234,23 +234,23 @@ class ElementNodeTests: XCTestCase {
         XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text3.length())))
     }
 
-    func testLeafNodesWrappingRange5() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
-
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
-        let range = NSRange(location: 0, length: mainNode.length() - text3.length())
-
-        let nodesAndRanges = mainNode.leafNodesWrapping(range)
-
-        XCTAssertEqual(nodesAndRanges.count, 2)
-        XCTAssertEqual(nodesAndRanges[0].node as? TextNode, text1)
-        XCTAssertEqual(nodesAndRanges[1].node as? TextNode, text2)
-
-        XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: 0, length: text1.length())))
-        XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text2.length())))
-    }
+//    func testLeafNodesWrappingRange5() {
+//        let text1 = TextNode(text: "text1 goes here")
+//        let text2 = TextNode(text: "text2 goes here.")
+//        let text3 = TextNode(text: "text3 goes here..")
+//
+//        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+//        let range = NSRange(location: 0, length: mainNode.length() - text3.length())
+//
+//        let nodesAndRanges = mainNode.leafNodesWrapping(range)
+//
+//        XCTAssertEqual(nodesAndRanges.count, 2)
+//        XCTAssertEqual(nodesAndRanges[0].node as? TextNode, text1)
+//        XCTAssertEqual(nodesAndRanges[1].node as? TextNode, text2)
+//
+//        XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: 0, length: text1.length())))
+//        XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text2.length())))
+//    }
 
     func testLeafNodesWrappingRange6() {
         let text1 = TextNode(text: "text1 goes here")
@@ -294,33 +294,33 @@ class ElementNodeTests: XCTestCase {
     ///     - The output should be: <div><p>Hello</p><p> World!</p></div>
     ///     - The original paragraph object should point to the first child paragraph.
     ///
-    func testSplitAtLocation1() {
-        let text1 = "Hello"
-        let text2 = " World!"
-        
-        let textNode = TextNode(text: "\(text1)\(text2)")
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
-        
-        let splitLocation = text1.characters.count
-        
-        paragraph.split(atLocation: splitLocation)
-        
-        XCTAssertEqual(div.children.count, 2)
-        
-        guard let newParagraph1 = div.children[0] as? ElementNode
-            where newParagraph1 == paragraph && newParagraph1.text() == text1 else {
-                XCTFail("Expected the first new paragraph to exist and be the same as the original paragraph.")
-                return
-        }
-        
-        guard let newParagraph2 = div.children[1] as? ElementNode
-            where newParagraph2.text() == text2 else {
-                XCTFail("Expected the first new paragraph to exist.")
-                return
-        }
-    }
-    
+//    func testSplitAtLocation1() {
+//        let text1 = "Hello"
+//        let text2 = " World!"
+//        
+//        let textNode = TextNode(text: "\(text1)\(text2)")
+//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+//        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+//        
+//        let splitLocation = text1.characters.count
+//        
+//        paragraph.split(atLocation: splitLocation)
+//        
+//        XCTAssertEqual(div.children.count, 2)
+//        
+//        guard let newParagraph1 = div.children[0] as? ElementNode
+//            where newParagraph1 == paragraph && newParagraph1.text() == text1 else {
+//                XCTFail("Expected the first new paragraph to exist and be the same as the original paragraph.")
+//                return
+//        }
+//        
+//        guard let newParagraph2 = div.children[1] as? ElementNode
+//            where newParagraph2.text() == text2 else {
+//                XCTFail("Expected the first new paragraph to exist.")
+//                return
+//        }
+//    }
+
     /// Tests that splitting an element node at a specified text location works fine.
     ///
     /// HTML string: <div><p>Hello World!</p></div>
@@ -330,24 +330,24 @@ class ElementNodeTests: XCTestCase {
     /// The results should be:
     ///     - The output match the input, no splitting should occur.
     ///
-    func testSplitAtLocation2() {
-        
-        let text = "Hello World!"
-        let textNode = TextNode(text: text)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
-        
-        let splitLocation = 0
-        
-        paragraph.split(atLocation: splitLocation)
-        
-        XCTAssertEqual(div.children.count, 1)
-        XCTAssertEqual(div.children[0], paragraph)
-        XCTAssertEqual(paragraph.children.count, 1)
-        XCTAssertEqual(paragraph.children[0], textNode)
-        XCTAssertEqual(paragraph.text(), "Hello World!")
-    }
-    
+//    func testSplitAtLocation2() {
+//        
+//        let text = "Hello World!"
+//        let textNode = TextNode(text: text)
+//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+//        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+//        
+//        let splitLocation = 0
+//        
+//        paragraph.split(atLocation: splitLocation)
+//        
+//        XCTAssertEqual(div.children.count, 1)
+//        XCTAssertEqual(div.children[0], paragraph)
+//        XCTAssertEqual(paragraph.children.count, 1)
+//        XCTAssertEqual(paragraph.children[0], textNode)
+//        XCTAssertEqual(paragraph.text(), "Hello World!")
+//    }
+
     /// Tests that splitting an element node at a specified text location works fine.
     ///
     /// HTML string: <div><p>Hello World!</p></div>
@@ -357,23 +357,23 @@ class ElementNodeTests: XCTestCase {
     /// The results should be:
     ///     - The output match the input, no splitting should occur.
     ///
-    func testSplitAtLocation3() {
-        
-        let text = "Hello World!"
-        let textNode = TextNode(text: text)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
-        
-        let splitLocation = text.characters.count
-        
-        paragraph.split(atLocation: splitLocation - 1)
-        
-        XCTAssertEqual(div.children.count, 1)
-        XCTAssertEqual(div.children[0], paragraph)
-        XCTAssertEqual(paragraph.children.count, 1)
-        XCTAssertEqual(paragraph.children[0], textNode)
-        XCTAssertEqual(paragraph.text(), "Hello World!")
-    }
+//    func testSplitAtLocation3() {
+//        
+//        let text = "Hello World!"
+//        let textNode = TextNode(text: text)
+//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+//        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+//        
+//        let splitLocation = text.characters.count
+//        
+//        paragraph.split(atLocation: splitLocation - 1)
+//        
+//        XCTAssertEqual(div.children.count, 1)
+//        XCTAssertEqual(div.children[0], paragraph)
+//        XCTAssertEqual(paragraph.children.count, 1)
+//        XCTAssertEqual(paragraph.children[0], textNode)
+//        XCTAssertEqual(paragraph.text(), "Hello World!")
+//    }
 
     func testSplitWithFullRange() {
 
@@ -585,32 +585,32 @@ class ElementNodeTests: XCTestCase {
     ///     - (node: p, range: (0...5))
     ///     - (node: div, range: (11...5))
     ///
-    func testLowestBlockLevelElements2() {
-
-        let textPart1 = "Hello "
-        let textPart2 = "there"
-        let textPart3 = " man!"
-
-        let textNode1 = TextNode(text: textPart1)
-        let textNode2 = TextNode(text: textPart2)
-        let textNode3 = TextNode(text: textPart3)
-
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
-        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3])
-
-        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
-
-        XCTAssertEqual(results.count, 3)
-        XCTAssertEqual(results[0].element.name, "div")
-        XCTAssertEqual(results[0].intersection.location, 0)
-        XCTAssertEqual(results[0].intersection.length, 6)
-        XCTAssertEqual(results[1].element.name, "p")
-        XCTAssertEqual(results[1].intersection.location, 0)
-        XCTAssertEqual(results[1].intersection.length, 5)
-        XCTAssertEqual(results[2].element.name, "div")
-        XCTAssertEqual(results[2].intersection.location, 11)
-        XCTAssertEqual(results[2].intersection.length, 5)
-    }
+//    func testLowestBlockLevelElements2() {
+//
+//        let textPart1 = "Hello "
+//        let textPart2 = "there"
+//        let textPart3 = " man!"
+//
+//        let textNode1 = TextNode(text: textPart1)
+//        let textNode2 = TextNode(text: textPart2)
+//        let textNode3 = TextNode(text: textPart3)
+//
+//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
+//        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3])
+//
+//        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
+//
+//        XCTAssertEqual(results.count, 3)
+//        XCTAssertEqual(results[0].element.name, "div")
+//        XCTAssertEqual(results[0].intersection.location, 0)
+//        XCTAssertEqual(results[0].intersection.length, 6)
+//        XCTAssertEqual(results[1].element.name, "p")
+//        XCTAssertEqual(results[1].intersection.location, 0)
+//        XCTAssertEqual(results[1].intersection.length, 5)
+//        XCTAssertEqual(results[2].element.name, "div")
+//        XCTAssertEqual(results[2].intersection.location, 11)
+//        XCTAssertEqual(results[2].intersection.length, 5)
+//    }
 
 
     /// Tests obtaining the block-level elements intercepting the full range of the following
@@ -621,28 +621,28 @@ class ElementNodeTests: XCTestCase {
     ///     - (node: p, range: (0...6))
     ///     - (node: div, range: (6...6))
     ///
-    func testLowestBlockLevelElements3() {
+//    func testLowestBlockLevelElements3() {
+//
+//        let textPart1 = "Hello "
+//        let textPart2 = "there!"
+//
+//        let textNode1 = TextNode(text: textPart1)
+//        let textNode2 = TextNode(text: textPart2)
+//
+//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1])
+//        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2])
+//
+//        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
+//
+//        XCTAssertEqual(results.count, 2)
+//        XCTAssertEqual(results[0].element.name, "p")
+//        XCTAssertEqual(results[0].intersection.location, 0)
+//        XCTAssertEqual(results[0].intersection.length, 6)
+//        XCTAssertEqual(results[1].element.name, "div")
+//        XCTAssertEqual(results[1].intersection.location, 6)
+//        XCTAssertEqual(results[1].intersection.length, 6)
+//    }
 
-        let textPart1 = "Hello "
-        let textPart2 = "there!"
-
-        let textNode1 = TextNode(text: textPart1)
-        let textNode2 = TextNode(text: textPart2)
-
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2])
-
-        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
-
-        XCTAssertEqual(results.count, 2)
-        XCTAssertEqual(results[0].element.name, "p")
-        XCTAssertEqual(results[0].intersection.location, 0)
-        XCTAssertEqual(results[0].intersection.length, 6)
-        XCTAssertEqual(results[1].element.name, "div")
-        XCTAssertEqual(results[1].intersection.location, 6)
-        XCTAssertEqual(results[1].intersection.length, 6)
-    }
-    
     /// Tests force-wrapping child nodes intersecting a certain range in a new node.
     ///
     /// HTML String: <div>Hello there!</div>

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -294,32 +294,32 @@ class ElementNodeTests: XCTestCase {
     ///     - The output should be: <div><p>Hello</p><p> World!</p></div>
     ///     - The original paragraph object should point to the first child paragraph.
     ///
-//    func testSplitAtLocation1() {
-//        let text1 = "Hello"
-//        let text2 = " World!"
-//        
-//        let textNode = TextNode(text: "\(text1)\(text2)")
-//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-//        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
-//        
-//        let splitLocation = text1.characters.count
-//        
-//        paragraph.split(atLocation: splitLocation)
-//        
-//        XCTAssertEqual(div.children.count, 2)
-//        
-//        guard let newParagraph1 = div.children[0] as? ElementNode
-//            where newParagraph1 == paragraph && newParagraph1.text() == text1 else {
-//                XCTFail("Expected the first new paragraph to exist and be the same as the original paragraph.")
-//                return
-//        }
-//        
-//        guard let newParagraph2 = div.children[1] as? ElementNode
-//            where newParagraph2.text() == text2 else {
-//                XCTFail("Expected the first new paragraph to exist.")
-//                return
-//        }
-//    }
+    func testSplitAtLocation1() {
+        let text1 = "Hello"
+        let text2 = " World!"
+        
+        let textNode = TextNode(text: "\(text1)\(text2)")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        
+        let splitLocation = text1.characters.count
+        
+        paragraph.split(atLocation: splitLocation)
+        
+        XCTAssertEqual(div.children.count, 2)
+        
+        guard let newParagraph1 = div.children[0] as? ElementNode
+            where newParagraph1 == paragraph && newParagraph1.text() == text1 + "\n" else {
+                XCTFail("Expected the first new paragraph to exist and be the same as the original paragraph.")
+                return
+        }
+        
+        guard let newParagraph2 = div.children[1] as? ElementNode
+            where newParagraph2.text() == text2 + "\n" else {
+                XCTFail("Expected the first new paragraph to exist.")
+                return
+        }
+    }
 
     /// Tests that splitting an element node at a specified text location works fine.
     ///
@@ -330,23 +330,23 @@ class ElementNodeTests: XCTestCase {
     /// The results should be:
     ///     - The output match the input, no splitting should occur.
     ///
-//    func testSplitAtLocation2() {
-//        
-//        let text = "Hello World!"
-//        let textNode = TextNode(text: text)
-//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-//        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
-//        
-//        let splitLocation = 0
-//        
-//        paragraph.split(atLocation: splitLocation)
-//        
-//        XCTAssertEqual(div.children.count, 1)
-//        XCTAssertEqual(div.children[0], paragraph)
-//        XCTAssertEqual(paragraph.children.count, 1)
-//        XCTAssertEqual(paragraph.children[0], textNode)
-//        XCTAssertEqual(paragraph.text(), "Hello World!")
-//    }
+    func testSplitAtLocation2() {
+        
+        let text = "Hello World!"
+        let textNode = TextNode(text: text)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        
+        let splitLocation = 0
+        
+        paragraph.split(atLocation: splitLocation)
+        
+        XCTAssertEqual(div.children.count, 1)
+        XCTAssertEqual(div.children[0], paragraph)
+        XCTAssertEqual(paragraph.children.count, 1)
+        XCTAssertEqual(paragraph.children[0], textNode)
+        XCTAssertEqual(paragraph.text(), "Hello World!\n")
+    }
 
     /// Tests that splitting an element node at a specified text location works fine.
     ///
@@ -357,23 +357,23 @@ class ElementNodeTests: XCTestCase {
     /// The results should be:
     ///     - The output match the input, no splitting should occur.
     ///
-//    func testSplitAtLocation3() {
-//        
-//        let text = "Hello World!"
-//        let textNode = TextNode(text: text)
-//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-//        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
-//        
-//        let splitLocation = text.characters.count
-//        
-//        paragraph.split(atLocation: splitLocation - 1)
-//        
-//        XCTAssertEqual(div.children.count, 1)
-//        XCTAssertEqual(div.children[0], paragraph)
-//        XCTAssertEqual(paragraph.children.count, 1)
-//        XCTAssertEqual(paragraph.children[0], textNode)
-//        XCTAssertEqual(paragraph.text(), "Hello World!")
-//    }
+    func testSplitAtLocation3() {
+        
+        let text = "Hello World!"
+        let textNode = TextNode(text: text)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        
+        let splitLocation = text.characters.count
+        
+        paragraph.split(atLocation: splitLocation - 1)
+        
+        XCTAssertEqual(div.children.count, 1)
+        XCTAssertEqual(div.children[0], paragraph)
+        XCTAssertEqual(paragraph.children.count, 1)
+        XCTAssertEqual(paragraph.children[0], textNode)
+        XCTAssertEqual(paragraph.text(), "Hello World!\n")
+    }
 
     func testSplitWithFullRange() {
 
@@ -585,32 +585,32 @@ class ElementNodeTests: XCTestCase {
     ///     - (node: p, range: (0...5))
     ///     - (node: div, range: (11...5))
     ///
-//    func testLowestBlockLevelElements2() {
-//
-//        let textPart1 = "Hello "
-//        let textPart2 = "there"
-//        let textPart3 = " man!"
-//
-//        let textNode1 = TextNode(text: textPart1)
-//        let textNode2 = TextNode(text: textPart2)
-//        let textNode3 = TextNode(text: textPart3)
-//
-//        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
-//        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3])
-//
-//        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
-//
-//        XCTAssertEqual(results.count, 3)
-//        XCTAssertEqual(results[0].element.name, "div")
-//        XCTAssertEqual(results[0].intersection.location, 0)
-//        XCTAssertEqual(results[0].intersection.length, 6)
-//        XCTAssertEqual(results[1].element.name, "p")
-//        XCTAssertEqual(results[1].intersection.location, 0)
-//        XCTAssertEqual(results[1].intersection.length, 5)
-//        XCTAssertEqual(results[2].element.name, "div")
-//        XCTAssertEqual(results[2].intersection.location, 11)
-//        XCTAssertEqual(results[2].intersection.length, 5)
-//    }
+    func testLowestBlockLevelElements2() {
+
+        let textPart1 = "Hello "
+        let textPart2 = "there"
+        let textPart3 = " man!"
+
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+        let textNode3 = TextNode(text: textPart3)
+
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3])
+
+        let results = div.lowestBlockLevelElements(intersectingRange: div.range())
+
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(results[0].element.name, "div")
+        XCTAssertEqual(results[0].intersection.location, 0)
+        XCTAssertEqual(results[0].intersection.length, 6)
+        XCTAssertEqual(results[1].element.name, "p")
+        XCTAssertEqual(results[1].intersection.location, 0)
+        XCTAssertEqual(results[1].intersection.length, 5)
+        XCTAssertEqual(results[2].element.name, "div")
+        XCTAssertEqual(results[2].intersection.location, 12)
+        XCTAssertEqual(results[2].intersection.length, 5)
+    }
 
 
     /// Tests obtaining the block-level elements intercepting the full range of the following

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -176,25 +176,25 @@ class ElementNodeTests: XCTestCase {
         XCTAssert(NSEqualRanges(nodesAndRanges[2].range, NSRange(location: 0, length: text3.length())))
     }
 
-//    func testLeafNodesWrappingRange2() {
-//        let text1 = TextNode(text: "text1 goes here")
-//        let text2 = TextNode(text: "text2 goes here.")
-//        let text3 = TextNode(text: "text3 goes here..")
-//
-//        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
-//        let range = NSRange(location: 0, length: mainNode.length() - 1)
-//
-//        let nodesAndRanges = mainNode.leafNodesWrapping(range)
-//
-//        XCTAssertEqual(nodesAndRanges.count, 3)
-//        XCTAssertEqual(nodesAndRanges[0].node as? TextNode, text1)
-//        XCTAssertEqual(nodesAndRanges[1].node as? TextNode, text2)
-//        XCTAssertEqual(nodesAndRanges[2].node as? TextNode, text3)
-//
-//        XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: 0, length: text1.length())))
-//        XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text2.length())))
-//        XCTAssert(NSEqualRanges(nodesAndRanges[2].range, NSRange(location: 0, length: text3.length() - 1)))
-//    }
+    func testLeafNodesWrappingRange2() {
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here.")
+        let text3 = TextNode(text: "text3 goes here..")
+
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let range = NSRange(location: 0, length: mainNode.length() - 2)
+
+        let nodesAndRanges = mainNode.leafNodesWrapping(range)
+
+        XCTAssertEqual(nodesAndRanges.count, 3)
+        XCTAssertEqual(nodesAndRanges[0].node as? TextNode, text1)
+        XCTAssertEqual(nodesAndRanges[1].node as? TextNode, text2)
+        XCTAssertEqual(nodesAndRanges[2].node as? TextNode, text3)
+
+        XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: 0, length: text1.length())))
+        XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text2.length())))
+        XCTAssert(NSEqualRanges(nodesAndRanges[2].range, NSRange(location: 0, length: text3.length() - 1)))
+    }
 
     func testLeafNodesWrappingRange3() {
         let text1 = TextNode(text: "text1 goes here")
@@ -234,23 +234,23 @@ class ElementNodeTests: XCTestCase {
         XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text3.length())))
     }
 
-//    func testLeafNodesWrappingRange5() {
-//        let text1 = TextNode(text: "text1 goes here")
-//        let text2 = TextNode(text: "text2 goes here.")
-//        let text3 = TextNode(text: "text3 goes here..")
-//
-//        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
-//        let range = NSRange(location: 0, length: mainNode.length() - text3.length())
-//
-//        let nodesAndRanges = mainNode.leafNodesWrapping(range)
-//
-//        XCTAssertEqual(nodesAndRanges.count, 2)
-//        XCTAssertEqual(nodesAndRanges[0].node as? TextNode, text1)
-//        XCTAssertEqual(nodesAndRanges[1].node as? TextNode, text2)
-//
-//        XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: 0, length: text1.length())))
-//        XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text2.length())))
-//    }
+    func testLeafNodesWrappingRange5() {
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here.")
+        let text3 = TextNode(text: "text3 goes here..")
+
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let range = NSRange(location: 0, length: (mainNode.length() - 1) - text3.length())
+
+        let nodesAndRanges = mainNode.leafNodesWrapping(range)
+
+        XCTAssertEqual(nodesAndRanges.count, 2)
+        XCTAssertEqual(nodesAndRanges[0].node as? TextNode, text1)
+        XCTAssertEqual(nodesAndRanges[1].node as? TextNode, text2)
+
+        XCTAssert(NSEqualRanges(nodesAndRanges[0].range, NSRange(location: 0, length: text1.length())))
+        XCTAssert(NSEqualRanges(nodesAndRanges[1].range, NSRange(location: 0, length: text2.length())))
+    }
 
     func testLeafNodesWrappingRange6() {
         let text1 = TextNode(text: "text1 goes here")

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -1,6 +1,6 @@
 <p>
 I'm a test post.
-
+</p>
 <p>
     this is some text
     that is spread out
@@ -9,18 +9,17 @@ I'm a test post.
     single line in a browser
 </p>
 
+<strong>Bold text</strong><br/>
 
-<strong>Bold text</strong>
+<em>Italic text</em><br/>
 
-<em>Italic text</em>
+<u>Underlined text</u><br/>
 
-<u>Underlined text</u>
-
-<a href="http://www.wordpress.com">I'm a link!</a>
+<a href="http://www.wordpress.com">I'm a link!</a><br/>
 
 <!--more-->
-
-<del datetime="2014-05-19T20:55:58+00:00">Strikethrough</del>
+<p>
+<del datetime="2014-05-19T20:55:58+00:00">Strikethrough</del><br/>
 
 Moar Text.
 </p>


### PR DESCRIPTION
This PR makes the following changes on the parsing of HTML:

- Removes any extra whitespace ( space, newlines, tabs) between nodes in HTML
- Implicit adds new lines on the visual representation of block elements

How to test:

- Run the demo project and check if the html is properly parsed.