### PR TITLE
Reimplement list markers using layout manager

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -118,7 +118,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         }
 
         if node.isBlockLevelElement() && !node.isLastChildBlockLevelElement() {
-            content.appendAttributedString(NSAttributedString(string: "\n", attributes: inheritedAttributes))
+            content.appendAttributedString(NSAttributedString(string: "\n", attributes: childAttributes))
         }
 
         if let nodeType = node.standardName {

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -222,6 +222,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             if let listStyle = attributes[TextList.attributeName] as? TextList {
                 listStyle.currentListNumber += 1
                 attributes[TextListItem.attributeName] = TextListItem(number: listStyle.currentListNumber)
+                attributes[NSParagraphStyleAttributeName] = NSParagraphStyle.Aztec.defaultListParagraphStyle
             }
         }
 

--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -127,6 +127,16 @@ extension NSAttributedString
         return attribute(TextList.attributeName, atIndex: index, effectiveRange: nil) as? TextList
     }
 
+    /// Returns the TextListItem attribute at the specified NSRange, if any.
+    ///
+    /// - Parameter index: The index at which to inspect.
+    ///
+    /// - Returns: A TextListItem optional.
+    ///
+    func textListItemAttribute(atIndex index: Int) -> TextListItem? {
+        return attribute(TextListItem.attributeName, atIndex: index, effectiveRange: nil) as? TextListItem
+    }
+
 
     /// Returns the TextList attribute, assuming that there is one, spanning the specified Range.
     ///

--- a/Aztec/Classes/Extensions/NSParagraphStyle+Helpers.swift
+++ b/Aztec/Classes/Extensions/NSParagraphStyle+Helpers.swift
@@ -26,6 +26,16 @@ extension NSParagraphStyle
             return style
         }()
 
+        static let defaultListParagraphStyle: NSParagraphStyle = {
+            let style = NSMutableParagraphStyle()
+            style.setParagraphStyle(defaultParagraphStyle)
+
+            style.headIndent = 12
+            style.firstLineHeadIndent = style.headIndent
+
+            return style
+        }()
+
         private static let tabStepInterval = 8
         private static let tabStepCount    = 12
     }

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -50,11 +50,13 @@ class TextListFormatter
         var styleOptional: TextList.Style?
         // Load Paragraph Ranges
 
-        let paragraphRanges = string.paragraphRanges(spanningRange: range)
-        guard let firstParagraphRange = paragraphRanges.first else {
+        var paragraphRanges = string.paragraphRanges(spanningRange: range)
+        if paragraphRanges.count == 0 {
             if let paragraphRange = string.rangeOfLine(atIndex: range.location) {
-                return removeList(fromString: string, atRanges: [paragraphRange])
+                paragraphRanges.append(paragraphRange)
             }
+        }
+        guard let firstParagraphRange = paragraphRanges.first else {
             return nil
         }
         if let textList = string.attribute(TextList.attributeName, atIndex: firstParagraphRange.location, effectiveRange: nil) as? TextList {
@@ -84,7 +86,8 @@ class TextListFormatter
     /// - Returns: the total range that was affected by this method
     ///
     func removeList(inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
-        return removeList(fromString: string, atRanges: [range])
+        let paragraphRange = string.paragraphRange(for: range)
+        return removeList(fromString: string, atRanges: [paragraphRange])
     }
 }
 

--- a/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
@@ -84,19 +84,7 @@ extension Libxml2 {
             case .img:
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)), attributes: attributes)
             case .br:
