### PR TITLE
Paste and Match: Supporting Images

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */; };
 		B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */; };
 		B5B86D3C1DA41A550083DB3F /* TextListFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */; };
+		B5B96DAB1E01B2F300791315 /* UIPasteboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */; };
 		B5BC4FEE1DA2C17800614582 /* NSAttributedString+Lists.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */; };
 		B5BC4FF21DA2D17000614582 /* NSAttributedStringListsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */; };
 		B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FF51DA2D76600614582 /* TextList.swift */; };
@@ -154,6 +155,7 @@
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
 		B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Traits.swift"; sourceTree = "<group>"; };
 		B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatter.swift; sourceTree = "<group>"; };
+		B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIPasteboard+Helpers.swift"; sourceTree = "<group>"; };
 		B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Lists.swift"; sourceTree = "<group>"; };
 		B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringListsTests.swift; path = Extensions/NSAttributedStringListsTests.swift; sourceTree = "<group>"; };
 		B5BC4FF51DA2D76600614582 /* TextList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextList.swift; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 				599F25271D8BC9A1002871D6 /* UITextView+Helpers.swift */,
 				FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */,
 				B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */,
+				B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -631,6 +634,7 @@
 				599F25541D8BC9A1002871D6 /* TextView.swift in Sources */,
 				E1C163A51DB6056B00E66A83 /* BlockquoteFormatter.swift in Sources */,
 				599F254A1D8BC9A1002871D6 /* NSAttributedString+Attachments.swift in Sources */,
+				B5B96DAB1E01B2F300791315 /* UIPasteboard+Helpers.swift in Sources */,
 				F15C9B881DD58D8B00833C39 /* ElementNodeDescriptor.swift in Sources */,
 				599F254C1D8BC9A1002871D6 /* UITextView+Helpers.swift in Sources */,
 				FFA61E891DF18F3D00B71BF6 /* ParagraphStyle.swift in Sources */,

