### PR TITLE
Implement blockquotes with paragraph style

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 		B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FF51DA2D76600614582 /* TextList.swift */; };
 		B5E607331DA56EC700C8A389 /* TextListFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */; };
 		E109B51C1DC33F2C0099605E /* LayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E109B51B1DC33F2C0099605E /* LayoutManager.swift */; };
-		E11B77601DBA14B40024E455 /* BlockquteFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11B775F1DBA14B40024E455 /* BlockquteFormatterTests.swift */; };
+		E11B77601DBA14B40024E455 /* BlockquoteFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11B775F1DBA14B40024E455 /* BlockquoteFormatterTests.swift */; };
 		E11B77641DBA6ADC0024E455 /* AttributeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11B77631DBA6ADC0024E455 /* AttributeFormatter.swift */; };
 		E1C163A51DB6056B00E66A83 /* BlockquoteFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C163A41DB6056B00E66A83 /* BlockquoteFormatter.swift */; };
 		F11904A51D9D857500BFF9A1 /* TextNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */; };
@@ -157,7 +157,7 @@
 		B5BC4FF51DA2D76600614582 /* TextList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextList.swift; sourceTree = "<group>"; };
 		B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatterTests.swift; sourceTree = "<group>"; };
 		E109B51B1DC33F2C0099605E /* LayoutManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutManager.swift; sourceTree = "<group>"; };
-		E11B775F1DBA14B40024E455 /* BlockquteFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockquteFormatterTests.swift; sourceTree = "<group>"; };
+		E11B775F1DBA14B40024E455 /* BlockquoteFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockquoteFormatterTests.swift; sourceTree = "<group>"; };
 		E11B77631DBA6ADC0024E455 /* AttributeFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributeFormatter.swift; sourceTree = "<group>"; };
 		E1C163A41DB6056B00E66A83 /* BlockquoteFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockquoteFormatter.swift; sourceTree = "<group>"; };
 		F11904A41D9D857500BFF9A1 /* TextNodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextNodeTests.swift; sourceTree = "<group>"; };
@@ -462,7 +462,7 @@
 			isa = PBXGroup;
 			children = (
 				B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */,
-				E11B775F1DBA14B40024E455 /* BlockquteFormatterTests.swift */,
+				E11B775F1DBA14B40024E455 /* BlockquoteFormatterTests.swift */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -668,7 +668,7 @@
 				F11904A51D9D857500BFF9A1 /* TextNodeTests.swift in Sources */,
 				59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */,
 				594C9D721D8BE6BC00D74542 /* OutNodeConverterTests.swift in Sources */,
-				E11B77601DBA14B40024E455 /* BlockquteFormatterTests.swift in Sources */,
+				E11B77601DBA14B40024E455 /* BlockquoteFormatterTests.swift in Sources */,
 				599F25951D8BDCFC002871D6 /* AztecVisualEditorTests.swift in Sources */,
 				594C9D711D8BE6B800D74542 /* OutAttributeConverterTests.swift in Sources */,
 				59FEA06F1D8BDFA700D138DF /* OutHTMLConverterTests.swift in Sources */,

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -125,10 +125,10 @@ extension CharacterAttributeFormatter {
     func toggleAttribute(inTextView textView: UITextView, atRange range: NSRange) {
         let applicationRange = self.applicationRange(forRange: range, inString: textView.textStorage)
 
-        guard applicationRange.length > 0 else {
-            toggleTypingAttribute(inTextView: textView)
-            return
-        }
+//        guard applicationRange.length > 0 else {
+//            toggleTypingAttribute(inTextView: textView)
+//            return
+//        }
         toggleAttribute(inString: textView.textStorage, atRange: applicationRange)
     }
 }
@@ -144,11 +144,11 @@ extension ParagraphAttributeFormatter {
     func toggleAttribute(inTextView textView: UITextView, atRange range: NSRange) {
         let applicationRange = self.applicationRange(forRange: range, inString: textView.textStorage)
 
-        guard applicationRange.length > 0 else {
-            toggleTypingAttribute(inTextView: textView)
-            insertEmptyAttribute(inString: textView.textStorage, at: applicationRange.location)
-            return
-        }
+//        guard applicationRange.length > 0 else {
+//            toggleTypingAttribute(inTextView: textView)
+//            insertEmptyAttribute(inString: textView.textStorage, at: applicationRange.location)
+//            return
+//        }
         toggleAttribute(inString: textView.textStorage, atRange: applicationRange)
     }
 }

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -125,10 +125,9 @@ extension CharacterAttributeFormatter {
     func toggleAttribute(inTextView textView: UITextView, atRange range: NSRange) {
         let applicationRange = self.applicationRange(forRange: range, inString: textView.textStorage)
 
-//        guard applicationRange.length > 0 else {
-//            toggleTypingAttribute(inTextView: textView)
-//            return
-//        }
+        guard applicationRange.length > 0 || textView.textStorage.length > 0 else {
+            return
+        }
         toggleAttribute(inString: textView.textStorage, atRange: applicationRange)
     }
 }
