### PR TITLE
Fixes a crash with underline and strikethrough.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -337,10 +337,18 @@ public class TextStorage: NSTextStorage {
         if enable {
             addAttribute(attributeName, value: value, range: range)
         } else {
+            
             /// We should be calculating what attributes to remove in `TextStorage.setAttributes()`
             /// but since that may take a while to implement, we need this workaround until it's ready.
             ///
-            dom.removeUnderline(spanning: range)
+            switch attributeName {
+            case NSStrikethroughStyleAttributeName:
+                dom.removeStrikethrough(spanning: range)
+            case NSUnderlineStyleAttributeName:
+                dom.removeUnderline(spanning: range)
+            default:
+                break
+            }
             
             removeAttribute(attributeName, range: range)
         }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -322,7 +322,7 @@ public class TextStorage: NSTextStorage {
         var effectiveRange = NSRange()
         let enable: Bool
         
-        if attribute(attributeName, atIndex: range.location, effectiveRange: &effectiveRange) != nil {
+        if attribute(attributeName, atIndex: range.location, longestEffectiveRange: &effectiveRange, inRange: range) != nil {
             let intersection = range.intersect(withRange: effectiveRange)
             
             if let intersection = intersection {


### PR DESCRIPTION
When trying to remove underline and strikethrough the app was crashing and / or not responding.

**How to test:**
1. Run the app in develop, apply underline or strikethrough, remove it.  The app should not respond, or crash.
2. Run the app in this PR, apply underline or strikethrough, remove it.  It should work fine and not crash.