### PR TITLE
Fix copy paste for lists, block quotes and images

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		F1CF272A1DBA8CDB0001C61D /* DocumentObjectModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF27291DBA8CDB0001C61D /* DocumentObjectModel.swift */; };
 		F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */; };
 		FFA61E891DF18F3D00B71BF6 /* ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */; };
+		FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift */; };
 		FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */; };
 		FFF585CF1DB6398E00299B93 /* StandardElementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF585CE1DB6398E00299B93 /* StandardElementType.swift */; };
 /* End PBXBuildFile section */
@@ -170,6 +171,7 @@
 		FF5B98E21DC29D0C00571CA4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		FF5B98E41DC355B400571CA4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParagraphStyle.swift; sourceTree = "<group>"; };
+		FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Encoding.swift"; sourceTree = "<group>"; };
 		FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutManager+Attachments.swift"; sourceTree = "<group>"; };
 		FFF585CE1DB6398E00299B93 /* StandardElementType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardElementType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -340,6 +342,7 @@
 			children = (
 				599F25251D8BC9A1002871D6 /* NSAttributedString+Attachments.swift */,
 				B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */,
+				FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift */,
 				F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */,
 				599F25261D8BC9A1002871D6 /* String+RangeConversion.swift */,
 				599F25271D8BC9A1002871D6 /* UITextView+Helpers.swift */,
@@ -631,6 +634,7 @@
 				B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */,
 				599F25391D8BC9A1002871D6 /* InHTMLConverter.swift in Sources */,
 				599F25411D8BC9A1002871D6 /* EditableNode.swift in Sources */,
+				FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift in Sources */,
 				599F253E1D8BC9A1002871D6 /* OutHTMLNodeConverter.swift in Sources */,
 				E109B51C1DC33F2C0099605E /* LayoutManager.swift in Sources */,
 				B5BC4FEE1DA2C17800614582 /* NSAttributedString+Lists.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -71,7 +71,7 @@
 		F1CF272A1DBA8CDB0001C61D /* DocumentObjectModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF27291DBA8CDB0001C61D /* DocumentObjectModel.swift */; };
 		F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */; };
 		FFA61E891DF18F3D00B71BF6 /* ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */; };
-		FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift */; };
+		FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */; };
 		FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */; };
 		FFF585CF1DB6398E00299B93 /* StandardElementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF585CE1DB6398E00299B93 /* StandardElementType.swift */; };
 /* End PBXBuildFile section */
@@ -171,7 +171,7 @@
 		FF5B98E21DC29D0C00571CA4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		FF5B98E41DC355B400571CA4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParagraphStyle.swift; sourceTree = "<group>"; };
-		FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Encoding.swift"; sourceTree = "<group>"; };
+		FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Archive.swift"; sourceTree = "<group>"; };
 		FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutManager+Attachments.swift"; sourceTree = "<group>"; };
 		FFF585CE1DB6398E00299B93 /* StandardElementType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardElementType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -342,7 +342,7 @@
 			children = (
 				599F25251D8BC9A1002871D6 /* NSAttributedString+Attachments.swift */,
 				B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */,
-				FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift */,
+				FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */,
 				F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */,
 				599F25261D8BC9A1002871D6 /* String+RangeConversion.swift */,
 				599F25271D8BC9A1002871D6 /* UITextView+Helpers.swift */,
@@ -634,7 +634,7 @@
 				B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */,
 				599F25391D8BC9A1002871D6 /* InHTMLConverter.swift in Sources */,
 				599F25411D8BC9A1002871D6 /* EditableNode.swift in Sources */,
-				FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Encoding.swift in Sources */,
+				FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Archive.swift in Sources */,
 				599F253E1D8BC9A1002871D6 /* OutHTMLNodeConverter.swift in Sources */,
 				E109B51C1DC33F2C0099605E /* LayoutManager.swift in Sources */,
 				B5BC4FEE1DA2C17800614582 /* NSAttributedString+Lists.swift in Sources */,