--- a/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
@@ -6,6 +6,20 @@ import UIKit
 //
 extension NSAttributedString
 {
+    ///
+    ///
+    func loadLazyAttachments() {
+        enumerateAttachmentsOfType(NSTextAttachment.self) { (attachment, _, _) in
+            guard let data = attachment.fileWrapper?.regularFileContents else {
+                return
+            }
+
+            let image = UIImage(data: data)
+            attachment.fileWrapper = nil
+            attachment.image = image
+        }
+    }
+
     /// Enumerates all of the available NSTextAttachment's of the specified kind, in a given range.
     /// For each one of those elements, the specified block will be called.
     ///
@@ -29,8 +43,7 @@ extension NSAttributedString
     ///
     /// - returns: an array of ranges where the attachement can be found
     ///
-    public func ranges(forAttachment attachment: NSTextAttachment) -> [NSRange]
-    {
+    public func ranges(forAttachment attachment: NSTextAttachment) -> [NSRange] {
         let range = NSRange(location: 0, length: length)
         var attachmentRanges = [NSRange]()
         enumerateAttribute(NSAttachmentAttributeName, in: range, options: []) { (value, effectiveRange, nil) in

--- a/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
@@ -6,7 +6,7 @@ import UIKit
 //
 extension NSAttributedString
 {
-    ///
+    /// Loads any NSTextAttachment's lazy file reference, into a UIImage instance, in memory.
     ///
     func loadLazyAttachments() {
         enumerateAttachmentsOfType(NSTextAttachment.self) { (attachment, _, _) in

--- a/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
+++ b/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
@@ -15,11 +15,11 @@ extension UIPasteboard {
             return string
         }
 
-        if let string = RTFAttributedString {
+        if let string = RTFDAttributedString {
             return string
         }
 
-        if let string = RTFDAttributedString {
+        if let string = RTFAttributedString {
             return string
         }
 

--- a/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
+++ b/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
@@ -5,30 +5,12 @@ import UIKit
 
 // MARK: - Pasteboard Helpers
 //
-extension UIPasteboard
-{
-    ///
-    ///
-    private struct StringOptions {
-        static let RTFText = [NSDocumentTypeDocumentAttribute: NSRTFTextDocumentType]
-        static let RTFDText = [NSDocumentTypeDocumentAttribute: NSRTFDTextDocumentType]
-        static let plainText = [NSDocumentTypeDocumentAttribute: NSPlainTextDocumentType]
-    }
+extension UIPasteboard {
 
-    ///
-    ///
-    private func unarchiveAttributedString(fromPasteboardCFType type: CFString, with options: [String: Any]) -> NSAttributedString? {
-        guard let data = data(forPasteboardType: String(type)) else {
-            return nil
-        }
-
-        return try? NSAttributedString(data: data, options: options, documentAttributes: nil)
-    }
-
-
-    ///
+    /// Attempts to load the Pasteboard's contents into a NSAttributedString Instance, if possible.
     ///
     func loadAttributedString() -> NSAttributedString? {
+
         if let string = aztecAttributedString {
             return string
         }
@@ -47,35 +29,40 @@ extension UIPasteboard
 
         return plainTextAttributedString
     }
+}
 
+
+// MARK: - Pasteboard Private Helpers
+//
+private extension UIPasteboard {
+
+    /// Attempts to unarchive the Pasteboard's RTF contents into an Attributed String
     ///
-    ///
-    private var RTFAttributedString: NSAttributedString? {
+    var RTFAttributedString: NSAttributedString? {
         return unarchiveAttributedString(fromPasteboardCFType: kUTTypeRTF, with: StringOptions.RTFText)
     }
 
+    /// Attempts to unarchive the Pasteboard's RTFD contents into an Attributed String
     ///
-    ///
-    private var RTFDAttributedString: NSAttributedString? {
+    var RTFDAttributedString: NSAttributedString? {
         return unarchiveAttributedString(fromPasteboardCFType: kUTTypeFlatRTFD, with: StringOptions.RTFDText)
     }
 
+    /// Attempts to unarchive the Pasteboard's Text contents into an Attributed String
     ///
-    ///
-    private var richTextAttributedString: NSAttributedString? {
+    var richTextAttributedString: NSAttributedString? {
         return unarchiveAttributedString(fromPasteboardCFType: kUTTypeText, with: StringOptions.RTFText)
     }
 
+    /// Attempts to unarchive the Pasteboard's Plain Text contents into an Attributed String
     ///
-    ///
-    private var plainTextAttributedString: NSAttributedString? {
+    var plainTextAttributedString: NSAttributedString? {
         return unarchiveAttributedString(fromPasteboardCFType: kUTTypePlainText, with: StringOptions.plainText)
     }
 
-
+    /// Attempts to unarchive the Pasteboard's Aztec-Archived String
     ///
-    ///
-    private var aztecAttributedString: NSAttributedString? {
+    var aztecAttributedString: NSAttributedString? {
         guard let data = data(forPasteboardType: NSAttributedString.pastesboardUTI) else {
             return nil
         }
@@ -83,9 +70,29 @@ extension UIPasteboard
         return NSAttributedString.unarchive(with: data)
     }
 
+    // MARK: - Helpers
 
-//        let fullRange = stripped.rangeOfEntireString
-//        stripped.removeAttribute(NSFontAttributeName, range: fullRange)
-//        stripped.removeAttribute(NSStrikethroughStyleAttributeName, range: fullRange)
-//        stripped.removeAttribute(NSUnderlineStyleAttributeName, range: fullRange)
+    /// String Initialization Options
+    ///
+    private struct StringOptions {
+        static let RTFText = [NSDocumentTypeDocumentAttribute: NSRTFTextDocumentType]
+        static let RTFDText = [NSDocumentTypeDocumentAttribute: NSRTFDTextDocumentType]
+        static let plainText = [NSDocumentTypeDocumentAttribute: NSPlainTextDocumentType]
+    }
+
+    /// Attempts to unarchive a Pasteboard's Entry into a NSAttributedString Instance.
+    ///
+    /// - Parameters:
+    ///     - type: Pasteboard's Attribute Key
+    ///     - options: Properties to be utilized during the NSAttributedString Initialization.
+    ///
+    /// - Returns: NSAttributed String with the contents of the specified Pasteboard entry, if any.
+    ///
+    private func unarchiveAttributedString(fromPasteboardCFType type: CFString, with options: [String: Any]) -> NSAttributedString? {
+        guard let data = data(forPasteboardType: String(type)) else {
+            return nil
+        }
+
+        return try? NSAttributedString(data: data, options: options, documentAttributes: nil)
+    }
 }

--- a/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
+++ b/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
@@ -1,0 +1,50 @@
+import Foundation
+import MobileCoreServices
+import UIKit
+
+
+///
+///
+extension UIPasteboard
+{
+    ///
+    ///
+    func stripStringAttributes() {
+        let plainOptions = [NSDocumentTypeDocumentAttribute: NSPlainTextDocumentType]
+        let richOptions = [NSDocumentTypeDocumentAttribute: NSRTFTextDocumentType]
+
+        let supportedTypes = [
+            String(kUTTypeRTF):         richOptions,
+            String(kUTTypeText):        richOptions,
+            String(kUTTypePlainText):   plainOptions
+        ]
+
+        for (type, options) in supportedTypes {
+            guard let data = data(forPasteboardType: type),
+                let original = try? NSAttributedString(data: data, options: options, documentAttributes: nil),
+                let stripped = original.string.data(using: .utf8) else
+            {
+                continue
+            }
+
+            setData(stripped, forPasteboardType: type)
+        }
+    }
+
+    ///
+    ///
+    func stripAztecAttributes() {
+        guard let data = value(forPasteboardType: NSAttributedString.pastesboardUTI) as? Data,
+            let original = NSAttributedString.unarchive(with: data) else
+        {
+            return
+        }
+
+        let rearchived = NSAttributedString(string: original.string).archivedData()
+        setValue(rearchived, forPasteboardType: NSAttributedString.pastesboardUTI)
+
+//        let reencoded = NSAttributedString(string: original.string, attributes: typingAttributes)
+//        let rearchived = reencoded.archivedData()
+//        setValue(rearchived, forPasteboardType: NSAttributedString.pastesboardUTI)
+    }
+}

--- a/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
+++ b/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
@@ -3,11 +3,11 @@ import MobileCoreServices
 import UIKit
 
 
-///
-///
+// MARK: - Pasteboard Helpers
+//
 extension UIPasteboard
 {
-    ///
+    /// Removes all of the stored Rich String's Attributes
     ///
     func stripStringAttributes() {
         let plainOptions = [NSDocumentTypeDocumentAttribute: NSPlainTextDocumentType]
@@ -31,7 +31,7 @@ extension UIPasteboard
         }
     }
 
-    ///
+    /// Removes all of the Aztec-Stored String's Attributes
     ///
     func stripAztecAttributes() {
         guard let data = value(forPasteboardType: NSAttributedString.pastesboardUTI) as? Data,
@@ -42,9 +42,5 @@ extension UIPasteboard
 
         let rearchived = NSAttributedString(string: original.string).archivedData()
         setValue(rearchived, forPasteboardType: NSAttributedString.pastesboardUTI)
-
-//        let reencoded = NSAttributedString(string: original.string, attributes: typingAttributes)
-//        let rearchived = reencoded.archivedData()
-//        setValue(rearchived, forPasteboardType: NSAttributedString.pastesboardUTI)
     }
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -101,27 +101,27 @@ open class TextView: UITextView {
     }
 
     open override func paste(_ sender: Any?) {
-        guard let data = UIPasteboard.general.value(forPasteboardType: NSAttributedString.pastesboardUTI) as? Data,
-           let aztecString = NSAttributedString.unarchive(with: data) else
-        {
+        guard let string = UIPasteboard.general.loadAttributedString() else {
             super.paste(sender)
             return
         }
 
-        storage.replaceCharacters(in: selectedRange, with: aztecString)
+        string.loadLazyAttachments()
+        storage.replaceCharacters(in: selectedRange, with: string)
     }
 
     open func pasteAndMatchStyle(_ sender: Any?) {
-        let pasteboard = UIPasteboard.general
-        let pristineItems = pasteboard.items
+        guard let string = UIPasteboard.general.loadAttributedString()?.mutableCopy() as? NSMutableAttributedString else {
+            super.paste(sender)
+            return
+        }
 
-        pasteboard.stripStringAttributes()
-        pasteboard.stripAztecAttributes()
 
-        paste(sender)
+        let range = string.rangeOfEntireString
+        string.addAttributes(typingAttributes, range: range)
+        string.loadLazyAttachments()
 
-        // Fallback to the original Pasteboard state
-        pasteboard.items = pristineItems
+        storage.replaceCharacters(in: selectedRange, with: string)
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -101,13 +101,14 @@ open class TextView: UITextView {
     }
 
     open override func paste(_ sender: Any?) {
-        let pasteboard  = UIPasteboard.general
-        if let data = pasteboard.value(forPasteboardType: NSAttributedString.pastesboardUTI) as? Data,
-           let aztecString = NSAttributedString.unarchive(with: data) {
-            storage.replaceCharacters(in: selectedRange, with: aztecString)
-        } else {
+        guard let data = UIPasteboard.general.value(forPasteboardType: NSAttributedString.pastesboardUTI) as? Data,
+           let aztecString = NSAttributedString.unarchive(with: data) else
+        {
             super.paste(sender)
+            return
         }
+
+        storage.replaceCharacters(in: selectedRange, with: aztecString)
     }
 
     open func pasteAndMatchStyle(_ sender: Any?) {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -112,13 +112,18 @@ open class TextView: UITextView {
     }
 
     open func pasteAndMatchStyle(_ sender: Any?) {
-        guard let plainString = UIPasteboard.general.string, plainString.isEmpty == false else {
-            super.paste(sender)
-            return
-        }
+        let pasteboard = UIPasteboard.general
+        let pristineItems = pasteboard.items
 
-        storage.replaceCharacters(in: selectedRange, with: plainString)
+        pasteboard.stripStringAttributes()
+        pasteboard.stripAztecAttributes()
+
+        paste(sender)
+
+        // Fallback to the original Pasteboard state
+        pasteboard.items = pristineItems
     }
+
 
     // MARK: - Intersect keyboard operations
 


### PR DESCRIPTION
### Details:
This PR adds support for Image Attachments, when running **Paste and Match Style**.
Closes #172

### Testing: Reminders
1. Copy text from Reminders.app
2. Run **Paste and Match Style** in Aztec
3. Verify that the style looks as expected. Compare it with a regular **Paste** OP

### Testing: Safari
1. Copy text from Safari.app. Make sure to include an image asset
2. Run **Paste and Match Style** in Aztec
3. Verify that the style looks as expected. Compare it with a regular **Paste** OP


Needs Review: @diegoreymendez  
