### PR TITLE
Implement the list attributes using the same protocols has block quotes.

### DIFF
--- a/Aztec/Classes/Constants/Metrics.swift
+++ b/Aztec/Classes/Constants/Metrics.swift
@@ -7,7 +7,9 @@ import Foundation
 enum Metrics
 {
 
-    static let defaultIndentation = CGFloat(20)
+    static let defaultIndentation = CGFloat(12)
     static let maxIndentation = CGFloat(200)
+    static let tabStepInterval = 8
+    static let tabStepCount = 12
 
 }

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -211,17 +211,17 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         }
 
         if node.isNodeType(.ol) {
-            let listParagraph = ParagraphStyle.defaultList
-            let textList = TextList(style: .ordered)
-            listParagraph.textList = textList
-            attributes[NSParagraphStyleAttributeName] = listParagraph
+            let formatter = TextListFormatter(style: .ordered)
+            for (key, value) in formatter.attributes {
+                attributes[key] = value
+            }
         }
 
         if node.isNodeType(.ul) {
-            let listParagraph = ParagraphStyle.defaultList
-            let textList = TextList(style: .unordered)
-            listParagraph.textList = textList
-            attributes[NSParagraphStyleAttributeName] = listParagraph
+            let formatter = TextListFormatter(style: .unordered)
+            for (key, value) in formatter.attributes {
+                attributes[key] = value
+            }
         }
 
         return attributes

--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -309,51 +309,6 @@ extension NSAttributedString
         }
     }
 