-                return NSAttributedString(string: "\n", attributes: attributes)
-            case .li:
-                if let listItemAttribute = content.attribute(TextListItem.attributeName, atIndex: 0, effectiveRange: nil) as? TextListItem,
-                   let listAttribute = content.attribute(TextList.attributeName, atIndex: 0, effectiveRange: nil) as? TextList
-                {
-                    var attributesForMarker = attributes
-                    attributesForMarker[TextListItemMarker.attributeName] = TextListItemMarker()
-                    attributesForMarker[NSParagraphStyleAttributeName] = NSParagraphStyle.Aztec.defaultParagraphStyle
-                    let markerString = NSAttributedString(string:listAttribute.style.markerText(forItemNumber: listItemAttribute.number),
-                                                          attributes: attributesForMarker)
-                    resultString.insertAttributedString(markerString, atIndex: 0)
-                }
-                return resultString
+                return NSAttributedString(string: "\n", attributes: attributes)            
             default:
                 return resultString
             }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -5,15 +5,18 @@ import QuartzCore
 class LayoutManager: NSLayoutManager {
     override func drawBackgroundForGlyphRange(glyphsToShow: NSRange, atPoint origin: CGPoint) {
         super.drawBackgroundForGlyphRange(glyphsToShow, atPoint: origin)
+        guard let textStorage = textStorage else {
+            return
+        }
+
+        guard let context = UIGraphicsGetCurrentContext() else {
+            preconditionFailure("When drawBackgroundForGlyphRange is called, the graphics context is supposed to be set by UIKit")
+        }
 
         let characterRange = characterRangeForGlyphRange(glyphsToShow, actualGlyphRange: nil)
-        textStorage?.enumerateAttribute(Blockquote.attributeName, inRange: characterRange, options: []){ (object, range, stop) in
+        textStorage.enumerateAttribute(Blockquote.attributeName, inRange: characterRange, options: []){ (object, range, stop) in
             guard object is Blockquote else {
                 return
-            }
-
-            guard let context = UIGraphicsGetCurrentContext() else {
-                preconditionFailure("When drawBackgroundForGlyphRange is called, the graphics context is supposed to be set by UIKit")
             }
 
             let borderColor = UIColor(red: 0.5294117647, green: 0.650980392156863, blue: 0.737254902, alpha: 1.0)
@@ -27,6 +30,37 @@ class LayoutManager: NSLayoutManager {
                 let borderRect = CGRect(origin: lineRect.origin, size: CGSize(width: 2, height: lineRect.height))
                 borderColor.setFill()
                 CGContextFillRect(context, borderRect)
+            }
+        }
+
+        // draw list markers
+        textStorage.enumerateAttribute(TextListItem.attributeName, inRange: characterRange, options: []){ (object, range, stop) in
+            guard let textListItem = object as? TextListItem,
+                  let textList = textStorage.attribute(TextList.attributeName, atIndex: range.location, effectiveRange: nil) as? TextList
+                else {
+                return
+            }
+
+//            let borderColor = UIColor(red: 0.5294117647, green: 0.650980392156863, blue: 0.737254902, alpha: 1.0)//
+//            let backgroundColor = UIColor.redColor()
+            let blockquoteGlyphRange = glyphRangeForCharacterRange(range, actualCharacterRange: nil)
+
+            enumerateLineFragmentsForGlyphRange(blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
+                let lineRect = rect.offsetBy(dx: origin.x, dy: origin.y)
+//                backgroundColor.setFill()
+//                CGContextFillRect(context, lineRect)
+//                let borderRect = CGRect(origin: lineRect.origin, size: CGSize(width: 2, height: lineRect.height))
+//                borderColor.setFill()
+//                CGContextFillRect(context, borderRect)
+
+                let lineRange = self.characterRangeForGlyphRange(glyphRange, actualGlyphRange: nil)
+                let isStartOfLine = textStorage.isStartOfNewLine(atLocation: lineRange.location)
+                var attributes = textStorage.attributesAtIndex(lineRange.location, effectiveRange: nil)
+                attributes[NSParagraphStyleAttributeName] = NSParagraphStyle.Aztec.defaultParagraphStyle
+                if isStartOfLine {
+                    let markerText = NSAttributedString(string:textList.style.markerText(forItemNumber: textListItem.number), attributes:attributes)
+                    markerText.drawInRect(lineRect)
+                }
             }
         }
     }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -3,6 +3,7 @@ import UIKit
 import QuartzCore
 
 class LayoutManager: NSLayoutManager {
+
     override func drawBackgroundForGlyphRange(glyphsToShow: NSRange, atPoint origin: CGPoint) {
         super.drawBackgroundForGlyphRange(glyphsToShow, atPoint: origin)
         guard let textStorage = textStorage else {
@@ -41,18 +42,10 @@ class LayoutManager: NSLayoutManager {
                 return
             }
 
-//            let borderColor = UIColor(red: 0.5294117647, green: 0.650980392156863, blue: 0.737254902, alpha: 1.0)//
-//            let backgroundColor = UIColor.redColor()
-            let blockquoteGlyphRange = glyphRangeForCharacterRange(range, actualCharacterRange: nil)
+            let listGlyphRange = glyphRangeForCharacterRange(range, actualCharacterRange: nil)
 
-            enumerateLineFragmentsForGlyphRange(blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
+            enumerateLineFragmentsForGlyphRange(listGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
                 let lineRect = rect.offsetBy(dx: origin.x, dy: origin.y)
-//                backgroundColor.setFill()
-//                CGContextFillRect(context, lineRect)
-//                let borderRect = CGRect(origin: lineRect.origin, size: CGSize(width: 2, height: lineRect.height))
-//                borderColor.setFill()
-//                CGContextFillRect(context, borderRect)
-
                 let lineRange = self.characterRangeForGlyphRange(glyphRange, actualGlyphRange: nil)
                 let isStartOfLine = textStorage.isStartOfNewLine(atLocation: lineRange.location)
                 var attributes = textStorage.attributesAtIndex(lineRange.location, effectiveRange: nil)

--- a/Aztec/Classes/TextKit/TextList.swift
+++ b/Aztec/Classes/TextKit/TextList.swift
@@ -67,14 +67,3 @@ class TextListItem
     ///
     static let attributeName = "TextListItemAttributeName"
 }
-
-
-// MARK: - Encompases the range of the bullet/number + tab.
-//
-class TextListItemMarker {
-    // MARK: - Constants
-
-    /// Attributed String's Attribute Name
-    ///
-    static let attributeName = "TextListItemMarkerAttributeName"
-}

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -428,7 +428,7 @@ public class TextView: UITextView {
         if storage.length == 0 {
             return attributes
         }
-        let inBoundsIndex = max(0,min(index-1, storage.length-1))
+        let inBoundsIndex = max(0,min(index, storage.length-1))
         if let textList = storage.textListAttribute(atIndex: inBoundsIndex),
            let textListItem = storage.textListItemAttribute(atIndex: inBoundsIndex)
         {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -106,9 +106,11 @@ public class TextView: UITextView {
     public override func deleteBackward() {
         var deletionRange = selectedRange
         var deletedString = NSAttributedString()
-        if storage.length > 0 {
+        if deletionRange.length == 0 {
             deletionRange.location = max(selectedRange.location - 1, 0)
             deletionRange.length = 1
+        }
+        if storage.length > 0 {
             deletedString = storage.attributedSubstringFromRange(deletionRange)
         }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -86,14 +86,18 @@ public class TextView: UITextView {
     }
 
     // MARK: - Intersect keyboard operations
-
-    public override func insertText(text: String) {
-        var insertionRange = selectedRange
+    func updateTypingAttributes() {
         var attributes = listCustomAttributes(atIndex: selectedRange.location)
         for (k,v) in typingAttributes {
             attributes[k] = v
         }
         typingAttributes = attributes
+    }
+
+
+    public override func insertText(text: String) {
+        updateTypingAttributes()
+        var insertionRange = selectedRange
         super.insertText(text)
         insertionRange.length = 1
         refreshListAfterInsertionOf(text: text, range: insertionRange)
@@ -424,7 +428,7 @@ public class TextView: UITextView {
         if storage.length == 0 {
             return attributes
         }
-        let inBoundsIndex = max(0,min(index, storage.length-1))
+        let inBoundsIndex = max(0,min(index-1, storage.length-1))
         if let textList = storage.textListAttribute(atIndex: inBoundsIndex),
            let textListItem = storage.textListItemAttribute(atIndex: inBoundsIndex)
         {

--- a/AztecTests/Extensions/NSAttributedStringListsTests.swift
+++ b/AztecTests/Extensions/NSAttributedStringListsTests.swift
@@ -484,10 +484,7 @@ class NSAttributedStringListsTests: XCTestCase {
         for index in (0 ..< applied.length) {
             let item = applied.attribute(TextListItem.attributeName, atIndex: index, effectiveRange: nil) as? TextListItem
             XCTAssertNotNil(item)
-        }
-
-        let marker = applied.attribute(TextListItemMarker.attributeName, atIndex: 0, effectiveRange: nil) as? TextListItemMarker
-        XCTAssertNotNil(marker)
+        }        
     }
 
     /// Tests that `attributedStringByApplyingListItemAttributes` effectively removes the TextListItem Attribute.


### PR DESCRIPTION
This PR reimplement the display of list markers using our custom layout manager.
This avoid a lot of special code to handle markers in the content.

How to test:
 - Load the demo app
 - Try to edit lists of all type and see if the handling is done correctly
 - Check if the initial transformation from HTML to AttributedString is correct.

Note: this still doesn't update the DOM when edits happens to the attributed string. So list changes made there will not be reflected to the DOM.