### PR TITLE
Lists: HTML to NSAttributedString support

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -22,7 +22,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
     /// The current active list number
     ///
-    var currentListNumber: Int = 0
+    var currentListNumber: Int = 1
 
     required init(usingDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) {
         self.defaultFontDescriptor = defaultFontDescriptor
@@ -252,13 +252,13 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         }
 
         if isNode(node, ofType: .ol) {
-            currentListNumber = 0
+            currentListNumber = 1
             currentListStyle = .Ordered
             attributes[TextList.attributeName] = TextList(style: .Ordered)
         }
 
         if isNode(node, ofType: .ul) {
-            currentListNumber = 0
+            currentListNumber = 1
             currentListStyle = .Unordered
             attributes[TextList.attributeName] = TextList(style: .Unordered)
         }

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -113,12 +113,12 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         let childAttributes = attributes(forNode: node, inheritingAttributes: inheritedAttributes)
 
         for child in node.children {
-            let childContent = NSMutableAttributedString(attributedString:convert(child, inheritingAttributes: childAttributes))
+            let childContent = NSAttributedString(attributedString:convert(child, inheritingAttributes: childAttributes))
             content.appendAttributedString(childContent)
         }
 
         if node.isBlockLevelElement() && !node.isLastChildBlockLevelElement() {
-            content.appendAttributedString(NSMutableAttributedString(string: "\n", attributes: inheritedAttributes))
+            content.appendAttributedString(NSAttributedString(string: "\n", attributes: inheritedAttributes))
         }
 
         if let nodeType = node.standardName {
@@ -210,15 +210,15 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             attributes[NSAttachmentAttributeName] = attachment
         }
 
