### PR TITLE
Check for valid glyph index before trying to access it.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -143,9 +143,12 @@ open class TextView: UITextView {
 
     open override func caretRect(for position: UITextPosition) -> CGRect {
         let characterIndex = offset(from: beginningOfDocument, to: position)
+        var caretRect = super.caretRect(for: position)
+        guard layoutManager.isValidGlyphIndex(characterIndex) else {
+            return caretRect
+        }
         let glyphIndex = layoutManager.glyphIndexForCharacter(at: characterIndex)
         let usedLineFragment = layoutManager.lineFragmentUsedRect(forGlyphAt: glyphIndex, effectiveRange: nil)
-        var caretRect = super.caretRect(for: position)
         if !usedLineFragment.isEmpty {
             caretRect.origin.y = usedLineFragment.origin.y + textContainerInset.top
             caretRect.size.height = usedLineFragment.size.height


### PR DESCRIPTION
How to test:

 - Start the demo app
 - Move the cursor to the end of the text
 - Check if the cursor shows up correctly
 - Check if the following warnings on the console stop showing up.
```2016-12-12 15:03:16.803 AztecExample[65536:2235645] !!! _NSLayoutTreeLineFragmentUsedRectForGlyphAtIndex invalid glyph index 2146
2016-12-12 15:03:17.211 AztecExample[65536:2235645] !!! _NSLayoutTreeLineFragmentUsedRectForGlyphAtIndex invalid glyph index 2146
2016-12-12 15:03:17.217 AztecExample[65536:2235645] !!! _NSLayoutTreeLineFragmentUsedRectForGlyphAtIndex invalid glyph index 2146
2016-12-12 15:03:17.220 AztecExample[65536:2235645] !!! _NSLayoutTreeLineFragmentUsedRectForGlyphAtIndex invalid glyph index 2146
2016-12-12 15:03:17.220 AztecExample[65536:2235645] !!! _NSLayoutTreeLineFragmentUsedRectForGlyphAtIndex invalid glyph index 2146```