### PR TITLE
Fix crash when typing return

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -489,8 +489,9 @@ public class TextView: UITextView {
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
     private func refreshListIfNewLinesOn(text text:String, range:NSRange) {
-        // check if are doing two empy list items in a row
-        if text != "\n" {
+        guard text == "\n"
+            && range.location + 1 < storage.length
+            else {
             refreshListsOnlyIfListExists(atRange: range)
             return
         }


### PR DESCRIPTION
The code in `refreshListIfNewLinesOn` would crash if you typed return at the
end of the text, as it tried to check for the next character which was out of
bounds.

Needs Review: @SergioEstevao 