### PR TITLE
Fixing Format Bar

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -338,6 +338,22 @@ open class TextView: UITextView {
             identifiers.append(.strikethrough)
         }
 
+        if typingAttributesContainsBlockquote() {
+            identifiers.append(.blockquote)
+        }
+
+        if typingAttributesContainsOrderedList() {
+            identifiers.append(.orderedlist)
+        }
+
+        if typingAttributesContainsUnorderedList() {
+            identifiers.append(.unorderedlist)
+        }
+
+        if typingAttributesContainsLink() {
+            identifiers.append(.link)
+        }
+
         return identifiers
     }
 
@@ -1045,6 +1061,36 @@ open class TextView: UITextView {
     ///
     open func typingAttributesContainsUnderline() -> Bool {
         return typingAttributes[NSUnderlineStyleAttributeName] != nil
+    }
+
+
+    /// Checks if the next character that the user types will be formatted as Blockquote, or not.
+    ///
+    open func typingAttributesContainsBlockquote() -> Bool {
+        let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle
+        return paragraphStyle?.blockquote != nil
+    }
+
+
+    /// Checks if the next character that the user types will be formatted as an Ordered List, or not.
+    ///
+    open func typingAttributesContainsOrderedList() -> Bool {
+        let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle
+        return paragraphStyle?.textList?.style == .ordered
+    }
+
+
+    /// Checks if the next character that the user types will be formatted as an Unordered List, or not.
+    ///
+    open func typingAttributesContainsUnorderedList() -> Bool {
+        let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle
+        return paragraphStyle?.textList?.style == .unordered
+    }
+
+    /// Checks if the next character that the user types will be part of a link anchor, or not.
+    ///
+    open func typingAttributesContainsLink() -> Bool {
+        return typingAttributes[NSLinkAttributeName] != nil
     }
 
 


### PR DESCRIPTION
### Details:
This PR fixes an issue introduced in #171, which caused the Format Bar not to properly reflect the typing attributes, whenever the cursor is within a Blockquote / List / Link.

### Testing:
- Place the cursor over a Blockquote / List / Link.
- Verify that the Format Bar lights up as expected.

Needs Review: @diegoreymendez 
cc @SergioEstevao 

Thanks for spotting this Sergio!