--- a/Aztec/Classes/Extensions/NSAttributedString+Archive.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Archive.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-// MARK: - NSAttributedString Enconding methods
+// MARK: - NSAttributedString Archive methods
 //
 extension NSAttributedString
 {
     static let pastesboardUTI = "com.wordpress.aztec.attributedString"
 
-    func archiveToData() -> Data {
+    func archivedData() -> Data {
         let data = NSKeyedArchiver.archivedData(withRootObject: self)
         return data
     }
 
-    static func unarchive(fromData data: Data) -> NSAttributedString? {
+    static func unarchive(with data: Data) -> NSAttributedString? {
         let attributedString = NSKeyedUnarchiver.unarchiveObject(with: data) as? NSAttributedString
         return attributedString
     }

--- a/Aztec/Classes/Extensions/NSAttributedString+Encoding.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Encoding.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// MARK: - NSAttributedString Enconding methods
+//
+extension NSAttributedString
+{
+    static let pastesboardUTI = "com.wordpress.aztec.attributedString"
+
+    func archiveToData() -> Data {
+        let data = NSKeyedArchiver.archivedData(withRootObject: self)
+        return data
+    }
+
+    static func unarchive(fromData data: Data) -> NSAttributedString? {
+        let attributedString = NSKeyedUnarchiver.unarchiveObject(with: data) as? NSAttributedString
+        return attributedString
+    }
+    
+}

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -1,8 +1,20 @@
 import Foundation
 import UIKit
 
-class Blockquote {
+class Blockquote: NSObject, NSCoding {
     static let attributeName = "AZBlockquote"
+
+    public func encode(with aCoder: NSCoder) {
+
+    }
+
+    override public init() {
+
+    }
+
+    required public init?(coder aDecoder: NSCoder){
+
+    }
 }
 
 struct BlockquoteFormatter: ParagraphAttributeFormatter {

--- a/Aztec/Classes/Libxml2/DocumentObjectModel.swift
+++ b/Aztec/Classes/Libxml2/DocumentObjectModel.swift
@@ -155,7 +155,7 @@ extension Libxml2 {
             
             attributedString.enumerateAttributes(in: sourceRange, options: options) { (attributes, sourceSubrange, stop) in
                 
-                let subrangeWithOffset = NSRange(location: location, length: sourceSubrange.length)
+                let subrangeWithOffset = NSRange(location: location + sourceSubrange.location, length: sourceSubrange.length)
                 applyStyles(from: attributes as [String : AnyObject], to: subrangeWithOffset)
             }
         }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -12,8 +12,8 @@ open class ParagraphStyle: NSMutableParagraphStyle {
 
     public required init?(coder aDecoder: NSCoder) {
         textList = nil
-        if aDecoder.containsValue(forKey: String(describing:TextList.self)) {
-            let styleRaw = aDecoder.decodeInteger(forKey: String(describing:TextList.self))
+        if aDecoder.containsValue(forKey: String(describing: TextList.self)) {
+            let styleRaw = aDecoder.decodeInteger(forKey: String(describing: TextList.self))
             if let style = TextList.Style(rawValue:styleRaw) {
                 textList = TextList(style: style)
             }
@@ -24,7 +24,7 @@ open class ParagraphStyle: NSMutableParagraphStyle {
     override open func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
         if let textListSet = textList {
-            aCoder.encode(textListSet.style.rawValue, forKey: String(describing:TextList.self))
+            aCoder.encode(textListSet.style.rawValue, forKey: String(describing: TextList.self))
         }
     }
 

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -12,7 +12,20 @@ open class ParagraphStyle: NSMutableParagraphStyle {
 
     public required init?(coder aDecoder: NSCoder) {
         textList = nil
-        super.init()
+        if aDecoder.containsValue(forKey: String(describing:TextList.self)) {
+            let styleRaw = aDecoder.decodeInteger(forKey: String(describing:TextList.self))
+            if let style = TextList.Style(rawValue:styleRaw) {
+                textList = TextList(style: style)
+            }
+        }
+        super.init(coder: aDecoder)
+    }
+
+    override open func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        if let textListSet = textList {
+            aCoder.encode(textListSet.style.rawValue, forKey: String(describing:TextList.self))
+        }
     }
 
     override open func setParagraphStyle(_ obj: NSParagraphStyle) {

--- a/Aztec/Classes/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/TextKit/TextAttachment.swift
@@ -84,10 +84,49 @@ open class TextAttachment: NSTextAttachment
     ///
     required public init?(coder aDecoder: NSCoder) {
         identifier = ""
-        url = nil
         super.init(coder: aDecoder)
+        if let decodedIndentifier = aDecoder.decodeObject(forKey: EncodeKeys.identifier.rawValue) as? String {
+            identifier = decodedIndentifier
+        }
+        if aDecoder.containsValue(forKey: EncodeKeys.url.rawValue) {
+            url = aDecoder.decodeObject(forKey: EncodeKeys.url.rawValue) as? URL
+        }
+        if aDecoder.containsValue(forKey: EncodeKeys.alignment.rawValue) {
+            let alignmentRaw = aDecoder.decodeInteger(forKey: EncodeKeys.alignment.rawValue)
+            if let alignment = Alignment(rawValue:alignmentRaw) {
+                self.alignment = alignment
+            }
+        }
+        if aDecoder.containsValue(forKey: EncodeKeys.size.rawValue) {
+            let sizeRaw = aDecoder.decodeInteger(forKey: EncodeKeys.size.rawValue)
+            if let size = Size(rawValue:sizeRaw) {
+                self.size = size
+            }
+        }
     }
 
+    override init(data contentData: Data?, ofType uti: String?) {
+        identifier = ""
+        url = nil
+        super.init(data: contentData, ofType: uti)
+    }
+
+    override open func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        aCoder.encode(identifier, forKey: EncodeKeys.identifier.rawValue)
+        if let url = self.url {
+            aCoder.encode(url, forKey: EncodeKeys.url.rawValue)
+        }
+        aCoder.encode(alignment.rawValue, forKey: EncodeKeys.alignment.rawValue)
+        aCoder.encode(size.rawValue, forKey: EncodeKeys.size.rawValue)
+    }
+
+    fileprivate enum EncodeKeys: String {
+        case identifier
+        case url
+        case alignment
+        case size
+    }
     // MARK: - Origin calculation
 
     fileprivate func xPosition(forContainerWidth containerWidth: CGFloat) -> Int {
@@ -256,7 +295,7 @@ extension TextAttachment
 {
     /// Alignment
     ///
-    public enum Alignment {
+    public enum Alignment: Int {
         case none
         case left
         case center
@@ -289,7 +328,7 @@ extension TextAttachment
 
     /// Size Onscreen!
     ///
-    public enum Size {
+    public enum Size: Int {
         case thumbnail
         case medium
         case large

--- a/Aztec/Classes/TextKit/TextList.swift
+++ b/Aztec/Classes/TextKit/TextList.swift
@@ -10,7 +10,7 @@ class TextList: Equatable
 
     /// List Styles
     ///
-    enum Style {
+    enum Style: Int {
         case ordered
         case unordered
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -123,9 +123,8 @@ open class TextStorage: NSTextStorage {
                 return
             }
             
-            guard !(attachment is TextAttachment) else {
-                // Only replace plain NSTextAttachment objects.
-                //
+            if let textAttachment = attachment as? TextAttachment {
+                textAttachment.imageProvider = self
                 return
             }
             
@@ -170,7 +169,7 @@ open class TextStorage: NSTextStorage {
         textStore.replaceCharacters(in: range, with: processedString)
         edited([.editedAttributes, .editedCharacters], range: range, changeInLength: attrString.string.characters.count - range.length)
 
-        dom.replaceCharacters(inRange: range, withAttributedString: attrString, inheritStyle: false)
+        dom.replaceCharacters(inRange: range, withAttributedString: processedString, inheritStyle: false)
         
         endEditing()
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -84,7 +84,7 @@ open class TextView: UITextView {
 
     open override func copy(_ sender: Any?) {
         super.copy(sender)
-        let data = self.storage.attributedSubstring(from: selectedRange).archiveToData()
+        let data = self.storage.attributedSubstring(from: selectedRange).archivedData()
         let pasteboard  = UIPasteboard.general
         var items = pasteboard.items
         items[0][NSAttributedString.pastesboardUTI] = data
@@ -94,7 +94,7 @@ open class TextView: UITextView {
     open override func paste(_ sender: Any?) {
         let pasteboard  = UIPasteboard.general
         if let data = pasteboard.value(forPasteboardType: NSAttributedString.pastesboardUTI) as? Data,
-           let aztecString = NSAttributedString.unarchive(fromData: data) {
+           let aztecString = NSAttributedString.unarchive(with: data) {
             storage.replaceCharacters(in: selectedRange, with: aztecString)
         } else {
             super.paste(sender)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -82,6 +82,25 @@ open class TextView: UITextView {
 
     // MARK: - Intersect copy paste operations
 
+    open override func copy(_ sender: Any?) {
+        super.copy(sender)
+        let data = self.storage.attributedSubstring(from: selectedRange).archiveToData()
+        let pasteboard  = UIPasteboard.general
+        var items = pasteboard.items
+        items[0][NSAttributedString.pastesboardUTI] = data
+        pasteboard.items = items
+    }
+
+    open override func paste(_ sender: Any?) {
+        let pasteboard  = UIPasteboard.general
+        if let data = pasteboard.value(forPasteboardType: NSAttributedString.pastesboardUTI) as? Data,
+           let aztecString = NSAttributedString.unarchive(fromData: data) {
+            storage.replaceCharacters(in: selectedRange, with: aztecString)
+        } else {
+            super.paste(sender)
+        }
+    }
+
     // MARK: - Intersect keyboard operations
 
     open override func insertText(_ text: String) {


### PR DESCRIPTION
Fix #107 and #108

This PR implements support for NSCoding in all our custom attributes to allow them to be copy pasted, inside the editor.

It keeps the original pasteboard in place in order to allow other applications to work correctly when pasting in or copy out.

How to test:
 - Copy paste segments of text inside the editor from one place to another and check if the behaviour is correct.

Note: Lists and Blockquotes are still not updating the DOM so changes made are not reflected in the HTML view.