-
-    /// Returns a new NSAttributedString, with the required TextListItem attribute applied.
-    ///
-    /// - Parameters:
-    ///     - style: The type of text list.
-    ///     - itemNumber: The index of the item. This is used to number a numeric list item.
-    ///
-    /// - Return: An NSAttributedString.
-    ///
-    func attributedStringByApplyingListItemAttributes(ofStyle style: TextList.Style, withNumber number: Int) -> NSAttributedString {
-        // Begin by removing any existing list marker.
-        guard let output = attributedStringByRemovingListItemAttributes().mutableCopy() as? NSMutableAttributedString else {
-            return self
-        }
-
-        // TODO: Need to accomodate RTL languages too.
-
-        // Set the attributes for the list item style
-        let listItem = TextList(style: style)
-        //listItem.number = number
-        let paragraphStyle = ParagraphStyle.defaultList
-        paragraphStyle.textList = listItem
-        let listItemAttributes: [String: AnyObject] = [
-            NSParagraphStyleAttributeName: paragraphStyle
-        ]
-
-        output.addAttributes(listItemAttributes, range: output.rangeOfEntireString)
-
-        return output
-    }
-
-    /// Returns a new Attributed String, with the TextListItem formatting removed.
-    ///
-    func attributedStringByRemovingListItemAttributes() -> NSAttributedString {
-        let clean = NSMutableAttributedString(attributedString: self)
-
-        let range = clean.rangeOfEntireString
-
-        // Fall back to TextKit's default Paragraph Style
-        let paragraphStyle = ParagraphStyle.default
-        clean.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: range)
-
-        return clean
-    }
-
     /// Internal convenience helper. Returns the internal string as a NSString instance
     ///
     fileprivate var foundationString: NSString {

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -150,8 +150,12 @@ extension ParagraphAttributeFormatter {
         toggleAttribute(inString: textView.textStorage, atRange: applicationRange)
     }
 
-    func applyAttribute(inTextView textView: UITextView, atRange range: NSRange) {
-        let applicationRange = self.applicationRange(forRange: range, inString: textView.textStorage)
-        applyAttributes(toString: textView.textStorage, atRange: applicationRange)
+    func toggleAttribute(inText text: NSMutableAttributedString, atRange range: NSRange) {
+        let applicationRange = self.applicationRange(forRange: range, inString: text)
+
+        if applicationRange.length == 0 || text.length == 0 {
+            insertEmptyAttribute(inString: text, at: applicationRange.location)
+        }
+        toggleAttribute(inString: text, atRange: applicationRange)
     }
 }

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -1,290 +1,33 @@
 import Foundation
 import UIKit
 
+struct TextListFormatter: ParagraphAttributeFormatter {
 
-// MARK: - A helper for handling the formatting of ordered and unordered lists.
-//
-class TextListFormatter
-{
-    /// Creates a new text list, or modifies an existing text list.
-    ///
-    /// - Parameters
-    ///     - ofStyle: The kind of List to apply
-    ///     - inString: The NSMutableAttributed string to modify.
-    ///     - atRange: The range at which to apply the list style.
-    ///
-    /// - Returns: An NSRange representing the change to the attributed string.
-    ///
-    @discardableResult
-    func toggleList(ofStyle style: TextList.Style, inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
-        // Load Paragraph Ranges
-        let paragraphRanges = string.paragraphRanges(spanningRange: range)
-        guard paragraphRanges.isEmpty == false else {
-            return nil
-        }
+    let listStyle: TextList.Style
 
-        // 1st Paragraph: No List >> Apply, skipping paragraphs that currently contain TextLists
-        guard let listRange = string.rangeOfTextList(atIndex: paragraphRanges[0].location) else {
-            let filtered = string.filterListRanges(paragraphRanges, notMatchingStyle: style)
-            return applyLists(ofStyle: style, toString: string, atNonContiguousRanges: filtered)
-        }
-
-        // 1st Paragraph: Matching List Style >> Remove
-        guard let listAttribute = string.textListAttribute(spanningRange: listRange), listAttribute.style != style else {
-            return removeList(fromString: string, atRanges: paragraphRanges)
-        }
-
-        // 1st Paragraph: Non Matching Style >> Update!
-        let listParagraphs = string.paragraphRanges(spanningRange: listRange)
-        return applyList(ofStyle: style, toString: string, atRanges: listParagraphs)
+    init(style: TextList.Style) {
+        self.listStyle = style
     }
 
-    /// Updates the list attributes on the specified range
-    ///
-    /// - Parameters:
-    ///   - string: the string to update
-    ///   - range: the range where to check for list
-    /// - Returns: the total range that was affected by the method
-    ///
-    @discardableResult
-    func updatesList(inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
+    var attributes: [String: AnyObject] {
+        get {
+            let style = ParagraphStyle()
+            style.headIndent = Metrics.defaultIndentation
+            style.firstLineHeadIndent = style.headIndent
+            style.textList = TextList(style: self.listStyle)
 
-        var styleOptional: TextList.Style?
-        // Load Paragraph Ranges
-
-        var paragraphRanges = string.paragraphRanges(spanningRange: range)
-        if paragraphRanges.count == 0 {
-            if let paragraphRange = string.rangeOfLine(atIndex: range.location) {
-                paragraphRanges.append(paragraphRange)
-            }
+            return [
+                NSParagraphStyleAttributeName: style
+            ]
         }
-        guard let firstParagraphRange = paragraphRanges.first else {
-            return nil
-        }
-        if let paragraphAttribute = string.attribute(NSParagraphStyleAttributeName, at: firstParagraphRange.location, effectiveRange: nil) as? ParagraphStyle,
-           let textList = paragraphAttribute.textList {
-            styleOptional = textList.style
-        }
-
-        guard let style = styleOptional else {
-            return removeList(fromString: string, atRanges: [firstParagraphRange])
-        }
-
-
-        guard let listRange = string.rangeOfTextList(atIndex: firstParagraphRange.location) else {
-            return nil
-        }
-
-        let listParagraphs = string.paragraphRanges(spanningRange: listRange)
-        return applyList(ofStyle: style, toString: string, atRanges: listParagraphs)
     }
 
-
-    /// Removes any list attributes on the provided string that exist on the specified range.
-    /// This method also updates any surrounding lists of the specified range
-    ///
-    /// - Parameters:
-    ///   - string: the string to update
-    ///   - range: the range to where remove the list attributes
-    /// - Returns: the total range that was affected by this method
-    ///
-    @discardableResult
-    func removeList(inString string: NSMutableAttributedString, atRange range: NSRange) -> NSRange? {
-        let paragraphRange = string.paragraphRange(for: range)
-        return removeList(fromString: string, atRanges: [paragraphRange])
+    func present(inAttributes attributes: [String : AnyObject]) -> Bool {
+        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
+              let textList = paragraphStyle.textList else {
+            return false
+        }
+        return textList.style == listStyle
     }
 }
 
-
-// MARK: - Private Helpers
-//
-private extension TextListFormatter
-{
-    /// Applies a TextList attribute to the specified non contiguous ranges.
-    ///
-    /// - Parameters:
-    ///     - style: Style of TextList to be applied.
-    ///     - string: Target String.
-    ///     - ranges: Segments of the receiver string to be transformed into lists.
-    ///
-    /// - Returns: The affected NSRange, or nil if no changes were made.
-    ///
-    /// - Notes: The returned NSRange, if any, will *INCLUDE* any String Ranges that lie between the non contiguous
-    ///   groups. Specifically...
-    ///
-    ///     [Line 1]  Text                          [Line 1]  1. Text
-    ///     [Line 2]  - Unordered List      >>      [Line 2]  - Unordered List
-    ///     [Line 3]  More Text                     [Line 3]  1. More Text
-    ///     [Line 4]  Something Else                [Line 4]  Something Else
-    ///
-    ///   Calling ApplyLists over Lines 1-3 should produce the results at the right hand, and lines 1-3 should
-    ///   remain selected. Capicci?
-    ///
-    func applyLists(ofStyle style: TextList.Style, toString string: NSMutableAttributedString, atNonContiguousRanges ranges: [NSRange]) -> NSRange? {
-        guard let first = ranges.first, let last = ranges.last else {
-            return nil
-        }
-
-        let grouped = groupContiguousRanges(ranges)
-        var textLengthDelta = 0
-
-        for group in grouped.reversed() {
-            // Apply List Style to the current group
-            guard let listRange = applyList(ofStyle: style, toString: string, atRanges: group) else {
-                continue
-            }
-
-            // Calculate the Length Delta between SUM(group.range.length) and "EFFECTIVE List Length"
-            textLengthDelta += calculateLengthDelta(betweenContiguousRanges: group, andConsolidatedRange: listRange)
-        }
-
-        // Simply calculate the "Effective List Range"
-        let length = last.endLocation - first.location + textLengthDelta
-        return NSRange(location: first.location, length: length)
-    }
-
-
-    /// Applies a TextList attribute to the specified paragraph ranges in the
-    /// specified string. Each paragraph range is treated as a list item.
-    ///
-    /// - Parameters:
-    ///     - ofStyle: The kind of List to apply
-    ///     - toString: The NSMutableAttributedString to manipulate.
-    ///     - atRanges: The paragraph ranges to operate upon. Each range becomes a list item.
-    ///     - startingAt: The starting item number for an ordered list.
-    ///
-    /// - Returns: The affected NSRange, or nil if no changes were made.
-    ///
-    @discardableResult
-    func applyList(ofStyle style: TextList.Style, toString string: NSMutableAttributedString, atRanges range: [NSRange], startingAt number: Int = 1) -> NSRange? {
-        // Adjust Ranges: Add preceeding + following ranges, if needed
-        let adjustedRanges = string.paragraphRanges(preceedingAndSucceding: range, matchingListStyle: style)
-        guard let startingLocation = adjustedRanges.first?.location else {
-            return nil
-        }
-
-        // TextListItem: Apply to each one of the paragraphs
-        var length = 0
-
-        string.beginEditing()
-
-        for (index, range) in adjustedRanges.enumerated().reversed() {
-            let number = index + number
-            let unformatted = string.attributedSubstring(from: range)
-            let formatted = unformatted.attributedStringByApplyingListItemAttributes(ofStyle: style, withNumber: number)
-
-            string.replaceCharacters(in: range, with: formatted)
-            length += formatted.length
-        }
-
-        let listRange = NSRange(location: startingLocation, length: length)
-        // Done Editing!
-        string.endEditing()
-
-        return listRange
-    }
-
-
-    /// Removes TextList attributes from the specified ranges in the specified string.
-    ///
-    /// - Parameters:
-    ///     - froMString: The NSMutableAttributed string to modify.
-    ///     - atRanges: The ranges to modify.
-    ///
-    /// - Returns: The NSRange of the changes.
-    ///
-    func removeList(fromString string: NSMutableAttributedString, atRanges ranges: [NSRange]) -> NSRange? {
-        guard let firstRange = ranges.first else {
-            return nil
-        }
-        
-        var length = 0
-
-        for range in ranges.reversed() {
-            let formatted = string.attributedSubstring(from: range)
-            let clean = formatted.attributedStringByRemovingListItemAttributes()
-
-            string.replaceCharacters(in: range, with: clean)
-            length += clean.length
-        }
-
-        // Update the (SUCCEDING) List, if needed.
-        let adjustedRange = NSRange(location: firstRange.location, length: length)
-        updateList(inString: string, succeedingRange: adjustedRange)
-
-        return adjustedRange
-    }
-
-
-    /// Updates the TextListTpe for a TextList at the specified index.
-    ///
-    /// - Parameters:
-    ///     - inString: An NSMutableAttributedString to modify.
-    ///     - atIndex: An index intersecting the TextList within `attrString`.
-    ///     - toStyle: The type of list to become.
-    ///
-    func updateList(inString string: NSMutableAttributedString, succeedingRange range: NSRange) {
-        // Update its markers if the following range was an ordered list
-        let nextListIndex = NSMaxRange(range) + 1
-
-        guard nextListIndex < string.length else {
-            return
-        }
-
-        guard let nextListAttribute = string.textListAttribute(atIndex: nextListIndex), nextListAttribute.style != .unordered else {
-            return
-        }
-
-        let nextListParagraphs = string.paragraphRanges(atIndex: nextListIndex, matchingListStyle: nextListAttribute.style)
-        applyList(ofStyle: nextListAttribute.style, toString: string, atRanges: nextListParagraphs)
-    }
-}
-
-
-// MARK: - Private Helpers
-//
-private extension TextListFormatter
-{
-    /// This helper groups contiguous ranges, and returns each group inside their own array.
-    ///
-    /// - Parameter ranges: The ranges to be grouped.
-    ///
-    /// - Returns: An array of grouped contiguous-ranges.
-    ///
-    func groupContiguousRanges(_ ranges: [NSRange]) -> [[NSRange]] {
-        var grouped = [[NSRange]]()
-        var current = [NSRange]()
-        var last: NSRange?
-
-        for range in ranges {
-            if let endLocation = last?.endLocation, range.location != endLocation {
-                grouped.append(current)
-                current.removeAll()
-                last = nil
-            }
-
-            current.append(range)
-            last = range
-        }
-
-        if !current.isEmpty {
-            grouped.append(current)
-        }
-        
-        return grouped
-    }
-
-
-    /// Calculates the difference, in length, between a group of contiguous ranges, and another NSRange instance.
-    ///
-    /// - Parameters:
-    ///     - contiguous: Collection of contiguous NSRange instances.
-    ///     - consolidated: A single NSRange instance.
-    ///
-    /// - Returns: Delta between the SUM(contiguous.length) and consolidated.length
-    ///
-    func calculateLengthDelta(betweenContiguousRanges contiguous: [NSRange], andConsolidatedRange consolidated: NSRange) -> Int {
-        let contiguousLength = contiguous.reduce(0) { $0 + $1.length }
-        return consolidated.length - contiguousLength
-    }
-}

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -84,6 +84,9 @@ open class ParagraphStyle: NSMutableParagraphStyle {
         let originalCopy = super.copy(with: zone) as! NSParagraphStyle
         let copy = ParagraphStyle()
         copy.setParagraphStyle(originalCopy)
+        copy.textList = textList
+        copy.blockquote = blockquote
+
         return copy
     }
 
@@ -91,6 +94,9 @@ open class ParagraphStyle: NSMutableParagraphStyle {
         let originalCopy = super.mutableCopy(with: zone) as! NSParagraphStyle
         let copy = ParagraphStyle()
         copy.setParagraphStyle(originalCopy)
+        copy.textList = textList
+        copy.blockquote = blockquote
+
         return copy
     }
 

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -35,23 +35,20 @@ open class ParagraphStyle: NSMutableParagraphStyle {
     }
 
     override open func setParagraphStyle(_ obj: NSParagraphStyle) {
+        super.setParagraphStyle(obj)
         if let paragrahStyle = obj as? ParagraphStyle {
             textList = paragrahStyle.textList
             blockquote = paragrahStyle.blockquote
         }
-        super.setParagraphStyle(obj)
     }
 
-    private static let tabStepInterval = 8
-    private static let tabStepCount    = 12
-    
     open override class var `default`: NSParagraphStyle {
         let style = ParagraphStyle()
 
         var tabStops = [NSTextTab]()
 
-        for intervalNumber in (1 ..< tabStepCount) {
-            let location = intervalNumber * tabStepInterval
+        for intervalNumber in (1 ..< Metrics.tabStepCount) {
+            let location = intervalNumber * Metrics.tabStepInterval
             let textTab = NSTextTab(textAlignment: .natural, location: CGFloat(location), options: [:])
 
             tabStops.append(textTab)
@@ -59,15 +56,6 @@ open class ParagraphStyle: NSMutableParagraphStyle {
 
         style.tabStops = tabStops
 
-        return style
-    }
-
-    class var defaultList : ParagraphStyle {
-        let style = ParagraphStyle()
-        style.setParagraphStyle(self.default)
-
-        style.headIndent = 12
-        style.firstLineHeadIndent = style.headIndent        
         return style
     }
 
@@ -93,21 +81,17 @@ open class ParagraphStyle: NSMutableParagraphStyle {
     }
 
     open override func copy(with zone: NSZone? = nil) -> Any {
-        let result = super.copy(with: zone)
-        let thisResult = ParagraphStyle()
-        thisResult.setParagraphStyle(result as! NSParagraphStyle)
-        thisResult.textList = textList
-        thisResult.blockquote = blockquote
-        return thisResult
+        let originalCopy = super.copy(with: zone) as! NSParagraphStyle
+        let copy = ParagraphStyle()
+        copy.setParagraphStyle(originalCopy)
+        return copy
     }
 
     open override func mutableCopy(with zone: NSZone? = nil) -> Any {
-        let result = super.mutableCopy(with: zone)
-        let thisResult = ParagraphStyle()
-        thisResult.setParagraphStyle(result as! NSParagraphStyle)
-        thisResult.textList = textList
-        thisResult.blockquote = blockquote
-        return thisResult
+        let originalCopy = super.mutableCopy(with: zone) as! NSParagraphStyle
+        let copy = ParagraphStyle()
+        copy.setParagraphStyle(originalCopy)
+        return copy
     }
 
     var debugString: String {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -476,11 +476,7 @@ open class TextView: UITextView {
     ///
     open func toggleOrderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .ordered)
-        var applyRange = range
-        if let fullRange = self.textStorage.rangeOfTextList(atIndex: range.location) {
-            applyRange = fullRange
-        }
-        formatter.toggleAttribute(inTextView: self, atRange: applyRange)
+        formatter.toggleAttribute(inTextView: self, atRange: range)
     }
 
 
@@ -490,11 +486,7 @@ open class TextView: UITextView {
     ///
     open func toggleUnorderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .unordered)
-        var applyRange = range
-        if let fullRange = self.textStorage.rangeOfTextList(atIndex: range.location) {
-            applyRange = fullRange
-        }
-        formatter.toggleAttribute(inTextView: self, atRange: applyRange)
+        formatter.toggleAttribute(inTextView: self, atRange: range)
     }
 
     // MARK: - Blockquotes

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -420,7 +420,7 @@ open class TextView: UITextView {
     ///   - range: the range of the insertion of the new text
     private func refreshListAfterInsertionOf(text:String, range:NSRange) {
         //check if new text is part of a list
-        if storage.textListAttribute(atIndex: range.location) == nil {
+        guard let textList = storage.textListAttribute(atIndex: range.location) else {
             return
         }
 
@@ -439,9 +439,9 @@ open class TextView: UITextView {
         let isBegginingOfListItem = storage.isStartOfNewLine(atLocation: range.location)
 
         if text == "\n" && beforeString == "\n" && afterString == "\n" && isBegginingOfListItem {
-            removeList(aroundRange: range)
+            remove(list:textList, at: range)
             if afterRange.endLocation < storage.length {
-                removeList(aroundRange: afterRange)
+                remove(list: textList, at: afterRange)
                 deleteBackward()
             } else {
                 selectedRange = NSRange(location: range.location, length: 0)
@@ -455,19 +455,19 @@ open class TextView: UITextView {
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
     private func refreshListAfterDeletionOf(text deletedText: NSAttributedString, atRange range:NSRange) {
-        guard deletedText.textListAttribute(atIndex: 0) != nil,
+        guard let textList = deletedText.textListAttribute(atIndex: 0),
               deletedText.string == "\n" || range.location == 0 else {
             return
         }
 
         if (range.location == 0) {
-            removeList(aroundRange: range)
+            remove(list: textList, at: range)
         }
     }
 
-    fileprivate func removeList(aroundRange range: NSRange) {
-        let formatter = TextListFormatter()
-        formatter.removeList(inString: storage, atRange: range)
+    fileprivate func remove(list: TextList, at range: NSRange) {
+        let formatter = TextListFormatter(style: list.style)
+        formatter.toggleAttribute(inTextView: self, atRange: range)
     }
 
     /// Adds or removes a ordered list style from the specified range.
@@ -475,9 +475,12 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleOrderedList(range: NSRange) {
-        let appliedRange = rangeForTextList(range)
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .ordered, inString: storage, atRange: appliedRange)
+        let formatter = TextListFormatter(style: .ordered)
+        var applyRange = range
+        if let fullRange = self.textStorage.rangeOfTextList(atIndex: range.location) {
+            applyRange = fullRange
+        }
+        formatter.toggleAttribute(inTextView: self, atRange: applyRange)
     }
 
 
@@ -486,9 +489,12 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleUnorderedList(range: NSRange) {
-        let appliedRange = rangeForTextList(range)
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .unordered, inString: storage, atRange: appliedRange)
+        let formatter = TextListFormatter(style: .unordered)
+        var applyRange = range
+        if let fullRange = self.textStorage.rangeOfTextList(atIndex: range.location) {
+            applyRange = fullRange
+        }
+        formatter.toggleAttribute(inTextView: self, atRange: applyRange)
     }
 
     // MARK: - Blockquotes

--- a/AztecTests/Extensions/NSAttributedStringListsTests.swift
+++ b/AztecTests/Extensions/NSAttributedStringListsTests.swift
@@ -473,48 +473,6 @@ class NSAttributedStringListsTests: XCTestCase {
             }
         }
     }
-
-    /// Tests that `attributedStringByApplyingListItemAttributes` effectively applies a ParagrahStyle.
-    ///
-    /// Set up:
-    /// - Plain raw string
-    ///
-    /// Expected result:
-    /// - TextListItem Style + Marker
-    ///
-    func testAttributedStringByApplyingListItemAttributesEffectivelyAppliesListItemStyle() {
-        let original = sampleSingleLine
-        let applied = original.attributedStringByApplyingListItemAttributes(ofStyle: .ordered, withNumber: 5)
-
-        for index in (0 ..< applied.length) {
-            let item = applied.textListAttribute(atIndex: index)
-            XCTAssertNotNil(item)
-        }        
-    }
-
-    /// Tests that `attributedStringByApplyingListItemAttributes` effectively removes the TextListItem Attribute.
-    ///
-    /// Set up:
-    /// - Attributed String with a TextItem style
-    ///
-    /// Expected result:
-    /// - No style after running the clean method
-    ///
-    func testAttributedStringByRemovingListItemAttributesEffectivelyNukesListItemStyle() {
-        let original = sampleSingleLine
-        let applied = original.attributedStringByApplyingListItemAttributes(ofStyle: .unordered, withNumber: 2)
-        let clean = applied.attributedStringByRemovingListItemAttributes()
-
-        for index in (0 ..< applied.length) {
-            let item = applied.textListAttribute(atIndex: index)
-            XCTAssertNotNil(item)
-        }
-
-        for index in (0 ..< clean.length) {
-            let nothing = clean.textListAttribute(atIndex: index)
-            XCTAssertNil(nothing)
-        }
-    }
 }
 
 
@@ -544,7 +502,7 @@ extension NSAttributedStringListsTests
             "Yay!")
 
         let range = (sample.string as NSString).range(of: sampleListContents)
-        let listParagraphStyle = ParagraphStyle.defaultList
+        let listParagraphStyle = ParagraphStyle()
         listParagraphStyle.textList = TextList(style: .ordered)
         let attributes = [NSParagraphStyleAttributeName: listParagraphStyle]
         sample.addAttributes(attributes, range: range)

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -83,8 +83,8 @@ class TextListFormatterTests: XCTestCase
     func testApplyingOrderedListOnFirstParagraphAppliesOrderedList() {
         let string = NSMutableAttributedString(string: plainText)
 
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .ordered, inString: string, atRange: NSRange(location: 0, length: 1))
+        let formatter = TextListFormatter(style: .ordered)
+        formatter.toggleAttribute(inText: string, atRange: NSRange(location: 0, length: 1))
 
         let ranges = paragraphRanges(inString: string)
         let lists = textListAttributes(inString: string, atRanges: ranges)
@@ -110,13 +110,13 @@ class TextListFormatterTests: XCTestCase
     func testRemovingOrderedListOnFirstParagraphEffectivelyNukesAnyLists() {
         let string = NSMutableAttributedString(string: plainText)
 
-        let formatter = TextListFormatter()
+        let formatter = TextListFormatter(style: .ordered)
 
         // Toggle the 1st line as an Ordered List
-        formatter.toggleList(ofStyle: .ordered, inString: string, atRange: NSRange(location: 0, length: 1))
+        formatter.toggleAttribute(inText: string, atRange: NSRange(location: 0, length: 1))
 
         // And... undo?
-        formatter.toggleList(ofStyle: .ordered, inString: string, atRange: NSRange(location: 0, length: 1))
+        formatter.toggleAttribute(inText: string, atRange: NSRange(location: 0, length: 1))
 
         let ranges = paragraphRanges(inString: string)
         let lists = textListAttributes(inString: string, atRanges: ranges)
@@ -140,8 +140,8 @@ class TextListFormatterTests: XCTestCase
         let list = listWithOrderedStyle
         let ranges = paragraphRanges(inString: list)
 
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .ordered, inString: list, atRange: ranges[0])
+        let formatter = TextListFormatter(style: .ordered)
+        formatter.toggleAttribute(inText: list, atRange: ranges[0])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -173,10 +173,9 @@ class TextListFormatterTests: XCTestCase
         let ranges = paragraphRanges(inString: list)
 
         // Toggle Ordered List on the first line
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .unordered, inString: list, atRange: ranges[2])
+        let formatter = TextListFormatter(style: .unordered)
+        formatter.toggleAttribute(inText: list, atRange: ranges[2])
 
-        //
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
         XCTAssert(lists.count == 4)
@@ -200,24 +199,20 @@ class TextListFormatterTests: XCTestCase
     //  Line 4:     4 [Text]            - [Text]
     //  Line 5:     5 [Text]            - [Text]
     //
-    // Toggling "Unordered List" on Line 1 should switch everything to an Unordered List
+    // Toggling "Unordered List" on Line 1 should switch only that element to an Unordered List
     //
     func testToggleUnorderedListOnFirstOrderedListItemUpdatesTheRemainingItemNumbers() {
         let list = listWithOrderedStyle
         let ranges = paragraphRanges(inString: list)
 
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .unordered, inString: list, atRange: ranges[0])
+        let formatter = TextListFormatter(style: .unordered)
+        formatter.toggleAttribute(inText: list, atRange: ranges[0])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
         XCTAssert(lists.count == 5)
 
         XCTAssert(lists[0].style == .unordered)
-        XCTAssert(lists[1].style == .unordered)
-        XCTAssert(lists[2].style == .unordered)
-        XCTAssert(lists[3].style == .unordered)
-        XCTAssert(lists[4].style == .unordered)
     }
 
 
@@ -238,10 +233,9 @@ class TextListFormatterTests: XCTestCase
         let ranges = paragraphRanges(inString: list)
 
         // Toggle Ordered List on the first line
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .ordered, inString: list, atRange: ranges[0])
+        let formatter = TextListFormatter(style: .ordered)
+        formatter.toggleAttribute(inText: list, atRange: ranges[0])
 
-        //
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
         XCTAssert(ranges.count == plainTextParagraphLines.count)
@@ -267,14 +261,14 @@ class TextListFormatterTests: XCTestCase
     //  Line 4:     1 [Text]            1 [Text]
     //  Line 5:     - [Text]            - [Text]
     //
-    // Toggling "Ordered List" on Lines 1-5 should convert Line 1 into an Ordered List, and skip the rest.
+    // Toggling "Ordered List" on Lines 1-5 should convert all lines to  ordered List.
     //
     func testToggleListAppliesTheNewStyleOnTheFirstParagraphWhenTheFirstRangeContainsAnotherListOfDifferentStyle() {
         let list = listWithAlternatedStyle
 
         // Toggle Ordered List on the full string's range
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .ordered, inString: list, atRange: list.rangeOfEntireString)
+        let formatter = TextListFormatter(style: .ordered)
+        formatter.toggleAttribute(inText: list, atRange: list.rangeOfEntireString)
 
         // Verify we got a single big orderedList
         let ranges = paragraphRanges(inString: list)
@@ -282,13 +276,13 @@ class TextListFormatterTests: XCTestCase
 
         XCTAssert(lists[0].style == .ordered)
         XCTAssert(lists[1].style == .ordered)
-        XCTAssert(lists[2].style == .unordered)
+        XCTAssert(lists[2].style == .ordered)
         XCTAssert(lists[3].style == .ordered)
-        XCTAssert(lists[4].style == .unordered)
+        XCTAssert(lists[4].style == .ordered)
 
         XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 1)
         XCTAssert(list.itemNumber(in: lists[1], at: ranges[1].location) == 2)
-        XCTAssert(list.itemNumber(in: lists[3], at: ranges[3].location) == 1)
+        XCTAssert(list.itemNumber(in: lists[3], at: ranges[3].location) == 4)
 
     }
 
@@ -306,15 +300,15 @@ class TextListFormatterTests: XCTestCase
     //
     func testToggleOrderedListOnPlainTextFollowedByOrderedListUpdatesAllOfTheItemNumbers() {
         let string = NSMutableAttributedString(string: plainText)
-        let formatter = TextListFormatter()
+        let formatter = TextListFormatter(style: .ordered)
 
         // Apply the Ordered List style to the last three paragraphs
         for (index, range) in paragraphRanges(inString: string).enumerated() where index >= 2 {
-            formatter.toggleList(ofStyle: .ordered, inString: string, atRange: range)
+            formatter.toggleAttribute(inText: string, atRange: range)
         }
 
         // Now... toggle an Ordered List on the full text
-        formatter.toggleList(ofStyle: .ordered, inString: string, atRange: string.rangeOfEntireString)
+        formatter.toggleAttribute(inText: string, atRange: string.rangeOfEntireString)
 
         // Verify
         let paragraphs = paragraphRanges(inString: string)
@@ -338,19 +332,19 @@ class TextListFormatterTests: XCTestCase
     //  Line 4:       [Text]            1 [Text]
     //  Line 5:       [Text]            2 [Text]
     //
-    // Toggling "Ordered List" on lines 1-5 creates new lists on the selected paragraphs, skipping any lists
-    // that don't match the new style.
+    // Toggling "Ordered List" on lines 1-5 creates new lists on the selected paragraphs,
     //
     func testToggleOrderedListOnParagraphIntersectingUnorderedListEffectivelySkipsListWithNoMatchingStyle() {
         let string = NSMutableAttributedString(string: plainText)
-        let formatter = TextListFormatter()
+        let unorderedListFormatter = TextListFormatter(style: .unordered)
+        let orderedListFormatter = TextListFormatter(style: .ordered)
 
         // Line 3 > Unordered List
         let ranges = paragraphRanges(inString: string)
-        formatter.toggleList(ofStyle: .unordered, inString: string, atRange: ranges[2])
+        unorderedListFormatter.toggleAttribute(inText: string, atRange: ranges[2])
 
         // Entire Text > Ordered List
-        formatter.toggleList(ofStyle: .ordered, inString: string, atRange: string.rangeOfEntireString)
+        orderedListFormatter.toggleAttribute(inText: string, atRange: string.rangeOfEntireString)
 
         // Verify
         let paragraphs = paragraphRanges(inString: string)
@@ -361,15 +355,8 @@ class TextListFormatterTests: XCTestCase
                 return
             }
 
-            if index == 2 {
-                XCTAssert(list.style == .unordered)
-                continue
-            }
-
-            // Map (0, 1) > (1, 2) and (3, 4) > (1, 2)
-            let number = (index < 2) ? (index + 1) : (index - 2)
-            XCTAssert(string.itemNumber(in: list, at: range.location) == number)
             XCTAssert(list.style == .ordered)
+            XCTAssert(string.itemNumber(in: list, at: range.location) == index+1)
         }
     }
 
@@ -389,8 +376,8 @@ class TextListFormatterTests: XCTestCase
         let list = listWithAlternatedStyle
 
         // Toggle Ordered List on the full string's range
-        let formatter = TextListFormatter()
-        formatter.toggleList(ofStyle: .unordered, inString: list, atRange: list.rangeOfEntireString)
+        let formatter = TextListFormatter(style: .unordered)
+        formatter.toggleAttribute(inText: list, atRange: list.rangeOfEntireString)
 
         // Verify we got a single big orderedList
         let ranges = paragraphRanges(inString: list)
@@ -405,22 +392,24 @@ class TextListFormatterTests: XCTestCase
     //
     //  Line 1:     - [Text]            1 [Text]
     //  Line 2:     - [Text]            2 [Text]
-    //  Line 3:       [Text]    > > >     [Text]
-    //  Line 4:       [Text]              [Text]
-    //  Line 5:       [Text]              [Text]
+    //  Line 3:       [Text]    > > >   3 [Text]
+    //  Line 4:       [Text]            4 [Text]
+    //  Line 5:       [Text]            5 [Text]
     //
-    // Toggling "Ordered List" on Lines 1-5 should only switch Lines 1 and 2 to Ordered Lists.
+    // Toggling "Ordered List" on Lines 1-5 should switch all lines to Ordered Lists.
     //
     func testToggleListChangesTheStyleWhenTheFirstTwoSelectedParagraphsHaveDifferentStyles() {
         let list = NSMutableAttributedString(string: plainText)
         let plainRanges = plainTextParagraphRanges
-        let formatter = TextListFormatter()
+        let unorderedListFormatter = TextListFormatter(style: .unordered)
+        let orderedListFormatter = TextListFormatter(style: .ordered)
+
 
         // First TWO lines: Unordered List
         let length = plainRanges[1].location + plainRanges[1].length
         let range = NSRange(location: 0, length: length)
 
-        formatter.toggleList(ofStyle: .unordered, inString: list, atRange: range)
+        unorderedListFormatter.toggleAttribute(inText: list, atRange: range)
 
         let textList = list.textListAttribute(atIndex: 0)
         XCTAssert(textList != nil)
@@ -428,12 +417,12 @@ class TextListFormatterTests: XCTestCase
         XCTAssert(NSEqualRanges(list.range(of: textList!, at: 0)!,range))
 
         // Toggle
-        formatter.toggleList(ofStyle: .ordered, inString: list, atRange: list.rangeOfEntireString)
+        orderedListFormatter.toggleAttribute(inText: list, atRange: list.rangeOfEntireString)
 
         // Verify
         let items = textListAttributes(inString: list, atRanges: paragraphRanges(inString: list))
 
-        XCTAssert(items.count == 2)
+        XCTAssert(items.count == 5)
 
         XCTAssert(list.itemNumber(in: items[0], at: 0) == 1)
         XCTAssert(list.itemNumber(in: items[0], at: 13)  == 2)
@@ -465,22 +454,23 @@ private extension TextListFormatterTests
 
     var listWithOrderedStyle: NSMutableAttributedString {
         let string = NSMutableAttributedString(string: plainText)
-        let formatter = TextListFormatter()
+        let formatter = TextListFormatter(style: .ordered)
 
-        formatter.toggleList(ofStyle: .ordered, inString: string, atRange: string.rangeOfEntireString)
+        formatter.toggleAttribute(inText: string, atRange: string.rangeOfEntireString)
 
         return string
     }
 
     var listWithAlternatedStyle: NSMutableAttributedString {
         let string = NSMutableAttributedString(string: plainText)
-        let formatter = TextListFormatter()
-        var style = Style.unordered
+        let unorderedListFormatter = TextListFormatter(style: .unordered)
+        let orderedListFormatter = TextListFormatter(style: .ordered)
+        var currentFormatter = unorderedListFormatter
 
         for range in plainTextParagraphRanges.reversed() {
-            formatter.toggleList(ofStyle: style, inString: string, atRange: range)
+            currentFormatter.toggleAttribute(inText: string, atRange: range)
 
-            style = (style == .unordered) ? .ordered : .unordered
+            currentFormatter = (currentFormatter.listStyle == .unordered) ? orderedListFormatter : unorderedListFormatter
         }
 
         return string


### PR DESCRIPTION
This PR consolidates our formatters to use the same set of protocols allows to get less code and a more consistent approach to paragraph attributes.

How to test:

- Apply list attributes to paragraph and check if the behaviour is correct.

Note:

This changes some of the requirements of lists defined on #34 :

- Scenario 5: all paragraphs get the style applied
- Scenario 6: all paragraphs get the style applied
- Scenario 7: all paragraphs get the style applied

I actually think this is more consistent behaviour, but lets evaluate. If we really need that behaviour we can add it to the standard attributes protocol.