### PR TITLE
Issue/178 combine lists with bloquotes

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -45,7 +45,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    fileprivate func convert(_ node: Node, inheritingAttributes attributes: [String:AnyObject]) -> NSAttributedString {
+    fileprivate func convert(_ node: Node, inheritingAttributes attributes: [String:Any]) -> NSAttributedString {
 
         if let textNode = node as? TextNode {
             return convertTextNode(textNode, inheritingAttributes: attributes)
@@ -68,7 +68,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    fileprivate func convertTextNode(_ node: TextNode, inheritingAttributes inheritedAttributes: [String:AnyObject]) -> NSAttributedString {
+    fileprivate func convertTextNode(_ node: TextNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
         return NSAttributedString(string: node.text(), attributes: inheritedAttributes)
     }
 
@@ -80,7 +80,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes inheritedAttributes: [String:AnyObject]) -> NSAttributedString {
+    fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
         return NSAttributedString(string: node.text(), attributes: inheritedAttributes)
     }
 
@@ -92,7 +92,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    fileprivate func convertElementNode(_ node: ElementNode, inheritingAttributes attributes: [String:AnyObject]) -> NSAttributedString {
+    fileprivate func convertElementNode(_ node: ElementNode, inheritingAttributes attributes: [String:Any]) -> NSAttributedString {
         return stringForNode(node, inheritingAttributes: attributes)
     }
 
@@ -107,7 +107,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the attributed string representing the specified element node.
     ///
     ///
-    fileprivate func stringForNode(_ node: ElementNode, inheritingAttributes inheritedAttributes: [String:AnyObject]) -> NSAttributedString {
+    fileprivate func stringForNode(_ node: ElementNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
 
         let content = NSMutableAttributedString()
         let childAttributes = attributes(forNode: node, inheritingAttributes: inheritedAttributes)
@@ -138,7 +138,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
     ///
-    fileprivate func attributes(forNode node: ElementNode, inheritingAttributes inheritedAttributes: [String:AnyObject]) -> [String:AnyObject] {
+    fileprivate func attributes(forNode node: ElementNode, inheritingAttributes inheritedAttributes: [String:Any]) -> [String:Any] {
 
         var attributes = inheritedAttributes
 
@@ -180,9 +180,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         if isBlockquote(node) {
             let formatter = BlockquoteFormatter()
-            for (key, value) in formatter.attributes {
-                attributes[key] = value
-            }
+            attributes = formatter.apply(toAttributes:attributes)
         }
 
         if isImage(node) {
@@ -212,16 +210,12 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         if node.isNodeType(.ol) {
             let formatter = TextListFormatter(style: .ordered)
-            for (key, value) in formatter.attributes {
-                attributes[key] = value
-            }
+            attributes = formatter.apply(toAttributes: attributes)
         }
 
         if node.isNodeType(.ul) {
             let formatter = TextListFormatter(style: .unordered)
-            for (key, value) in formatter.attributes {
-                attributes[key] = value
-            }
+            attributes = formatter.apply(toAttributes: attributes)
         }
 
         return attributes

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -13,11 +13,17 @@ protocol AttributeFormatter {
     ///
     func present(inAttributes attributes: [String: AnyObject]) -> Bool
 
-    /// Apply the compound attribute represents to the provided list.
+    /// Apply the compound attributes to the provided attributes dictionary
+    ///
+    /// - Parameter attributes: the original attributes to apply to
+    /// - Returns: the resulting attributes dictionary
     ///
     func apply(toAttributes attributes:[String: Any]) -> [String: Any]
 
-    /// Remove attributes from the provided list.
+    /// Remove the compound attributes from the provided list.
+    ///
+    /// - Parameter attributes: the original attributes to remove from
+    /// - Returns: the resulting attributes dictionary
     ///
     func remove(fromAttributes attributes:[String: Any]) -> [String: Any]
 

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -13,9 +13,13 @@ protocol AttributeFormatter {
     ///
     func present(inAttributes attributes: [String: AnyObject]) -> Bool
 
-    /// The list of attributes that the compound attribute represents.
+    /// Apply the compound attribute represents to the provided list.
     ///
-    var attributes: [String: AnyObject] { get }
+    func apply(toAttributes attributes:[String: Any]) -> [String: Any]
+
+    /// Remove attributes from the provided list.
+    ///
+    func remove(fromAttributes attributes:[String: Any]) -> [String: Any]
 
     /// The range to apply the attributes to.
     ///
@@ -76,15 +80,11 @@ private extension AttributeFormatter {
     }
 
     func addTypingAttribute(toTextView textView: UITextView) {
-        for (key, value) in attributes {
-            textView.typingAttributes[key] = value
-        }
+        textView.typingAttributes = apply(toAttributes: textView.typingAttributes)
     }
 
     func removeTypingAttribute(fromTextView textView: UITextView) {
-        for (key, _) in attributes  {
-            textView.typingAttributes.removeValue(forKey: key)
-        }
+        textView.typingAttributes = remove(fromAttributes: textView.typingAttributes)
     }
 
     func toggleAttribute(inString string: NSMutableAttributedString, atRange range: NSRange) {
@@ -96,13 +96,15 @@ private extension AttributeFormatter {
     }
 
     func applyAttributes(toString string: NSMutableAttributedString, atRange range: NSRange) {
+        let currentAttributes = string.attributes(at: range.location, effectiveRange: nil)
+        let attributes = apply(toAttributes: currentAttributes)
         string.addAttributes(attributes, range: range)
     }
 
     func removeAttributes(fromString string: NSMutableAttributedString, atRange range: NSRange) {
-        for (attribute, _) in attributes {
-            string.removeAttribute(attribute, range: range)
-        }
+        let currentAttributes = string.attributes(at: range.location, effectiveRange: nil)
+        let attributes = remove(fromAttributes: currentAttributes)
+        string.addAttributes(attributes, range: range)
     }
 
     func attribute(inString string: NSAttributedString, at index: Int) -> Bool {
@@ -111,6 +113,7 @@ private extension AttributeFormatter {
     }
 
     func insertEmptyAttribute(inString string: NSMutableAttributedString, at index: Int) {
+        let attributes = apply(toAttributes: [:])
         let attributedSpace = NSAttributedString(string: placeholderForAttributedEmptyLine, attributes: attributes)
         string.insert(attributedSpace, at: index)
     }

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -20,19 +20,41 @@ class Blockquote: NSObject, NSCoding {
 }
 
 struct BlockquoteFormatter: ParagraphAttributeFormatter {
-    let attributes: [String: AnyObject] = {
-        let style = ParagraphStyle()
-        style.headIndent = Metrics.defaultIndentation
-        style.firstLineHeadIndent = style.headIndent
-        style.tailIndent = -Metrics.defaultIndentation
-        style.paragraphSpacing = Metrics.defaultIndentation
-        style.paragraphSpacingBefore = Metrics.defaultIndentation
-        style.blockquote = Blockquote()
 
-        return [
-            NSParagraphStyleAttributeName: style            
-        ]
-    }()
+
+    func apply(toAttributes attributes: [String : Any]) -> [String: Any] {
+        var resultingAttributes = attributes
+        let newParagraphStyle = ParagraphStyle()
+        if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
+            newParagraphStyle.setParagraphStyle(paragraphStyle)
+        }
+        newParagraphStyle.headIndent += Metrics.defaultIndentation
+        newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+        newParagraphStyle.tailIndent -= Metrics.defaultIndentation
+        newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
+        newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
+        newParagraphStyle.blockquote = Blockquote()
+        resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
+        return resultingAttributes
+    }
+
+    func remove(fromAttributes attributes:[String: Any]) -> [String: Any] {
+        var resultingAttributes = attributes
+        let newParagraphStyle = ParagraphStyle()
+        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
+            paragraphStyle.blockquote != nil else {
+            return resultingAttributes
+        }
+        newParagraphStyle.setParagraphStyle(paragraphStyle)
+        newParagraphStyle.headIndent -= Metrics.defaultIndentation
+        newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+        newParagraphStyle.tailIndent += Metrics.defaultIndentation
+        newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
+        newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
+        newParagraphStyle.blockquote = nil
+        resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
+        return resultingAttributes
+    }
 
     func present(inAttributes attributes: [String : AnyObject]) -> Bool {
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle {

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -9,17 +9,35 @@ struct TextListFormatter: ParagraphAttributeFormatter {
         self.listStyle = style
     }
 
-    var attributes: [String: AnyObject] {
-        get {
-            let style = ParagraphStyle()
-            style.headIndent = Metrics.defaultIndentation
-            style.firstLineHeadIndent = style.headIndent
-            style.textList = TextList(style: self.listStyle)
-
-            return [
-                NSParagraphStyleAttributeName: style
-            ]
+    func apply(toAttributes attributes: [String : Any]) -> [String: Any] {
+        var resultingAttributes = attributes
+        let newParagraphStyle = ParagraphStyle()
+        if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
+            newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
+        if newParagraphStyle.textList == nil {
+            newParagraphStyle.headIndent += Metrics.defaultIndentation
+            newParagraphStyle.firstLineHeadIndent += Metrics.defaultIndentation
+        }
+        newParagraphStyle.textList = TextList(style: self.listStyle)
+        resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
+        return resultingAttributes
+    }
+
+    func remove(fromAttributes attributes:[String: Any]) -> [String: Any] {
+        var resultingAttributes = attributes
+        let newParagraphStyle = ParagraphStyle()
+        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
+            paragraphStyle.textList?.style == self.listStyle
+        else {
+            return resultingAttributes
+        }
+        newParagraphStyle.setParagraphStyle(paragraphStyle)
+        newParagraphStyle.headIndent -= Metrics.defaultIndentation
+        newParagraphStyle.firstLineHeadIndent -= Metrics.defaultIndentation
+        newParagraphStyle.textList = nil
+        resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
+        return resultingAttributes
     }
 
     func present(inAttributes attributes: [String : AnyObject]) -> Bool {

--- a/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/StandardElementType.swift
@@ -77,7 +77,7 @@ extension Libxml2 {
             return implicitRepresentation(forContent: NSAttributedString(string:content), attributes: [:] ).string
         }
 
-        func implicitRepresentation(forContent content: NSAttributedString, attributes:[String:AnyObject]) -> NSAttributedString {
+        func implicitRepresentation(forContent content: NSAttributedString, attributes:[String:Any]) -> NSAttributedString {
 
             let resultString = NSMutableAttributedString(attributedString: content)
             switch self {

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -72,9 +72,10 @@ class LayoutManager: NSLayoutManager {
                 let isStartOfLine = textStorage.isStartOfNewLine(atLocation: lineRange.location)
                 let attributes = textStorage.attributes(at: lineRange.location, effectiveRange: nil)
                 if isStartOfLine {
+                    let markerRect = lineRect.offsetBy(dx: paragraphStyle.headIndent - Metrics.defaultIndentation, dy: paragraphStyle.paragraphSpacingBefore)
                     let markerAttributes = self.markerAttributesBasedOnParagraph(attributes: attributes)
                     let markerText = NSAttributedString(string:textList.style.markerText(forItemNumber: number), attributes:markerAttributes)
-                    markerText.draw(in: lineRect)
+                    markerText.draw(in: markerRect)
                 }
             }
         }

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -18,7 +18,9 @@ class BlockquoteFormatterTests: XCTestCase {
         let paragraphs = paragraphRanges(inString: textView.storage)
 
         let formatter = BlockquoteFormatter()
-        textView.storage.setAttributes(formatter.attributes, range: paragraphs[0])
+        var attributes = [String:Any]()
+        attributes = formatter.apply(toAttributes: attributes)
+        textView.storage.setAttributes(attributes, range: paragraphs[0])
         formatter.toggleAttribute(inTextView: textView, atRange: NSRange(location: 1, length: 1))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
@@ -29,7 +31,9 @@ class BlockquoteFormatterTests: XCTestCase {
         let paragraphs = paragraphRanges(inString: textView.storage)
 
         let formatter = BlockquoteFormatter()
-        textView.storage.setAttributes(formatter.attributes, range: paragraphs[1])
+        var attributes = [String:Any]()
+        attributes = formatter.apply(toAttributes: attributes)
+        textView.storage.setAttributes(attributes, range: paragraphs[1])
         formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
@@ -41,7 +45,9 @@ class BlockquoteFormatterTests: XCTestCase {
         let paragraphs = paragraphRanges(inString: textView.storage)
 
         let formatter = BlockquoteFormatter()
-        textView.storage.setAttributes(formatter.attributes, range: paragraphs[0])
+        var attributes = [String:Any]()
+        attributes = formatter.apply(toAttributes: attributes)
+        textView.storage.setAttributes(attributes, range: paragraphs[0])
         formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
@@ -50,13 +56,13 @@ class BlockquoteFormatterTests: XCTestCase {
 
     func testToggleBlockquoteTwiceLeavesReturnsIdenticalString() {
         let textView = testTextView
+        textView.storage.setAttributes([NSParagraphStyleAttributeName: ParagraphStyle.default], range: textView.storage.rangeOfEntireString)
         let paragraphs = paragraphRanges(inString: textView.storage)
 
         let formatter = BlockquoteFormatter()
         let original = textView.storage.copy() as! NSAttributedString
         formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
         formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
-
         XCTAssertTrue(original.isEqual(to: textView.storage))
     }
 }

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -47,6 +47,17 @@ Ordered List:
 </ol>
 </p>
 <p>
+Blockquote and Ordered List:
+<blockquote>
+<ol>
+    <li>One</li>
+    <li>Two</li>
+    <li>Three</li>
+</ol>
+</blockquote>
+</p>
+
+<p>
 Master cleanse Intelligentsia butcher Brooklyn Tumblr. Etsy lo-fi Marfa bicycle rights. Intelligentsia Helvetica fanny pack, normcore Odd Future fixie brunch mustache aesthetic kitsch artisan cardigan mlkshk. Pour-over hashtag selfies pug Tumblr mlkshk. Food truck small batch McSweeney's trust fund, Intelligentsia bitters Brooklyn twee meh authentic. Normcore distillery American Apparel single-origin coffee artisan try-hard, stumptown XOXO tote bag fanny pack Blue Bottle Shoreditch food truck Banksy. Church-key American Apparel Blue Bottle, swag try-hard Odd Future mustache chia iPhone.
 </p>
 <p>


### PR DESCRIPTION
Fix #178 

This PR allows the combination of list and block quotes to the same paragraphs.

How to test:
 - Open the demo controller
 - Select a paragraph
 - Apply a list type, ordered or unordered, check if it's correctly applied
 - Apply block quotes, check if it's correctly applied
 - Remove the list and see if the block quote remain in place
 - Apply the other list type and see if it's correct
 - Remove the blockquote
 - Try different combination of application orders.