@@ -144,11 +143,15 @@ extension ParagraphAttributeFormatter {
     func toggleAttribute(inTextView textView: UITextView, atRange range: NSRange) {
         let applicationRange = self.applicationRange(forRange: range, inString: textView.textStorage)
 
-//        guard applicationRange.length > 0 else {
-//            toggleTypingAttribute(inTextView: textView)
-//            insertEmptyAttribute(inString: textView.textStorage, at: applicationRange.location)
-//            return
-//        }
+        if applicationRange.length == 0 || textView.textStorage.length == 0 {
+            insertEmptyAttribute(inString: textView.textStorage, at: applicationRange.location)
+            textView.selectedRange = NSRange(location: applicationRange.location, length: 1)
+        }
         toggleAttribute(inString: textView.textStorage, atRange: applicationRange)
+    }
+
+    func applyAttribute(inTextView textView: UITextView, atRange range: NSRange) {
+        let applicationRange = self.applicationRange(forRange: range, inString: textView.textStorage)
+        applyAttributes(toString: textView.textStorage, atRange: applicationRange)
     }
 }

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -2,8 +2,6 @@ import Foundation
 import UIKit
 
 class Blockquote: NSObject, NSCoding {
-    static let attributeName = "AZBlockquote"
-
     public func encode(with aCoder: NSCoder) {
 
     }
@@ -19,21 +17,24 @@ class Blockquote: NSObject, NSCoding {
 
 struct BlockquoteFormatter: ParagraphAttributeFormatter {
     let attributes: [String: AnyObject] = {
-        let style = NSMutableParagraphStyle()
+        let style = ParagraphStyle()
         style.headIndent = Metrics.defaultIndentation
         style.firstLineHeadIndent = style.headIndent
         style.tailIndent = -Metrics.defaultIndentation
         style.paragraphSpacing = Metrics.defaultIndentation
         style.paragraphSpacingBefore = Metrics.defaultIndentation
+        style.blockquote = Blockquote()
 
         return [
-            NSParagraphStyleAttributeName: style,
-            Blockquote.attributeName: Blockquote()
+            NSParagraphStyleAttributeName: style            
         ]
     }()
 
     func present(inAttributes attributes: [String : AnyObject]) -> Bool {
-        return attributes[Blockquote.attributeName] is Blockquote
+        if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle {
+            return paragraphStyle.blockquote != nil
+        }
+        return false
     }
 }
 

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -13,6 +13,10 @@ class Blockquote: NSObject, NSCoding {
     required public init?(coder aDecoder: NSCoder){
 
     }
+
+    static func ==(lhs: Blockquote, rhs: Blockquote) -> Bool {
+        return true
+    }
 }
 
 struct BlockquoteFormatter: ParagraphAttributeFormatter {

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -15,9 +15,13 @@ class LayoutManager: NSLayoutManager {
         }
 
         let characterRange = self.characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
-        textStorage.enumerateAttribute(Blockquote.attributeName, in: characterRange, options: []){ (object, range, stop) in
-            guard object is Blockquote else {
-                return
+
+        //draw blockquotes
+        textStorage.enumerateAttribute(NSParagraphStyleAttributeName, in: characterRange, options: []){ (object, range, stop) in
+            guard let paragraphStyle = object as? ParagraphStyle,
+                let _ = paragraphStyle.blockquote
+                else {
+                    return
             }
 
             let borderColor = UIColor(red: 0.5294117647, green: 0.650980392156863, blue: 0.737254902, alpha: 1.0)

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -7,22 +7,18 @@ open class ParagraphStyle: NSMutableParagraphStyle {
     var blockquote: Blockquote?
 
     override init() {
-        textList = nil
-        blockquote = nil
         super.init()
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        textList = nil
-        blockquote = nil
         if aDecoder.containsValue(forKey: String(describing: TextList.self)) {
             let styleRaw = aDecoder.decodeInteger(forKey: String(describing: TextList.self))
             if let style = TextList.Style(rawValue:styleRaw) {
                 textList = TextList(style: style)
             }
         }
-        if aDecoder.containsValue(forKey: String(describing:Blockquote.self)) {
-            blockquote = aDecoder.decodeObject(forKey: String(describing:Blockquote.self)) as? Blockquote            
+        if aDecoder.containsValue(forKey: String(describing: Blockquote.self)) {
+            blockquote = aDecoder.decodeObject(forKey: String(describing: Blockquote.self)) as? Blockquote
         }
         super.init(coder: aDecoder)
     }
@@ -34,7 +30,7 @@ open class ParagraphStyle: NSMutableParagraphStyle {
         }
 
         if let blockquote = self.blockquote {
-            aCoder.encode(blockquote, forKey: String(describing:Blockquote.self))
+            aCoder.encode(blockquote, forKey: String(describing: Blockquote.self))
         }
     }
 

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -4,19 +4,25 @@ import UIKit
 open class ParagraphStyle: NSMutableParagraphStyle {
 
     var textList: TextList?
+    var blockquote: Blockquote?
 
     override init() {
         textList = nil
+        blockquote = nil
         super.init()
     }
 
     public required init?(coder aDecoder: NSCoder) {
         textList = nil
+        blockquote = nil
         if aDecoder.containsValue(forKey: String(describing:TextList.self)) {
             let styleRaw = aDecoder.decodeInteger(forKey: String(describing:TextList.self))
             if let style = TextList.Style(rawValue:styleRaw) {
                 textList = TextList(style: style)
             }
+        }
+        if aDecoder.containsValue(forKey: String(describing:Blockquote.self)) {
+            blockquote = aDecoder.decodeObject(forKey: String(describing:Blockquote.self)) as? Blockquote            
         }
         super.init(coder: aDecoder)
     }
@@ -26,11 +32,16 @@ open class ParagraphStyle: NSMutableParagraphStyle {
         if let textListSet = textList {
             aCoder.encode(textListSet.style.rawValue, forKey: String(describing:TextList.self))
         }
+
+        if let blockquote = self.blockquote {
+            aCoder.encode(blockquote, forKey: String(describing:Blockquote.self))
+        }
     }
 
     override open func setParagraphStyle(_ obj: NSParagraphStyle) {
         if let paragrahStyle = obj as? ParagraphStyle {
             textList = paragrahStyle.textList
+            blockquote = paragrahStyle.blockquote
         }
         super.setParagraphStyle(obj)
     }
@@ -85,6 +96,22 @@ open class ParagraphStyle: NSMutableParagraphStyle {
             return false
         }
 
+        if blockquote == nil || otherParagraph.blockquote == nil {
+            return super.isEqual(object)
+        }
+
+        if blockquote == nil && otherParagraph.blockquote != nil {
+            return false
+        }
+
+        if blockquote != nil && otherParagraph.blockquote == nil {
+            return false
+        }
+
+        if blockquote! != otherParagraph.blockquote! {
+            return false
+        }
+
         return super.isEqual(object)
     }
 
@@ -97,7 +124,7 @@ open class ParagraphStyle: NSMutableParagraphStyle {
         let thisResult = ParagraphStyle()
         thisResult.setParagraphStyle(result as! NSParagraphStyle)
         thisResult.textList = textList
-
+        thisResult.blockquote = blockquote
         return thisResult
     }
 
@@ -106,7 +133,7 @@ open class ParagraphStyle: NSMutableParagraphStyle {
         let thisResult = ParagraphStyle()
         thisResult.setParagraphStyle(result as! NSParagraphStyle)
         thisResult.textList = textList
-
+        thisResult.blockquote = blockquote
         return thisResult
     }
 
@@ -115,6 +142,6 @@ open class ParagraphStyle: NSMutableParagraphStyle {
     }
 
     open override var description:String {
-        return super.description + "\nTextList:\(textList?.style)"
+        return super.description + "\nTextList:\(textList?.style)\nBlockquote:\(blockquote)"
     }
 }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -80,37 +80,14 @@ open class ParagraphStyle: NSMutableParagraphStyle {
             return false
         }
 
-        if textList == nil || otherParagraph.textList == nil {
-            return super.isEqual(object)
-        }
-
-        if textList == nil && otherParagraph.textList != nil {
+        if textList != otherParagraph.textList {
             return false
         }
 
-        if textList != nil && otherParagraph.textList == nil {
+        if blockquote != otherParagraph.blockquote {
             return false
         }
 
-        if textList! != otherParagraph.textList! {
-            return false
-        }
-
-        if blockquote == nil || otherParagraph.blockquote == nil {
-            return super.isEqual(object)
-        }
-
-        if blockquote == nil && otherParagraph.blockquote != nil {
-            return false
-        }
-
-        if blockquote != nil && otherParagraph.blockquote == nil {
-            return false
-        }
-
-        if blockquote! != otherParagraph.blockquote! {
-            return false
-        }
 
         return super.isEqual(object)
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -108,7 +108,7 @@ open class TextView: UITextView {
         super.insertText(text)
         insertionRange.length = 1
         refreshListAfterInsertionOf(text: text, range: insertionRange)
-        refreshBlockquotesAfterInsertionOf(text: text, range: insertionRange)
+        refreshBlockquoteAfterInsertionOf(text: text, range: insertionRange)
     }
 
     open override func deleteBackward() {
@@ -129,6 +129,7 @@ open class TextView: UITextView {
         }
 
         refreshListAfterDeletionOf(text: deletedString, atRange: deletionRange)
+        refreshBlockquoteAfterDeletionOf(text: deletedString, atRange: deletionRange)
     }
 
     // MARK: - UIView Overrides
@@ -459,11 +460,7 @@ open class TextView: UITextView {
             return
         }
 
-        var isPreviousLocationList = false
-        if (range.location > 0) {
-            isPreviousLocationList = storage.textListAttribute(atIndex: range.location - 1) != nil
-        }
-        if !isPreviousLocationList {
+        if (range.location == 0) {
             removeList(aroundRange: range)
         }
     }
@@ -509,12 +506,29 @@ open class TextView: UITextView {
         formatter.toggleAttribute(inTextView: self, atRange: range)
     }
 
+    /// Refresh Lists attributes when text is deleted in the specified range
+    ///
+    /// - Parameters:
+    ///   - text: the text being added
+    ///   - range: the range of the insertion of the new text
+    private func refreshBlockquoteAfterDeletionOf(text deletedText: NSAttributedString, atRange range:NSRange) {
+        let formatter = BlockquoteFormatter()
+        guard formatter.attribute(inTextView: self, at: range.location),
+            deletedText.string == "\n" || range.location == 0 else {
+                return
+        }
+
+        if (range.location == 0) {
+            formatter.toggleAttribute(inTextView: self, atRange: range)
+        }
+    }
+
     /// Refresh blockquotes attributes when inserting new text in the specified range
     ///
     /// - Parameters:
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
-    private func refreshBlockquotesAfterInsertionOf(text:String, range:NSRange) {
+    private func refreshBlockquoteAfterInsertionOf(text:String, range:NSRange) {
         let formatter = BlockquoteFormatter()
         guard formatter.attribute(inTextView: self, at: range.location) else {
             return

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -511,6 +511,7 @@ open class TextView: UITextView {
     /// - Parameters:
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
+    ///
     private func refreshBlockquoteAfterDeletionOf(text deletedText: NSAttributedString, atRange range:NSRange) {
         let formatter = BlockquoteFormatter()
         guard formatter.attribute(inTextView: self, at: range.location),
@@ -528,7 +529,8 @@ open class TextView: UITextView {
     /// - Parameters:
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
-    private func refreshBlockquoteAfterInsertionOf(text:String, range:NSRange) {
+    ///
+    private func refreshBlockquoteAfterInsertionOf(text: String, range:NSRange) {
         let formatter = BlockquoteFormatter()
         guard formatter.attribute(inTextView: self, at: range.location) else {
             return

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -108,6 +108,7 @@ open class TextView: UITextView {
         super.insertText(text)
         insertionRange.length = 1
         refreshListAfterInsertionOf(text: text, range: insertionRange)
+        refreshBlockquotesAfterInsertionOf(text: text, range: insertionRange)
     }
 
     open override func deleteBackward() {
@@ -126,15 +127,8 @@ open class TextView: UITextView {
         if storage.string.isEmpty {
             return
         }
-        if deletedString.string == "\n" || deletionRange.location == 0 {
-            var isPreviousLocationList = false
-            if (selectedRange.location > 0) {
-                isPreviousLocationList = storage.textListAttribute(atIndex: selectedRange.location - 1) != nil
-            }
-            if !isPreviousLocationList {
-                removeList(aroundRange: selectedRange)
-            }
-        }
+
+        refreshListAfterDeletionOf(text: deletedString, atRange: deletionRange)
     }
 
     // MARK: - UIView Overrides
@@ -454,6 +448,26 @@ open class TextView: UITextView {
         }
     }
 
+    /// Refresh Lists attributes when text is deleted in the specified range
+    ///
+    /// - Parameters:
+    ///   - text: the text being added
+    ///   - range: the range of the insertion of the new text
+    private func refreshListAfterDeletionOf(text deletedText: NSAttributedString, atRange range:NSRange) {
+        guard deletedText.textListAttribute(atIndex: 0) != nil,
+              deletedText.string == "\n" || range.location == 0 else {
+            return
+        }
+
+        var isPreviousLocationList = false
+        if (range.location > 0) {
+            isPreviousLocationList = storage.textListAttribute(atIndex: range.location - 1) != nil
+        }
+        if !isPreviousLocationList {
+            removeList(aroundRange: range)
+        }
+    }
+
     fileprivate func removeList(aroundRange range: NSRange) {
         let formatter = TextListFormatter()
         formatter.removeList(inString: storage, atRange: range)
@@ -493,6 +507,42 @@ open class TextView: UITextView {
     open func toggleBlockquote(range: NSRange) {
         let formatter = BlockquoteFormatter()
         formatter.toggleAttribute(inTextView: self, atRange: range)
+    }
+
+    /// Refresh blockquotes attributes when inserting new text in the specified range
+    ///
+    /// - Parameters:
+    ///   - text: the text being added
+    ///   - range: the range of the insertion of the new text
+    private func refreshBlockquotesAfterInsertionOf(text:String, range:NSRange) {
+        let formatter = BlockquoteFormatter()
+        guard formatter.attribute(inTextView: self, at: range.location) else {
+            return
+        }
+
+        let afterRange = NSRange(location: range.location + 1, length: 1)
+        let beforeRange = NSRange(location: range.location - 1, length: 1)
+
+        var afterString = "\n"
+        var beforeString = "\n"
+        if beforeRange.location >= 0 {
+            beforeString = storage.attributedSubstring(from: beforeRange).string
+        }
+        if afterRange.endLocation < storage.length {
+            afterString = storage.attributedSubstring(from: afterRange).string
+        }
+
+        let isBegginingOfListItem = storage.isStartOfNewLine(atLocation: range.location)
+
+        if text == "\n" && beforeString == "\n" && afterString == "\n" && isBegginingOfListItem {
+            formatter.toggleAttribute(inTextView: self, atRange: range)
+            if afterRange.endLocation < storage.length {
+                formatter.toggleAttribute(inTextView: self, atRange: afterRange)
+                deleteBackward()
+            } else {
+                selectedRange = NSRange(location: range.location, length: 0)
+            }
+        }
     }
 
 

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Gridicons
 @testable import Aztec
 
-class BlockquteFormatterTests: XCTestCase {
+class BlockquoteFormatterTests: XCTestCase {
     func testApplyingBlockquoteOnFirstParagraph() {
         let textView = testTextView
         let paragraphs = paragraphRanges(inString: textView.storage)
@@ -61,7 +61,7 @@ class BlockquteFormatterTests: XCTestCase {
     }
 }
 
-private extension BlockquteFormatterTests {
+private extension BlockquoteFormatterTests {
     var testTextView: TextView {
         let view = TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: Gridicon.iconOfType(.image))
         view.text = plainText
@@ -81,7 +81,8 @@ private extension BlockquteFormatterTests {
 
     func existsBlockquote(for string: NSMutableAttributedString, in range: NSRange) -> Bool {
         var effectiveRange = NSRange()
-        guard string.attribute(Blockquote.attributeName, at: range.location, effectiveRange: &effectiveRange) != nil else {
+        guard let paragraphStyle = string.attribute(NSParagraphStyleAttributeName, at: range.location, effectiveRange: &effectiveRange) as? ParagraphStyle,
+            let _ = paragraphStyle.blockquote else {
             return false
         }
         // Blockquote attribute spans the whole range


### PR DESCRIPTION
Fix #76 #145 

This PR implements blockquotes using a custom paragraph style

How to test:
 - Add and remove block quote styles to ranges of text
 - Play around by adding or removing lines
 - Test the case where two new lines are inserted in a row and see if block quote is close

Notes:
 - Still not implements updates of the DOM nodes
 - At the moment it's not possible to combine block quotes and list it's one or the other.