-        if isNode(node, ofType: .ol) {
+        if node.isNodeType(.ol) {
             attributes[TextList.attributeName] = TextList(style: .Ordered)
         }
 
-        if isNode(node, ofType: .ul) {
+        if node.isNodeType(.ul) {
             attributes[TextList.attributeName] = TextList(style: .Unordered)
         }
 
-        if isNode(node, ofType: .li) {
+        if node.isNodeType(.li) {
             if let listStyle = attributes[TextList.attributeName] as? TextList {
                 listStyle.currentListNumber += 1
                 attributes[TextListItem.attributeName] = TextListItem(number: listStyle.currentListNumber)
@@ -286,9 +286,5 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
     private func isImage(node: ElementNode) -> Bool {
         return node.name == StandardElementType.img.rawValue
-    }
-
-    private func isNode(node:ElementNode, ofType type:StandardElementType) -> Bool {
-        return type.equivalentNames.contains(node.name)
-    }
+    }    
 }

--- a/Aztec/Classes/Libxml2/Converters/In/InHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InHTMLConverter.swift
@@ -45,7 +45,12 @@ extension Libxml2.In {
             //
             htmlHandleOmittedElem(0)
 
-            let document = htmlCtxtReadMemory(parserContext, htmlPtr, Int32(wrappedHTML.lengthOfBytesUsingEncoding(NSUTF8StringEncoding)), "", "UTF-8", Int32(HTML_PARSE_RECOVER.rawValue | HTML_PARSE_NODEFDTD.rawValue | HTML_PARSE_NOERROR.rawValue | HTML_PARSE_NOWARNING.rawValue | HTML_PARSE_NOIMPLIED.rawValue))
+            let document = htmlCtxtReadMemory(parserContext,
+                                              htmlPtr,
+                                              Int32(wrappedHTML.lengthOfBytesUsingEncoding(NSUTF8StringEncoding)),
+                                              "",
+                                              "UTF-8",
+                                              Int32(HTML_PARSE_RECOVER.rawValue | HTML_PARSE_NODEFDTD.rawValue | HTML_PARSE_NOERROR.rawValue | HTML_PARSE_NOWARNING.rawValue | HTML_PARSE_NOIMPLIED.rawValue | HTML_PARSE_NOBLANKS.rawValue))
             
             defer {
                 xmlFreeDoc(document)

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -91,13 +91,13 @@ extension Libxml2 {
         /// - Returns: true if the last child of this element is a block level element, false otherwise
         ///
         func isLastChildBlockLevelElement() -> Bool {
-            let childrenFiltered = children.filter { (node) -> Bool in
+            let childrenIgnoringEmptyTextNodes = children.filter { (node) -> Bool in
                 if let textNode = node as? TextNode {
                     return !textNode.text().isEmpty
                 }
                 return true
             }
-            if let lastChild = childrenFiltered.last as? ElementNode {
+            if let lastChild = childrenIgnoringEmptyTextNodes.last as? ElementNode {
                return lastChild.isBlockLevelElement()
             }
             return false
@@ -117,6 +117,10 @@ extension Libxml2 {
             }
 
             return standardName.isBlockLevelNodeName()
+        }
+
+        func isNodeType(type:StandardElementType) -> Bool {
+            return type.equivalentNames.contains(name.lowercaseString)
         }
 
         // MARK: - DOM Queries

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -91,7 +91,13 @@ extension Libxml2 {
         /// - Returns: true if the last child of this element is a block level element, false otherwise
         ///
         func isLastChildBlockLevelElement() -> Bool {
-            if let lastChild = children.last as? ElementNode {
+            let childrenFiltered = children.filter { (node) -> Bool in
+                if let textNode = node as? TextNode {
+                    return !textNode.text().isEmpty
+                }
+                return true
+            }
+            if let lastChild = childrenFiltered.last as? ElementNode {
                return lastChild.isBlockLevelElement()
             }
             return false

--- a/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
@@ -85,11 +85,22 @@ extension Libxml2 {
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)), attributes: attributes)
             case .br:
                 return NSAttributedString(string: "\n", attributes: attributes)
+            case .li:
+                if let listItemAttribute = content.attribute(TextListItem.attributeName, atIndex: 0, effectiveRange: nil) as? TextListItem,
+                   let listAttribute = content.attribute(TextList.attributeName, atIndex: 0, effectiveRange: nil) as? TextList
+                {
+                    var attributesForMarker = attributes
+                    attributesForMarker[TextListItemMarker.attributeName] = TextListItemMarker()
+                    attributesForMarker[NSParagraphStyleAttributeName] = NSParagraphStyle.Aztec.defaultParagraphStyle
+                    let markerString = NSAttributedString(string:listAttribute.style.markerText(forItemNumber: listItemAttribute.number),
+                                                          attributes: attributesForMarker)
+                    resultString.insertAttributedString(markerString, atIndex: 0)
+                }
+                return resultString
             default:
                 return resultString
             }
         }
-
-
+        
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
@@ -50,7 +50,7 @@ extension Libxml2 {
         /// Returns an array with all block-level elements.
         ///
         static var blockLevelNodeNames: [StandardElementType] {
-            return [.address, .blockquote, .div, .dl, .fieldset, .form, .h1, .h2, .h3, .h4, .h5, .h6,.hr, .noscript, .ol, .p, .pre, .table, .ul]
+            return [.address, .blockquote, .div, .dl, .fieldset, .form, .h1, .h2, .h3, .h4, .h5, .h6,.hr, .li, .noscript, .ol, .p, .pre, .table, .ul]
         }
 
         static func isBlockLevelNodeName(name: String) -> Bool {

--- a/Aztec/Classes/TextKit/TextList.swift
+++ b/Aztec/Classes/TextKit/TextList.swift
@@ -28,7 +28,7 @@ class TextList
     ///
     let style: Style
 
-
+    var currentListNumber: Int = 0
     // MARK: Initializers
 
     init(style: Style) {


### PR DESCRIPTION
#149 

This PR implements the parsing of ol, ul  and li element from HTML to attributed string.

How to test:
 - Using the sample content check if the OL and UL shows correctly in the attributed strings
 - Try to change the HTML to other valid OL and UL and see if they are parsed correctly
 - Switch from visual to HTML and see if list are represented back correctly

Note: This PR doesn't implement DOM interactions on list while using visual mode, so if lists are changed in visual mode they are not reflected to HTML mode. 