### PR TITLE
Paste and Match Style

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -64,6 +64,7 @@ open class TextView: UITextView {
         container.widthTracksTextView = true
         super.init(frame: CGRect(x: 0, y: 0, width: 10, height: 10), textContainer: container)
         commonInit()
+        setupMenuController()
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -72,6 +73,7 @@ open class TextView: UITextView {
         defaultMissingImage = Gridicon.iconOfType(.image)
         super.init(coder: aDecoder)
         commonInit()
+        setupMenuController()
     }
 
     private func commonInit() {
@@ -79,6 +81,13 @@ open class TextView: UITextView {
         storage.attachmentsDelegate = self
         font = defaultFont
     }
+
+    private func setupMenuController() {
+        let pasteAndMatchTitle = NSLocalizedString("Paste and Match Style", comment: "Paste and Match Menu Item")
+        let pasteAndMatchItem = UIMenuItem(title: pasteAndMatchTitle, action: #selector(pasteAndMatchStyle))
+        UIMenuController.shared.menuItems = [pasteAndMatchItem]
+    }
+
 
     // MARK: - Intersect copy paste operations
 
@@ -99,6 +108,15 @@ open class TextView: UITextView {
         } else {
             super.paste(sender)
         }
+    }
+
+    open func pasteAndMatchStyle(_ sender: Any?) {
+        guard let plainString = UIPasteboard.general.string else {
+            super.paste(sender)
+            return
+        }
+
+        storage.replaceCharacters(in: selectedRange, with: plainString)
     }
 
     // MARK: - Intersect keyboard operations

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -111,7 +111,7 @@ open class TextView: UITextView {
     }
 
     open func pasteAndMatchStyle(_ sender: Any?) {
-        guard let plainString = UIPasteboard.general.string else {
+        guard let plainString = UIPasteboard.general.string, plainString.isEmpty == false else {
             super.paste(sender)
             return
         }


### PR DESCRIPTION
### Details:
This PR adds the ability to Paste and Match the surrounding text's style. What we're doing here is:
- Adding a new `UIMenuController` item
- Simply grabbing the `UIPasteboard`'s string property, if any
- If there's no string property to be found, we'll fallback to the default behavior

### Testing:
1. Launch the Demo App
2. Switch over to Safari / Notes / Reminders
3. Copy some random text
4. Switch back to Aztec's Demo
5. Try the new `Paste and Match Style` action

Note that the original string's style should be striped out.

Needs Review: @diegoreymendez 
