### PR TITLE
Improves the undo manager code.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		F1288BAF1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1288BAD1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift */; };
 		F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1288BAE1DD0B1EF00E67ABC /* HTMLToAttributedString.swift */; };
 		F15C9B881DD58D8B00833C39 /* ElementNodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15C9B871DD58D8B00833C39 /* ElementNodeDescriptor.swift */; };
+		F15F61C91E0323EC00CD6DD8 /* UndoStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F61C81E0323EC00CD6DD8 /* UndoStack.swift */; };
 		F18733C81DA09737005AEB80 /* NSRangeComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */; };
 		F1A218151E02D5B3000AF5EB /* UndoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A218141E02D5B3000AF5EB /* UndoManager.swift */; };
 		F1CF272A1DBA8CDB0001C61D /* DOMString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF27291DBA8CDB0001C61D /* DOMString.swift */; };
@@ -167,6 +168,7 @@
 		F1288BAD1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLNodeToNSAttributedString.swift; sourceTree = "<group>"; };
 		F1288BAE1DD0B1EF00E67ABC /* HTMLToAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLToAttributedString.swift; sourceTree = "<group>"; };
 		F15C9B871DD58D8B00833C39 /* ElementNodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ElementNodeDescriptor.swift; path = Descriptors/ElementNodeDescriptor.swift; sourceTree = "<group>"; };
+		F15F61C81E0323EC00CD6DD8 /* UndoStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UndoStack.swift; sourceTree = "<group>"; };
 		F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRange+Helpers.swift"; sourceTree = "<group>"; };
 		F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSRangeComparisonTests.swift; path = Extensions/NSRangeComparisonTests.swift; sourceTree = "<group>"; };
 		F1A218141E02D5B3000AF5EB /* UndoManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UndoManager.swift; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				599F25131D8BC9A1002871D6 /* DOM */,
 				599F251A1D8BC9A1002871D6 /* Libxml2.swift */,
 				F1CF27291DBA8CDB0001C61D /* DOMString.swift */,
+				F15F61C81E0323EC00CD6DD8 /* UndoStack.swift */,
 			);
 			path = Libxml2;
 			sourceTree = "<group>";
@@ -625,6 +628,7 @@
 				B5B86D3C1DA41A550083DB3F /* TextListFormatter.swift in Sources */,
 				599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */,
 				599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */,
+				F15F61C91E0323EC00CD6DD8 /* UndoStack.swift in Sources */,
 				F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */,
 				E11B77641DBA6ADC0024E455 /* AttributeFormatter.swift in Sources */,
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,

--- a/Aztec/Classes/Converters/HTMLToAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLToAttributedString.swift
@@ -5,23 +5,27 @@ class HTMLToAttributedString: Converter {
 
     typealias RootNode = Libxml2.RootNode
     typealias TextNode = Libxml2.TextNode
+    typealias UndoRegistrationClosure = Libxml2.Node.UndoRegistrationClosure
 
     /// The default font descriptor that will be used as a base for conversions.
     ///
     let defaultFontDescriptor: UIFontDescriptor
+    
+    let registerUndo: UndoRegistrationClosure
 
-    required init(usingDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) {
+    required init(usingDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor, registerUndo: @escaping UndoRegistrationClosure) {
         self.defaultFontDescriptor = defaultFontDescriptor
+        self.registerUndo = registerUndo
     }
 
     func convert(_ html: String) throws -> (rootNode: RootNode, attributedString: NSAttributedString) {
-        let htmlToNode = Libxml2.In.HTMLConverter()
+        let htmlToNode = Libxml2.In.HTMLConverter(registerUndo: registerUndo)
         let nodeToAttributedString = HMTLNodeToNSAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
 
         let rootNode = try htmlToNode.convert(html)
 
         if rootNode.children.count == 0 {
-            rootNode.append(TextNode(text: html))
+            rootNode.append(TextNode(text: html, registerUndo: registerUndo))
         }
 
         let attributedString = nodeToAttributedString.convert(rootNode)

--- a/Aztec/Classes/Libxml2/Converters/In/InHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InHTMLConverter.swift
@@ -5,14 +5,18 @@ extension Libxml2.In {
     class HTMLConverter: Converter {
 
         typealias RootNode = Libxml2.RootNode
-
+        typealias UndoRegistrationClosure = Libxml2.Node.UndoRegistrationClosure
+        
         enum Error: String, Swift.Error {
             case NoRootNode = "No root node"
         }
+        
+        let registerUndo: UndoRegistrationClosure
 
         /// Not sure why, but the compiler is requiring this initializer.
         ///
-        init() {
+        required init(registerUndo: @escaping UndoRegistrationClosure) {
+            self.registerUndo = registerUndo
         }
 
         /// Converts HTML data into an HTML Node representing the same data.
@@ -84,7 +88,7 @@ extension Libxml2.In {
                 // It may be a good idea to wrap the HTML in a single fake root node before parsing
                 // it to bypass this behaviour.
                 //
-                let nodeConverter = NodeConverter()
+                let nodeConverter = NodeConverter(registerUndo: registerUndo)
 
                 guard let node = nodeConverter.convert(rootNode) as? RootNode else {
                     throw Error.NoRootNode

--- a/Aztec/Classes/Libxml2/Converters/In/InNodesConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodesConverter.swift
@@ -7,8 +7,10 @@ extension Libxml2.In {
     ///
     class NodesConverter: SafeCLinkedListToArrayConverter<NodeConverter> {
 
-        required init() {
-            super.init(elementConverter: NodeConverter(), next: { return $0.next })
+        typealias UndoRegistrationClosure = Libxml2.Node.UndoRegistrationClosure
+        
+        required init(registerUndo: @escaping UndoRegistrationClosure) {
+            super.init(elementConverter: NodeConverter(registerUndo: registerUndo), next: { return $0.next })
         }
     }
 }

--- a/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
@@ -7,6 +7,13 @@ extension Libxml2.Out {
         typealias Node = Libxml2.Node
         typealias ElementNode = Libxml2.ElementNode
         typealias RootNode = Libxml2.RootNode
+        typealias UndoRegistrationClosure = Node.UndoRegistrationClosure
+        
+        let registerUndo: UndoRegistrationClosure
+        
+        required init(registerUndo: @escaping UndoRegistrationClosure) {
+            self.registerUndo = registerUndo
+        }
 
         /// Converts the a Libxml2 Node into HTML representing the same data.
         ///

--- a/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
@@ -9,10 +9,7 @@ extension Libxml2.Out {
         typealias RootNode = Libxml2.RootNode
         typealias UndoRegistrationClosure = Node.UndoRegistrationClosure
         
-        let registerUndo: UndoRegistrationClosure
-        
-        required init(registerUndo: @escaping UndoRegistrationClosure) {
-            self.registerUndo = registerUndo
+        required init() {
         }
 
         /// Converts the a Libxml2 Node into HTML representing the same data.

--- a/Aztec/Classes/Libxml2/DOM/CommentNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/CommentNode.swift
@@ -17,10 +17,10 @@ extension Libxml2 {
         
         // MARK: - Initializers
         
-        init(text: String) {
+        init(text: String, registerUndo: @escaping UndoRegistrationClosure) {
             comment = text
 
-            super.init(name: "comment")
+            super.init(name: "comment", registerUndo: registerUndo)
         }
 
         /// Node length.

--- a/Aztec/Classes/Libxml2/DOM/EditableNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/EditableNode.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol EditableNode {
-    func deleteCharacters(inRange range: NSRange, undoManager: UndoManager?)
+    func deleteCharacters(inRange range: NSRange)
     
     /// Replaces the specified range with a new string.
     ///
@@ -10,9 +10,8 @@ protocol EditableNode {
     ///     - string: the new string to replace the original text with.
     ///     - inheritStyle: If `true` the new string will inherit the style information from the first position in
     ///             the specified range.  If `false`, the new sting will have no associated style.
-    ///     - undoManager: the undo manager for the operation.
     ///
-    func replaceCharacters(inRange range: NSRange, withString string: String, inheritStyle: Bool, undoManager: UndoManager?)
+    func replaceCharacters(inRange range: NSRange, withString string: String, inheritStyle: Bool)
 
     /// Should split the node at the specified text location.  The receiver will become the node before the specified
     /// location and a new node will be created to contain whatever comes after it.
@@ -21,7 +20,7 @@ protocol EditableNode {
     ///     - location: the text location to split the node at.
     ///     - undoManager: the undo manager for the operation.
     ///
-    func split(atLocation location: Int, undoManager: UndoManager?)
+    func split(atLocation location: Int)
     
     /// Should split the node for the specified text range.  The receiver will become the node
     /// at the specified range.
@@ -30,7 +29,7 @@ protocol EditableNode {
     ///     - range: the range to use for splitting the node.
     ///     - undoManager: the undo manager for the operation.
     ///
-    func split(forRange range: NSRange, undoManager: UndoManager?)
+    func split(forRange range: NSRange)
     
     /// Wraps the specified range in the specified element.
     ///
@@ -40,5 +39,5 @@ protocol EditableNode {
     ///     - undoManager: the undo manager for the operation.
     ///
     ///
-    func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor, undoManager: UndoManager?)
+    func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor)
 }

--- a/Aztec/Classes/Libxml2/DOM/EditableNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/EditableNode.swift
@@ -18,7 +18,6 @@ protocol EditableNode {
     ///
     /// - Parameters:
     ///     - location: the text location to split the node at.
-    ///     - undoManager: the undo manager for the operation.
     ///
     func split(atLocation location: Int)
     
@@ -27,7 +26,6 @@ protocol EditableNode {
     ///
     /// - Parameters:
     ///     - range: the range to use for splitting the node.
-    ///     - undoManager: the undo manager for the operation.
     ///
     func split(forRange range: NSRange)
     
@@ -36,7 +34,6 @@ protocol EditableNode {
     /// - Parameters:
     ///     - range: the range to wrap.
     ///     - elementDescriptor: the element to wrap the range in.
-    ///     - undoManager: the undo manager for the operation.
     ///
     ///
     func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor)

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -36,11 +36,11 @@ extension Libxml2 {
         
         // MARK: - Initializers
 
-        init(name: String, attributes: [Attribute], children: [Node]) {
+        init(name: String, attributes: [Attribute], children: [Node], registerUndo: @escaping UndoRegistrationClosure) {
             self.attributes.append(contentsOf: attributes)
             self.children = children
 
-            super.init(name: name)
+            super.init(name: name, registerUndo: registerUndo)
 
             for child in children {
 
@@ -52,8 +52,8 @@ extension Libxml2 {
             }
         }
         
-        convenience init(descriptor: ElementNodeDescriptor, children: [Node] = []) {
-            self.init(name: descriptor.name, attributes: descriptor.attributes, children: children)
+        convenience init(descriptor: ElementNodeDescriptor, children: [Node] = [], registerUndo: @escaping UndoRegistrationClosure) {
+            self.init(name: descriptor.name, attributes: descriptor.attributes, children: children, registerUndo: registerUndo)
         }
         
         // MARK: - Node Overrides
@@ -82,7 +82,7 @@ extension Libxml2 {
         /// - parameter attributeName: the name of the attribute
         /// - parameter value:         the value to mark the attribute
         ///
-        func updateAttribute(named attributeName:String, value: String, undoManager: UndoManager?) {
+        func updateAttribute(named attributeName:String, value: String) {
             for attribute in attributes {
                 if let attribute = attribute as? StringAttribute, attribute.name == attributeName {
                     attribute.value = value
@@ -672,7 +672,7 @@ extension Libxml2 {
         /// - Parameters:
         ///     - child: the node to append.
         ///
-        func append(_ child: Node, undoManager: UndoManager? = nil) {
+        func append(_ child: Node) {
 
             if let parent = child.parent {
                 parent.remove([child])
@@ -687,10 +687,10 @@ extension Libxml2 {
         /// - Parameters:
         ///     - child: the node to append.
         ///
-        func append(_ children: [Node], undoManager: UndoManager? = nil) {
+        func append(_ children: [Node]) {
             
             for child in children {
-                append(child, undoManager: undoManager)
+                append(child)
             }
         }
         
@@ -699,7 +699,7 @@ extension Libxml2 {
         /// - Parameters:
         ///     - child: the node to prepend.
         ///
-        func prepend(_ child: Node, undoManager: UndoManager? = nil) {
+        func prepend(_ child: Node) {
             
             if let parent = child.parent {
                 parent.remove([child])
@@ -714,7 +714,7 @@ extension Libxml2 {
         /// - Parameters:
         ///     - children: the nodes to prepend.
         ///
-        func prepend(_ children: [Node], undoManager: UndoManager? = nil) {
+        func prepend(_ children: [Node]) {
             
             for index in stride(from: (children.count - 1), through: 0, by: -1) {
                 prepend(children[index])
@@ -727,7 +727,7 @@ extension Libxml2 {
         ///     - child: the node to insert.
         ///     - index: the position where to insert the node.
         ///
-        func insert(_ child: Node, at index: Int, undoManager: UndoManager? = nil) {
+        func insert(_ child: Node, at index: Int) {
 
             if let parent = child.parent {
                 parent.remove([child])
@@ -743,7 +743,7 @@ extension Libxml2 {
         ///     - child: the node to remove.
         ///     - newChildren: the new child nodes to insert.
         ///
-        func replace(child: Node, with newChildren: [Node], undoManager: UndoManager? = nil) {
+        func replace(child: Node, with newChildren: [Node]) {
             guard let childIndex = children.index(of: child) else {
                 fatalError("This case should not be possible. Review the logic triggering this.")
             }
@@ -817,7 +817,7 @@ extension Libxml2 {
         ///
         /// - Returns: the requested nodes.
         ///
-        fileprivate func splitChildren(after splitLocation: Int, undoManager: UndoManager? = nil) -> [Node] {
+        fileprivate func splitChildren(after splitLocation: Int) -> [Node] {
 
             var result = [Node]()
             var childOffset = Int(0)
@@ -833,7 +833,7 @@ extension Libxml2 {
                     let splitLocationInChild = splitLocation - childOffset
                     let splitRange = NSRange(location: splitLocationInChild, length: childEndLocation - splitLocationInChild)
                     
-                    childEditableNode.split(forRange: splitRange, undoManager: undoManager)
+                    childEditableNode.split(forRange: splitRange)
                     result.append(child)
                 }
                 
@@ -850,7 +850,7 @@ extension Libxml2 {
         ///
         /// - Returns: the requested nodes.
         ///
-        fileprivate func splitChildren(before splitLocation: Int, undoManager: UndoManager? = nil) -> [Node] {
+        fileprivate func splitChildren(before splitLocation: Int) -> [Node] {
             
             var result = [Node]()
             var childOffset = Int(0)
@@ -866,7 +866,7 @@ extension Libxml2 {
                     let splitLocationInChild = splitLocation - childOffset
                     let splitRange = NSRange(location: 0, length: splitLocationInChild)
                     
-                    childEditableNode.split(forRange: splitRange, undoManager: undoManager)
+                    childEditableNode.split(forRange: splitRange)
                     result.append(child)
                 }
                 
@@ -892,7 +892,7 @@ extension Libxml2 {
         ///
         /// - Returns: The requested node, if one is found, or `nil`.
         ///
-        fileprivate func pushUp<T: Node>(siblingOrDescendantAtLeftSideOf childIndex: Int, evaluatedBy evaluation: ((T) -> Bool), bailIf bail: ((T) -> Bool) = { _ in return false }, undoManager: UndoManager? = nil) -> T? {
+        fileprivate func pushUp<T: Node>(siblingOrDescendantAtLeftSideOf childIndex: Int, evaluatedBy evaluation: ((T) -> Bool), bailIf bail: ((T) -> Bool) = { _ in return false }) -> T? {
             
             guard let theSibling: T = sibling(leftOf: childIndex), !bail(theSibling) else {
                 return nil
@@ -906,7 +906,7 @@ extension Libxml2 {
                 return nil
             }
             
-            return element.pushUp(rightSideDescendantEvaluatedBy: evaluation, bailIf: bail, undoManager: undoManager)
+            return element.pushUp(rightSideDescendantEvaluatedBy: evaluation, bailIf: bail)
         }
         
         /// Pushes up to the level of the receiver any left-side descendant that evaluates
@@ -921,7 +921,7 @@ extension Libxml2 {
         ///         node after being pushed all the way up, or `nil` if no matching descendant is
         ///         found.
         ///
-        func pushUp<T: Node>(leftSideDescendantEvaluatedBy evaluationClosure: ((T) -> Bool), bailIf bail: ((T) -> Bool) = { _ in return false }, undoManager: UndoManager? = nil) -> T? {
+        func pushUp<T: Node>(leftSideDescendantEvaluatedBy evaluationClosure: ((T) -> Bool), bailIf bail: ((T) -> Bool) = { _ in return false }) -> T? {
             
             guard let node = find(leftSideDescendantEvaluatedBy: evaluationClosure, bailIf: bail) else {
                 return nil
@@ -935,14 +935,14 @@ extension Libxml2 {
                     if let element = node as? ElementNode {
                         
                         let parentDescriptor = ElementNodeDescriptor(name: parent.name, attributes: parent.attributes)
-                        element.wrap(children: element.children, inElement: parentDescriptor, undoManager: undoManager)
+                        element.wrap(children: element.children, inElement: parentDescriptor)
                     }
                     
                     guard let parentIndex = grandParent.children.index(of: parent) else {
                         fatalError("The grandparent element should contain the parent element.")
                     }
                     
-                    grandParent.insert(node, at: parentIndex, undoManager: undoManager)
+                    grandParent.insert(node, at: parentIndex)
                     
                     if lastSwap {
                         break
@@ -968,7 +968,7 @@ extension Libxml2 {
         ///
         /// - Returns: The requested node, if one is found, or `nil`.
         ///
-        fileprivate func pushUp<T: Node>(siblingOrDescendantAtRightSideOf childIndex: Int, evaluatedBy evaluation: ((T) -> Bool), bailIf bail: ((T) -> Bool) = { _ in return false }, undoManager: UndoManager? = nil) -> T? {
+        fileprivate func pushUp<T: Node>(siblingOrDescendantAtRightSideOf childIndex: Int, evaluatedBy evaluation: ((T) -> Bool), bailIf bail: ((T) -> Bool) = { _ in return false }) -> T? {
             
             guard let theSibling: T = sibling(rightOf: childIndex), !bail(theSibling) else {
                     return nil
@@ -982,7 +982,7 @@ extension Libxml2 {
                 return nil
             }
             
-            return element.pushUp(leftSideDescendantEvaluatedBy: evaluation, bailIf: bail, undoManager: undoManager)
+            return element.pushUp(leftSideDescendantEvaluatedBy: evaluation, bailIf: bail)
         }
         
         /// Pushes up to the level of the receiver any right-side descendant that evaluates
@@ -997,7 +997,7 @@ extension Libxml2 {
         ///         node after being pushed all the way up, or `nil` if no matching descendant is
         ///         found.
         ///
-        func pushUp<T: Node>(rightSideDescendantEvaluatedBy evaluationClosure: ((T) -> Bool), bailIf bail: ((T) -> Bool) = { _ in return false }, undoManager: UndoManager? = nil) -> T? {
+        func pushUp<T: Node>(rightSideDescendantEvaluatedBy evaluationClosure: ((T) -> Bool), bailIf bail: ((T) -> Bool) = { _ in return false }) -> T? {
             
             guard let node = find(rightSideDescendantEvaluatedBy: evaluationClosure, bailIf: bail) else {
                 return nil
@@ -1011,14 +1011,14 @@ extension Libxml2 {
                     if let element = node as? ElementNode {
                         
                         let parentDescriptor = ElementNodeDescriptor(name: parent.name, attributes: parent.attributes)
-                        element.wrap(children: element.children, inElement: parentDescriptor, undoManager: undoManager)
+                        element.wrap(children: element.children, inElement: parentDescriptor)
                     }
                     
                     guard let parentIndex = grandParent.children.index(of: parent) else {
                         fatalError("The grandparent element should contain the parent element.")
                     }
                     
-                    grandParent.insert(node, at: parentIndex + 1, undoManager: undoManager)
+                    grandParent.insert(node, at: parentIndex + 1)
                     
                     if lastSwap {
                         break
@@ -1030,7 +1030,7 @@ extension Libxml2 {
 
         // MARK: - EditableNode
 
-        func deleteCharacters(inRange range: NSRange, undoManager: UndoManager? = nil) {
+        func deleteCharacters(inRange range: NSRange) {
             if range.location == 0 && range.length == length() {
                 removeFromParent()
             } else {
@@ -1039,7 +1039,7 @@ extension Libxml2 {
                 for (child, intersection) in childrenAndIntersections {
 
                     if let childEditableNode = child as? EditableNode {
-                        childEditableNode.deleteCharacters(inRange: intersection, undoManager: undoManager)
+                        childEditableNode.deleteCharacters(inRange: intersection)
                     } else {
                         remove(child)
                     }
@@ -1058,7 +1058,7 @@ extension Libxml2 {
         ///     - string: the string to insert in a new `TextNode`.
         ///     - index: the index where the next `TextNode` will be inserted.
         ///
-        func insert(_ string: String, at index: Int, undoManager: UndoManager? = nil) {
+        func insert(_ string: String, at index: Int) {
 
             guard index <= children.count else {
                 fatalError("The specified index is outside the range of possible indexes for insertion.")
@@ -1071,13 +1071,13 @@ extension Libxml2 {
             } else if index < children.count, let nextTextNode = children[index] as? TextNode {
                 nextTextNode.prepend(string)
             } else {
-                insert(TextNode(text: string), at: index)
+                insert(TextNode(text: string, registerUndo: registerUndo), at: index)
             }
         }
 
         /// Inserts the specified string at the specified location.
         ///
-        func insert(_ string: String, atLocation location: Int, undoManager: UndoManager? = nil) {
+        func insert(_ string: String, atLocation location: Int) {
 
             let blockLevelElementsAndIntersections = lowestBlockLevelElements(intersectingRange: NSRange(location: location, length: 0))
             
@@ -1106,7 +1106,7 @@ extension Libxml2 {
                         fatalError("We should never have a non-editable node with a representation that can be split.")
                     }
                     
-                    editableNode.split(atLocation: childIntersection, undoManager: undoManager)
+                    editableNode.split(atLocation: childIntersection)
                 }
                 
                 insertionIndex = childIndex + 1
@@ -1115,7 +1115,7 @@ extension Libxml2 {
             element.insert(string, at: insertionIndex)
         }
 
-        func replaceCharacters(inRange range: NSRange, withString string: String, inheritStyle: Bool, undoManager: UndoManager? = nil) {
+        func replaceCharacters(inRange range: NSRange, withString string: String, inheritStyle: Bool) {
             
             // When inheriting the style, we can just replace the text from the first child node with our new text.
             //
@@ -1129,9 +1129,9 @@ extension Libxml2 {
                 
                 if let childEditableNode = child as? EditableNode {
                     if index == 0 && replaceTextFromFirstChild {
-                        childEditableNode.replaceCharacters(inRange: intersection, withString: string, inheritStyle: inheritStyle, undoManager: undoManager)
+                        childEditableNode.replaceCharacters(inRange: intersection, withString: string, inheritStyle: inheritStyle)
                     } else {
-                        childEditableNode.deleteCharacters(inRange: intersection, undoManager: undoManager)
+                        childEditableNode.deleteCharacters(inRange: intersection)
                     }
                 } else {
                     remove(child)
@@ -1139,7 +1139,7 @@ extension Libxml2 {
             }
             
             if !inheritStyle && string.characters.count > 0 {
-                insert(string, atLocation: range.location, undoManager: undoManager)
+                insert(string, atLocation: range.location)
             }
         }
 
@@ -1158,7 +1158,7 @@ extension Libxml2 {
             let localRange = NSRange(location: targetRange.location - absoluteLocation, length: targetRange.length)
             textNode.split(forRange: localRange)
             
-            let imgNode = ElementNode(descriptor: elementDescriptor)
+            let imgNode = ElementNode(descriptor: elementDescriptor, registerUndo: registerUndo)
             
             guard let index = textNode.parent?.children.index(of: textNode) else {
                 assertionFailure("Can't remove a node that's not a child.")
@@ -1173,7 +1173,7 @@ extension Libxml2 {
             textNodeParent.remove(textNode)
         }
 
-        func split(atLocation location: Int, undoManager: UndoManager? = nil) {
+        func split(atLocation location: Int) {
             var trueLength = length()
             if isBlockLevelElement() {
                 trueLength -= 1
@@ -1195,10 +1195,10 @@ extension Libxml2 {
                     return
             }
             
-            let postNodes = splitChildren(after: location, undoManager: undoManager)
+            let postNodes = splitChildren(after: location)
             
             if postNodes.count > 0 {
-                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes)
+                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes, registerUndo: registerUndo)
                 
                 parent.insert(newElement, at: nodeIndex + 1)
                 remove(postNodes, updateParent: false)
@@ -1212,7 +1212,7 @@ extension Libxml2 {
         ///     - range: the range to use for splitting this node.  All nodes before and after the specified range will
         ///         be inserted in clones of this node.  All child nodes inside the range will be kept inside this node.
         ///
-        func split(forRange range: NSRange, undoManager: UndoManager? = nil) {
+        func split(forRange range: NSRange) {
 
             guard range.location >= 0 && range.location + range.length <= length() else {
                 assertionFailure("Specified range is out-of-bounds.")
@@ -1225,10 +1225,10 @@ extension Libxml2 {
                     return
             }
 
-            let postNodes = splitChildren(after: range.location + range.length, undoManager: undoManager)
+            let postNodes = splitChildren(after: range.location + range.length)
 
             if postNodes.count > 0 {
-                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes)
+                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes, registerUndo: registerUndo)
 
                 parent.insert(newElement, at: nodeIndex + 1)
                 remove(postNodes, updateParent: false)
@@ -1237,7 +1237,7 @@ extension Libxml2 {
             let preNodes = splitChildren(before: range.location)
 
             if preNodes.count > 0 {
-                let newElement = ElementNode(name: name, attributes: attributes, children: preNodes)
+                let newElement = ElementNode(name: name, attributes: attributes, children: preNodes, registerUndo: registerUndo)
 
                 parent.insert(newElement, at: nodeIndex)
                 remove(preNodes, updateParent: false)
@@ -1250,7 +1250,7 @@ extension Libxml2 {
         ///     - targetRange: the range that must be wrapped.
         ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor, undoManager: UndoManager? = nil) {
+        func wrap(range targetRange: NSRange, inElement elementDescriptor: Libxml2.ElementNodeDescriptor) {
 
             let mustFindLowestBlockLevelElements = !elementDescriptor.isBlockLevel()
 
@@ -1262,18 +1262,18 @@ extension Libxml2 {
                     let element = elementAndIntersection.element
                     let intersection = elementAndIntersection.intersection
                     
-                    element.forceWrapChildren(intersectingRange: intersection, inElement: elementDescriptor, undoManager: undoManager)
+                    element.forceWrapChildren(intersectingRange: intersection, inElement: elementDescriptor)
                 }
             } else {
-                forceWrap(range: targetRange, inElement: elementDescriptor, undoManager: undoManager)
+                forceWrap(range: targetRange, inElement: elementDescriptor)
             }
         }
 
         // MARK: - Wrapping
 
-        func unwrap(fromElementsNamed elementNames: [String], undoManager: UndoManager? = nil) {
+        func unwrap(fromElementsNamed elementNames: [String]) {
             if elementNames.contains(name) {
-                unwrapChildren(undoManager: undoManager)
+                unwrapChildren()
             }
         }
 
@@ -1288,13 +1288,13 @@ extension Libxml2 {
         ///         modify this to be able to do more complex lookups.  For instance we'll want
         ///         to be able to unwrapp CSS attributes, not just nodes by name.
         ///
-        func unwrap(range: NSRange, fromElementsNamed elementNames: [String], undoManager: UndoManager? = nil) {
+        func unwrap(range: NSRange, fromElementsNamed elementNames: [String]) {
             
             guard children.count > 0 else {
                 return
             }
             
-            unwrapChildren(intersectingRange: range, fromElementsNamed: elementNames, undoManager: undoManager)
+            unwrapChildren(intersectingRange: range, fromElementsNamed: elementNames)
 
             if elementNames.contains(name) {
 
@@ -1308,15 +1308,15 @@ extension Libxml2 {
 
                 if range.location > 0 {
                     let preRange = NSRange(location: 0, length: range.location)
-                    wrap(range: preRange, inElement: elementDescriptor, undoManager: undoManager)
+                    wrap(range: preRange, inElement: elementDescriptor)
                 }
 
                 if rangeEndLocation < myLength {
                     let postRange = NSRange(location: rangeEndLocation, length: myLength - rangeEndLocation)
-                    wrap(range: postRange, inElement: elementDescriptor, undoManager: undoManager)
+                    wrap(range: postRange, inElement: elementDescriptor)
                 }
 
-                unwrapChildren(undoManager: undoManager)
+                unwrapChildren()
             }
         }
 
@@ -1324,7 +1324,7 @@ extension Libxml2 {
         ///
         func unwrapChildren(undoManager: UndoManager? = nil) {
             if let parent = parent {
-                parent.replace(child: self, with: self.children, undoManager: undoManager)
+                parent.replace(child: self, with: self.children)
             } else {
                 for child in children {
                     child.parent = nil
@@ -1334,7 +1334,7 @@ extension Libxml2 {
             }
         }
 
-        func unwrapChildren(_ children: [Node], fromElementsNamed elementNames: [String], undoManager: UndoManager? = nil) {
+        func unwrapChildren(_ children: [Node], fromElementsNamed elementNames: [String]) {
 
             for child in children {
 
@@ -1342,7 +1342,7 @@ extension Libxml2 {
                     continue
                 }
 
-                childElement.unwrap(fromElementsNamed: elementNames, undoManager: undoManager)
+                childElement.unwrap(fromElementsNamed: elementNames)
             }
         }
 
@@ -1352,7 +1352,7 @@ extension Libxml2 {
         ///     - range: the range we want to unwrap.
         ///     - elementNames: the name of the elements we want to unwrap the nodes from.
         ///
-        func unwrapChildren(intersectingRange range: NSRange, fromElementsNamed elementNames: [String], undoManager: UndoManager? = nil) {
+        func unwrapChildren(intersectingRange range: NSRange, fromElementsNamed elementNames: [String]) {
             if isBlockLevelElement() && (range.location == self.length() - 1) {
                     return
             }
@@ -1365,7 +1365,7 @@ extension Libxml2 {
                     continue
                 }
 
-                childElement.unwrap(range: range, fromElementsNamed: elementNames, undoManager: undoManager)
+                childElement.unwrap(range: range, fromElementsNamed: elementNames)
             }
         }
 
@@ -1376,7 +1376,7 @@ extension Libxml2 {
         ///     - targetRange: the range that must be wrapped.
         ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        func wrapChildren(intersectingRange targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor, undoManager: UndoManager? = nil) {
+        func wrapChildren(intersectingRange targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
             
             // Before wrapping a range in a new node, we make sure equivalent element nodes wrapping that range are
             // removed.
@@ -1387,7 +1387,7 @@ extension Libxml2 {
                 elementNamesToRemove.append(elementDescriptor.name)
             }
             
-            unwrap(range: targetRange, fromElementsNamed: elementNamesToRemove, undoManager: undoManager)
+            unwrap(range: targetRange, fromElementsNamed: elementNamesToRemove)
 
             let mustFindLowestBlockLevelElements = !elementDescriptor.isBlockLevel()
 
@@ -1403,10 +1403,10 @@ extension Libxml2 {
                         continue
                     }
                     
-                    element.forceWrapChildren(intersectingRange: intersection, inElement: elementDescriptor, undoManager: undoManager)
+                    element.forceWrapChildren(intersectingRange: intersection, inElement: elementDescriptor)
                 }
             } else {
-                forceWrapChildren(intersectingRange: targetRange, inElement: elementDescriptor, undoManager: undoManager)
+                forceWrapChildren(intersectingRange: targetRange, inElement: elementDescriptor)
             }
         }
 
@@ -1421,7 +1421,7 @@ extension Libxml2 {
         ///     - targetRange: the range that must be wrapped.
         ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        func forceWrap(range targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor, undoManager: UndoManager? = nil) {
+        func forceWrap(range targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
             
             if NSEqualRanges(targetRange, range()) {
                 
@@ -1431,12 +1431,12 @@ extension Libxml2 {
                 let canWrapReceiverInNewNode = newNodeIsBlockLevel || !receiverIsBlockLevel
                 
                 if canWrapReceiverInNewNode {
-                    wrap(inElement: elementDescriptor, undoManager: undoManager)
+                    wrap(inElement: elementDescriptor)
                     return
                 }
             }
 
-            forceWrapChildren(intersectingRange: targetRange, inElement: elementDescriptor, undoManager: undoManager)
+            forceWrapChildren(intersectingRange: targetRange, inElement: elementDescriptor)
         }
 
         /// Force wraps child nodes intersecting the specified range inside new elements with the
@@ -1450,7 +1450,7 @@ extension Libxml2 {
         ///     - targetRange: the range that must be wrapped.
         ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        fileprivate func forceWrapChildren(intersectingRange targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor, undoManager: UndoManager? = nil) {
+        fileprivate func forceWrapChildren(intersectingRange targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
                 
             let childNodesAndRanges = childNodes(intersectingRange: targetRange)
             assert(childNodesAndRanges.count > 0)
@@ -1459,7 +1459,7 @@ extension Libxml2 {
             let firstChildIntersection = childNodesAndRanges[0].intersection
             
             if let firstEditableChild = firstChild as? EditableNode, !NSEqualRanges(firstChild.range(), firstChildIntersection) {
-                firstEditableChild.split(forRange: firstChildIntersection, undoManager: undoManager)
+                firstEditableChild.split(forRange: firstChildIntersection)
             }
             
             if childNodesAndRanges.count > 1 {
@@ -1467,7 +1467,7 @@ extension Libxml2 {
                 let lastChildIntersection = childNodesAndRanges[childNodesAndRanges.count - 1].intersection
                 
                 if let lastEditableChild = lastChild as? EditableNode, !NSEqualRanges(lastChild.range(), lastChildIntersection) {
-                    lastEditableChild.split(forRange: lastChildIntersection, undoManager: undoManager)
+                    lastEditableChild.split(forRange: lastChildIntersection)
                 }
             }
             
@@ -1475,7 +1475,7 @@ extension Libxml2 {
                 return child
             })
             
-            wrap(children: children, inElement: elementDescriptor, undoManager: undoManager)
+            wrap(children: children, inElement: elementDescriptor)
         }
 
         /// Wraps the specified children nodes in a newly created element with the specified name.
@@ -1488,11 +1488,11 @@ extension Libxml2 {
         /// - Returns: the newly created `ElementNode`.
         ///
         @discardableResult
-        func wrap(children newChildren: [Node], inElement elementDescriptor: ElementNodeDescriptor, undoManager: UndoManager? = nil) -> ElementNode {
+        func wrap(children newChildren: [Node], inElement elementDescriptor: ElementNodeDescriptor) -> ElementNode {
 
             guard newChildren.count > 0 else {
                 assertionFailure("Avoid calling this method with no nodes.")
-                return ElementNode(descriptor: elementDescriptor)
+                return ElementNode(descriptor: elementDescriptor, registerUndo: registerUndo)
             }
 
             guard let firstNodeIndex = children.index(of: newChildren[0]) else {
@@ -1528,7 +1528,7 @@ extension Libxml2 {
             }
             
             if let sibling = leftSibling {
-                sibling.append(childrenToWrap, undoManager: undoManager)
+                sibling.append(childrenToWrap)
                 childrenToWrap = sibling.children
                 
                 result = sibling
@@ -1541,7 +1541,7 @@ extension Libxml2 {
             if let result = result {
                 return result
             } else {
-                let newNode = ElementNode(descriptor: elementDescriptor, children: childrenToWrap)
+                let newNode = ElementNode(descriptor: elementDescriptor, children: childrenToWrap, registerUndo: registerUndo)
                 
                 children.insert(newNode, at: firstNodeIndex)
                 newNode.parent = self
@@ -1575,8 +1575,8 @@ extension Libxml2 {
         
         // MARK: - Initializers
 
-        init(children: [Node]) {
-            super.init(name: type(of: self).name, attributes: [], children: children)
+        init(children: [Node], registerUndo: @escaping UndoRegistrationClosure) {
+            super.init(name: type(of: self).name, attributes: [], children: children, registerUndo: registerUndo)
         }
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Node.swift
@@ -140,7 +140,6 @@ extension Libxml2 {
         ///
         /// - Parameters:
         ///     - elementDescriptor: the descriptor for the element to wrap the receiver in.
-        ///     - undoManager: the undo manager for the operation.
         ///
         /// - Returns: the newly created element.
         ///

--- a/Aztec/Classes/Libxml2/DOM/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Node.swift
@@ -11,7 +11,8 @@ extension Libxml2 {
         
         // MARK: - Properties: Undo Support
         
-        typealias UndoRegistrationClosure = (_ undoTask: @escaping () -> ()) -> ()
+        typealias UndoClosure = () -> ()
+        typealias UndoRegistrationClosure = (_ undoTask: @escaping UndoClosure) -> ()
         
         let registerUndo: UndoRegistrationClosure
         

--- a/Aztec/Classes/Libxml2/DOM/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/TextNode.swift
@@ -17,10 +17,10 @@ extension Libxml2 {
         
         // MARK: - Initializers
         
-        init(text: String) {
+        init(text: String, registerUndo: @escaping UndoRegistrationClosure) {
             contents = text
 
-            super.init(name: "text")
+            super.init(name: "text", registerUndo: registerUndo)
         }
 
         /// Node length.
@@ -31,28 +31,26 @@ extension Libxml2 {
 
         // MARK: - EditableNode
         
-        func append(_ string: String, undoManager: UndoManager? = nil) {
+        func append(_ string: String) {
             contents.append(string)
         }
 
-        func deleteCharacters(inRange range: NSRange, undoManager: UndoManager? = nil) {
+        func deleteCharacters(inRange range: NSRange) {
 
             guard let textRange = contents.rangeFromNSRange(range) else {
                 fatalError("The specified range is out of bounds.")
             }
 
-            if let undoManager = undoManager, let range = contents.rangeFromNSRange(range) {
-                recordUndoForDeleteCharacters(inRange: range, undoManager: undoManager)
-            }
+            registerUndoForDeleteCharacters(inRange: textRange)
             
             contents.removeSubrange(textRange)
         }
 
-        private func recordUndoForDeleteCharacters(inRange range: Range<String.CharacterView.Index>, undoManager: UndoManager) {
+        private func registerUndoForDeleteCharacters(inRange range: Range<String.CharacterView.Index>) {
             let originalText = self.contents.substring(with: range)
             let index = range.lowerBound
             
-            undoManager.registerUndo(withTarget: self) { [weak self] target in
+            registerUndo { [weak self] in
                 self?.undoDeleteCharacters(atIndex: index, restoring: originalText)
             }
         }
@@ -61,11 +59,11 @@ extension Libxml2 {
             contents.insert(contentsOf: originalText.characters, at: index)
         }
         
-        func prepend(_ string: String, undoManager: UndoManager? = nil) {
+        func prepend(_ string: String) {
             contents = "\(string)\(contents)"
         }
 
-        func replaceCharacters(inRange range: NSRange, withString string: String, inheritStyle: Bool, undoManager: UndoManager? = nil) {
+        func replaceCharacters(inRange range: NSRange, withString string: String, inheritStyle: Bool) {
 
             guard let textRange = contents.rangeFromNSRange(range) else {
                 fatalError("The specified range is out of bounds.")
@@ -74,7 +72,7 @@ extension Libxml2 {
             contents.replaceSubrange(textRange, with: string)
         }
 
-        func split(atLocation location: Int, undoManager: UndoManager? = nil) {
+        func split(atLocation location: Int) {
             
             guard location != 0 && location != length() else {
                 // Nothing to split, move along...
@@ -97,14 +95,14 @@ extension Libxml2 {
             let postRange = index ..< text().endIndex
             
             if postRange.lowerBound != postRange.upperBound {
-                let newNode = TextNode(text: text().substring(with: postRange))
+                let newNode = TextNode(text: text().substring(with: postRange), registerUndo: registerUndo)
                 
                 contents.removeSubrange(postRange)
                 parent.insert(newNode, at: nodeIndex + 1)
             }
         }
         
-        func split(forRange range: NSRange, undoManager: UndoManager? = nil) {
+        func split(forRange range: NSRange) {
 
             guard let swiftRange = contents.rangeFromNSRange(range) else {
                 fatalError("This scenario should not be possible. Review the logic.")
@@ -120,17 +118,17 @@ extension Libxml2 {
             let postRange = swiftRange.upperBound ..< contents.endIndex
 
             if !postRange.isEmpty {
-                let newNode = TextNode(text: contents.substring(with: postRange))
+                let newNode = TextNode(text: contents.substring(with: postRange), registerUndo: registerUndo)
 
                 contents.removeSubrange(postRange)
-                parent.insert(newNode, at: nodeIndex + 1, undoManager: undoManager)
+                parent.insert(newNode, at: nodeIndex + 1)
             }
             
             if !preRange.isEmpty {
-                let newNode = TextNode(text: contents.substring(with: preRange))
+                let newNode = TextNode(text: contents.substring(with: preRange), registerUndo: registerUndo)
 
                 contents.removeSubrange(preRange)
-                parent.insert(newNode, at: nodeIndex, undoManager: undoManager)
+                parent.insert(newNode, at: nodeIndex)
             }
         }
 
@@ -141,15 +139,15 @@ extension Libxml2 {
         ///     - targetRange: the range that must be wrapped.
         ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
-        func wrap(range targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor, undoManager: UndoManager? = nil) {
+        func wrap(range targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
 
             guard !NSEqualRanges(targetRange, NSRange(location: 0, length: length())) else {
-                wrap(inElement: elementDescriptor, undoManager: undoManager)
+                wrap(inElement: elementDescriptor)
                 return
             }
 
-            split(forRange: targetRange, undoManager: undoManager)
-            wrap(inElement: elementDescriptor, undoManager: undoManager)
+            split(forRange: targetRange)
+            wrap(inElement: elementDescriptor)
         }
         
         // MARK: - LeadNode

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -12,13 +12,13 @@ extension Libxml2 {
         
         typealias UndoRegistrationClosure = Node.UndoRegistrationClosure
         
-        fileprivate lazy var registerUndo: Node.UndoRegistrationClosure = { (undoTask: @escaping () -> ()) -> () in
+        private lazy var registerUndo: Node.UndoRegistrationClosure = { (undoTask: @escaping () -> ()) -> () in
             self.domUndoManager.registerUndo(withTarget: self, handler: { target in
                 undoTask()
             })
         }
         
-        fileprivate lazy var rootNode: RootNode = {
+        private lazy var rootNode: RootNode = {
             
             let textNode = TextNode(text: "", registerUndo: self.registerUndo)
             
@@ -27,7 +27,7 @@ extension Libxml2 {
         
         private var parentUndoManager: UndoManager?
         
-        public var undoManager: UndoManager? {
+        var undoManager: UndoManager? {
             get {
                 return parentUndoManager
             }
@@ -80,7 +80,7 @@ extension Libxml2 {
                     return
                 }
                 
-                let converter = Libxml2.Out.HTMLConverter(registerUndo: strongSelf.registerUndo)
+                let converter = Libxml2.Out.HTMLConverter()
                 result = converter.convert(strongSelf.rootNode)
             }
             

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -10,10 +10,19 @@ extension Libxml2 {
     ///
     class DOMString {
         
-        typealias RootNode = Libxml2.RootNode
+        typealias UndoRegistrationClosure = Node.UndoRegistrationClosure
         
-        fileprivate var rootNode: RootNode = {
-            return RootNode(children: [TextNode(text: "")])
+        fileprivate lazy var registerUndo: Node.UndoRegistrationClosure = { (undoTask: @escaping () -> ()) -> () in
+            self.domUndoManager.registerUndo(withTarget: self, handler: { target in
+                undoTask()
+            })
+        }
+        
+        fileprivate lazy var rootNode: RootNode = {
+            
+            let textNode = TextNode(text: "", registerUndo: self.registerUndo)
+            
+            return RootNode(children: [textNode], registerUndo: self.registerUndo)
         }()
         
         private var parentUndoManager: UndoManager?
@@ -30,9 +39,6 @@ extension Libxml2 {
             }
         }
         
-        private var undoObserver: NSObjectProtocol?
-        private var beginGroupObserver: NSObjectProtocol?
-        
         /// The private undo manager for the DOM.  This needs to be separated from the public undo
         /// manager because it'll be running in a separate dispatch queue, and undo managers "break"
         /// undo groups by run loops.
@@ -41,6 +47,14 @@ extension Libxml2 {
         /// an undo operation.
         ///
         private var domUndoManager = UndoManager()
+        
+        /// Parent undo manager observer for the undo event.
+        ///
+        private var undoObserver: NSObjectProtocol?
+        
+        /// Parent undo manager observer for the beginGroup event.
+        ///
+        private var beginGroupObserver: NSObjectProtocol?
         
         /// The queue that will be used for all DOM interaction operations.
         ///
@@ -66,7 +80,7 @@ extension Libxml2 {
                     return
                 }
                 
-                let converter = Libxml2.Out.HTMLConverter()
+                let converter = Libxml2.Out.HTMLConverter(registerUndo: strongSelf.registerUndo)
                 result = converter.convert(strongSelf.rootNode)
             }
             
@@ -84,7 +98,7 @@ extension Libxml2 {
         ///
         func setHTML(_ html: String, withDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) -> NSAttributedString {
             
-            let converter = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
+            let converter = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor, registerUndo: registerUndo)
             let output: (rootNode: RootNode, attributedString: NSAttributedString)
             
             do {
@@ -151,12 +165,12 @@ extension Libxml2 {
         ///             no associated style.
         ///
         private func replaceCharactersSynchronously(inRange range: NSRange, withString string: String, inheritStyle: Bool) {
-            rootNode.replaceCharacters(inRange: range, withString: string, inheritStyle: inheritStyle, undoManager: domUndoManager)
+            rootNode.replaceCharacters(inRange: range, withString: string, inheritStyle: inheritStyle)
         }
 
         private func replaceCharactersSynchronously(inRange range: NSRange, withAttributedString attributedString: NSAttributedString, inheritStyle: Bool) {
             
-            rootNode.replaceCharacters(inRange: range, withString: attributedString.string, inheritStyle: inheritStyle, undoManager: domUndoManager)
+            rootNode.replaceCharacters(inRange: range, withString: attributedString.string, inheritStyle: inheritStyle)
             
             applyStyles(from: attributedString, to: range.location)
         }
@@ -482,7 +496,7 @@ extension Libxml2 {
             let elementDescriptor = ElementNodeDescriptor(elementType: .a,
                                                           attributes: [Libxml2.StringAttribute(name:"href", value: url.absoluteString)])
             
-            rootNode.wrapChildren(intersectingRange: range, inElement: elementDescriptor, undoManager: domUndoManager)
+            rootNode.wrapChildren(intersectingRange: range, inElement: elementDescriptor)
         }
 
         // MARK: Remove Styles
@@ -535,19 +549,19 @@ extension Libxml2 {
         // MARK: - Remove Styles: Synchronously
         
         private func removeBoldSynchronously(spanning range: NSRange) {
-            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.b.equivalentNames, undoManager: domUndoManager)
+            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.b.equivalentNames)
         }
         
         private func removeItalicSynchronously(spanning range: NSRange) {
-            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.i.equivalentNames, undoManager: domUndoManager)
+            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.i.equivalentNames)
         }
         
         private func removeStrikethroughSynchronously(spanning range: NSRange) {
-            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.s.equivalentNames, undoManager: domUndoManager)
+            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.s.equivalentNames)
         }
         
         private func removeUnderlineSynchronously(spanning range: NSRange) {
-            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.u.equivalentNames, undoManager: domUndoManager)
+            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.u.equivalentNames)
         }
         
         // Apply Styles
@@ -615,7 +629,7 @@ extension Libxml2 {
         fileprivate func applyElement(_ elementName: String, spanning range: NSRange, equivalentElementNames: [String]) {
             
             let elementDescriptor = ElementNodeDescriptor(name: elementName, attributes: [], matchingNames: equivalentElementNames)
-            rootNode.wrapChildren(intersectingRange: range, inElement: elementDescriptor, undoManager: domUndoManager)
+            rootNode.wrapChildren(intersectingRange: range, inElement: elementDescriptor)
         }
         
         // MARK: - Candidates for removal
@@ -635,7 +649,7 @@ extension Libxml2 {
         // MARK: - Candidates for removal: Synchronously
         
         private func removeLinkSynchronously(inRange range: NSRange) {
-            rootNode.unwrap(range: range, fromElementsNamed: ["a"], undoManager: domUndoManager)
+            rootNode.unwrap(range: range, fromElementsNamed: ["a"])
         }
         
         private func updateImageSynchronously(spanning ranges: [NSRange], url: URL, size: TextAttachment.Size, alignment: TextAttachment.Alignment) {
@@ -645,10 +659,10 @@ extension Libxml2 {
                 
                 if element.name == StandardElementType.img.rawValue {
                     let classAttributes = alignment.htmlString() + " " + size.htmlString()
-                    element.updateAttribute(named: "class", value: classAttributes, undoManager: domUndoManager)
+                    element.updateAttribute(named: "class", value: classAttributes)
                     
                     if element.name == StandardElementType.img.rawValue {
-                        element.updateAttribute(named: "src", value: url.absoluteString, undoManager: domUndoManager)
+                        element.updateAttribute(named: "src", value: url.absoluteString)
                     }
                 }
             }

--- a/Aztec/Classes/Libxml2/UndoStack.swift
+++ b/Aztec/Classes/Libxml2/UndoStack.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class UndoStack {
+    
+}

--- a/AztecTests/Exporter/OutHTMLConverterTests.swift
+++ b/AztecTests/Exporter/OutHTMLConverterTests.swift
@@ -20,7 +20,7 @@ class OutHTMLConverterTests: XCTestCase {
     }
 
     func testSimpleNodeConversion() {
-        let inParser = Libxml2.In.HTMLConverter()
+        let inParser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
         let outParser = Libxml2.Out.HTMLConverter()
 
         let html = "<bold><i>Hello!</i></bold>"
@@ -36,7 +36,7 @@ class OutHTMLConverterTests: XCTestCase {
     }
 
     func testCommentNodeConversion() {
-        let inParser = Libxml2.In.HTMLConverter()
+        let inParser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
         let outParser = Libxml2.Out.HTMLConverter()
 
         let html = "<!--Hello Sample--><bold><i>Hello!</i></bold>"

--- a/AztecTests/Exporter/OutNodeConverterTests.swift
+++ b/AztecTests/Exporter/OutNodeConverterTests.swift
@@ -24,7 +24,7 @@ class OutNodeConverterTests: XCTestCase {
 
         let nodeName = "text"
         let nodeText = "This is the text."
-        let textNode = TextNode(text: nodeText)
+        let textNode = TextNode(text: nodeText, registerUndo: { _ in })
         let xmlNodePtr = Libxml2.Out.NodeConverter().convert(textNode)
         let xmlNode = xmlNodePtr.pointee
 
@@ -46,10 +46,10 @@ class OutNodeConverterTests: XCTestCase {
     func testElementAndChildElementNodeConversion() {
         
         let innerNodeName = "innerNode"
-        let innerNode = ElementNode(name: innerNodeName, attributes: [], children: [])
+        let innerNode = ElementNode(name: innerNodeName, attributes: [], children: [], registerUndo: { _ in })
         
         let outerNodeName = "element"
-        let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode])
+        let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode], registerUndo: { _ in })
         
         let xmlOuterNodePtr = Libxml2.Out.NodeConverter().convert(testNode)
         let xmlOuterNode = xmlOuterNodePtr.pointee
@@ -80,10 +80,10 @@ class OutNodeConverterTests: XCTestCase {
     func testElementAndChildTextNodeConversion() {
 
         let innerNodeText = "some text"
-        let innerNode = TextNode(text: innerNodeText)
+        let innerNode = TextNode(text: innerNodeText, registerUndo: { _ in })
 
         let outerNodeName = "element"
-        let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode])
+        let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode], registerUndo: { _ in })
 
         let xmlOuterNodePtr = Libxml2.Out.NodeConverter().convert(testNode)
         let xmlOuterNode = xmlOuterNodePtr.pointee

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -25,11 +25,11 @@ class ElementNodeTests: XCTestCase {
     /// returns the element node, as expected.
     ///
     func testThatLowestElementNodeWrappingRangeWorksWithASingleElementNode() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: {})
-        let text2 = TextNode(text: "text2 goes here", registerUndo: {})
-        let text3 = TextNode(text: "text3 goes here", registerUndo: {})
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length(), length: text2.length())
 
         let node = mainNode.lowestElementNodeWrapping(range)
@@ -40,13 +40,13 @@ class ElementNodeTests: XCTestCase {
     /// Whenever the range is inside a child node, make sure that child node is returned.
     ///
     func testThatLowestElementNodeWrappingRangeWorksWithAChildNode1() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: {})
-        let text2 = TextNode(text: "text2 goes here", registerUndo: {})
-        let text3 = TextNode(text: "text3 goes here", registerUndo: {})
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
 
-        let childNode = ElementNode(name: "em", attributes: [], children: [text2])
+        let childNode = ElementNode(name: "em", attributes: [], children: [text2], registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length(), length: text2.length())
 
         let node = mainNode.lowestElementNodeWrapping(range)
@@ -58,13 +58,13 @@ class ElementNodeTests: XCTestCase {
     /// returned instead.
     ///
     func testThatLowestElementNodeWrappingRangeWorksWithAChildNode2() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here")
-        let text3 = TextNode(text: "text3 goes here")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
 
-        let childNode = ElementNode(name: "em", attributes: [], children: [text2])
+        let childNode = ElementNode(name: "em", attributes: [], children: [text2], registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length() - 1, length: text2.length() + 2)
 
         let node = mainNode.lowestElementNodeWrapping(range)
@@ -76,11 +76,11 @@ class ElementNodeTests: XCTestCase {
     /// returns the text node, as expected.
     ///
     func testThatLowestTextNodeWrappingRangeWorksWithASingleElementNode() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here")
-        let text3 = TextNode(text: "text3 goes here")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length(), length: text2.length())
 
         let node = mainNode.lowestTextNodeWrapping(range)
@@ -91,13 +91,13 @@ class ElementNodeTests: XCTestCase {
     /// Whenever the range is inside a child node, make sure that child node is returned.
     ///
     func testThatLowestTextNodeWrappingRangeWorksWithAChildNode1() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here")
-        let text3 = TextNode(text: "text3 goes here")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
 
-        let childNode = ElementNode(name: "em", attributes: [], children: [text2])
+        let childNode = ElementNode(name: "em", attributes: [], children: [text2], registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length(), length: text2.length())
 
         let node = mainNode.lowestTextNodeWrapping(range)
@@ -109,13 +109,13 @@ class ElementNodeTests: XCTestCase {
     /// returned instead.
     ///
     func testThatLowestTextNodeWrappingRangeWorksWithAChildNode2() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here")
-        let text3 = TextNode(text: "text3 goes here")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
 
-        let childNode = ElementNode(name: "em", attributes: [], children: [text2])
+        let childNode = ElementNode(name: "em", attributes: [], children: [text2], registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length() - 1, length: text2.length() + 2)
 
         let node = mainNode.lowestTextNodeWrapping(range)
@@ -134,11 +134,11 @@ class ElementNodeTests: XCTestCase {
     ///
     func testEnumerateBlockLowestElementsIntersectingRange() {
 
-        let textNode1 = TextNode(text: "Hello ")
-        let textNode2 = TextNode(text: "world")
-        let textNode3 = TextNode(text: "!")
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        let textNode1 = TextNode(text: "Hello ", registerUndo: { _ in })
+        let textNode2 = TextNode(text: "world", registerUndo: { _ in })
+        let textNode3 = TextNode(text: "!", registerUndo: { _ in })
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
 
         let range = NSRange(location: textNode1.length(), length: textNode2.length())
         let atLeastOneElementFound = expectation(description: "At least one elements should be returned in the enumeration.")
@@ -157,11 +157,11 @@ class ElementNodeTests: XCTestCase {
     }
     
     func testLeafNodesWrappingRange1() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here")
-        let text3 = TextNode(text: "text3 goes here")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: 0, length: mainNode.length())
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -177,11 +177,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange2() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: 0, length: mainNode.length() - 2)
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -197,11 +197,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange3() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: 1, length: mainNode.length() - 1)
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -217,11 +217,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange4() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length(), length: mainNode.length() - text1.length())
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -235,11 +235,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange5() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: 0, length: (mainNode.length() - 1) - text3.length())
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -253,11 +253,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange6() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length(), length: 0)
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -269,11 +269,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange7() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
         let range = NSRange(location: text1.length() - 1, length: 0)
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -298,9 +298,9 @@ class ElementNodeTests: XCTestCase {
         let text1 = "Hello"
         let text2 = " World!"
         
-        let textNode = TextNode(text: "\(text1)\(text2)")
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        let textNode = TextNode(text: "\(text1)\(text2)", registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph], registerUndo: { _ in })
         
         let splitLocation = text1.characters.count
         
@@ -331,9 +331,9 @@ class ElementNodeTests: XCTestCase {
     func testSplitAtLocation2() {
         
         let text = "Hello World!"
-        let textNode = TextNode(text: text)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        let textNode = TextNode(text: text, registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph], registerUndo: { _ in })
         
         let splitLocation = 0
         
@@ -358,9 +358,9 @@ class ElementNodeTests: XCTestCase {
     func testSplitAtLocation3() {
         
         let text = "Hello World!"
-        let textNode = TextNode(text: text)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        let textNode = TextNode(text: text, registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph], registerUndo: { _ in })
         
         let splitLocation = text.characters.count
         
@@ -375,9 +375,9 @@ class ElementNodeTests: XCTestCase {
 
     func testSplitWithFullRange() {
 
-        let textNode = TextNode(text: "Some text goes here")
-        let elemNode = ElementNode(name: "SomeNode", attributes: [], children: [textNode])
-        let rootNode = RootNode(children: [elemNode])
+        let textNode = TextNode(text: "Some text goes here", registerUndo: { _ in })
+        let elemNode = ElementNode(name: "SomeNode", attributes: [], children: [textNode], registerUndo: { _ in })
+        let rootNode = RootNode(children: [elemNode], registerUndo: { _ in })
 
         let splitRange = NSRange(location: 0, length: textNode.length())
 
@@ -397,9 +397,9 @@ class ElementNodeTests: XCTestCase {
         let textPart2 = " text goes here"
         let fullText = "\(textPart1)\(textPart2)"
 
-        let textNode = TextNode(text: fullText)
-        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
-        let rootNode = RootNode(children: [elemNode])
+        let textNode = TextNode(text: fullText, registerUndo: { _ in })
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode], registerUndo: { _ in })
+        let rootNode = RootNode(children: [elemNode], registerUndo: { _ in })
 
         let splitRange = NSRange(location: 0, length: textPart1.characters.count)
 
@@ -444,9 +444,9 @@ class ElementNodeTests: XCTestCase {
         let textPart2 = " text goes here"
         let fullText = "\(textPart1)\(textPart2)"
 
-        let textNode = TextNode(text: fullText)
-        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
-        let rootNode = RootNode(children: [elemNode])
+        let textNode = TextNode(text: fullText, registerUndo: { _ in })
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode], registerUndo: { _ in })
+        let rootNode = RootNode(children: [elemNode], registerUndo: { _ in })
 
         let splitRange = NSRange(location: textPart1.characters.count, length: textPart2.characters.count)
 
@@ -493,9 +493,9 @@ class ElementNodeTests: XCTestCase {
         let textPart3 = "here"
         let fullText = "\(textPart1)\(textPart2)\(textPart3)"
 
-        let textNode = TextNode(text: fullText)
-        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
-        let rootNode = RootNode(children: [elemNode])
+        let textNode = TextNode(text: fullText, registerUndo: { _ in })
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode], registerUndo: { _ in })
+        let rootNode = RootNode(children: [elemNode], registerUndo: { _ in })
 
         let splitRange = NSRange(location: textPart1.characters.count, length: textPart2.characters.count)
 
@@ -558,11 +558,11 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there"
 
-        let textNode1 = TextNode(text: textPart1)
-        let textNode2 = TextNode(text: textPart2)
+        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
+        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
 
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
-        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph], registerUndo: { _ in })
 
         let results = div.lowestBlockLevelElements(intersectingRange: div.range())
 
@@ -589,12 +589,12 @@ class ElementNodeTests: XCTestCase {
         let textPart2 = "there"
         let textPart3 = " man!"
 
-        let textNode1 = TextNode(text: textPart1)
-        let textNode2 = TextNode(text: textPart2)
-        let textNode3 = TextNode(text: textPart3)
+        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
+        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
+        let textNode3 = TextNode(text: textPart3, registerUndo: { _ in })
 
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
-        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3], registerUndo: { _ in })
 
         let results = div.lowestBlockLevelElements(intersectingRange: div.range())
 
@@ -624,11 +624,11 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there!"
 
-        let textNode1 = TextNode(text: textPart1)
-        let textNode2 = TextNode(text: textPart2)
+        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
+        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
 
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2], registerUndo: { _ in })
 
         let results = div.lowestBlockLevelElements(intersectingRange: div.range())
 
@@ -652,8 +652,8 @@ class ElementNodeTests: XCTestCase {
         let text1 = "Hello"
         let text2 = " there!"
         let fullText = "\(text1)\(text2)"
-        let textNode = TextNode(text: fullText)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let textNode = TextNode(text: fullText, registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
         
         let wrapRange = NSRange(location: 0, length: text1.characters.count)
         
@@ -686,8 +686,8 @@ class ElementNodeTests: XCTestCase {
     ///
     func testForceWrapChildren2() {
         let fullText = "Hello there!"
-        let textNode = TextNode(text: fullText)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let textNode = TextNode(text: fullText, registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
         
         let wrapRange = NSRange(location: 0, length: fullText.characters.count)
         
@@ -714,10 +714,10 @@ class ElementNodeTests: XCTestCase {
     func testForceWrapChildren3() {
         let text1 = "Hello"
         let text2 = " there!"
-        let textNode1 = TextNode(text: text1)
-        let textNode2 = TextNode(text: text2)
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode1])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode, textNode2])
+        let textNode1 = TextNode(text: text1, registerUndo: { _ in })
+        let textNode2 = TextNode(text: text2, registerUndo: { _ in })
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode, textNode2], registerUndo: { _ in })
 
         let wrapRange = NSRange(location: text1.characters.count, length: text2.characters.count)
         
@@ -750,11 +750,11 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there!"
 
-        let textNode1 = TextNode(text: textPart1)
-        let textNode2 = TextNode(text: textPart2)
+        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
+        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
 
-        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
-        let div = ElementNode(name: "div", attributes: [], children: [em, textNode2])
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [em, textNode2], registerUndo: { _ in })
 
         div.wrapChildren(intersectingRange: range, inElement: ElementNodeDescriptor(elementType: boldElementType))
 
@@ -792,12 +792,12 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there!"
 
-        let textNode1 = TextNode(text: textPart1)
-        let textNode2 = TextNode(text: textPart2)
+        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
+        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
 
-        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
-        let underline = ElementNode(name: "u", attributes: [], children: [textNode2])
-        let div = ElementNode(name: "div", attributes: [], children: [em, underline])
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let underline = ElementNode(name: "u", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [em, underline], registerUndo: { _ in })
 
         div.wrapChildren(intersectingRange: div.range(), inElement: ElementNodeDescriptor(name: boldNodeName))
 
@@ -835,12 +835,12 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there!"
 
-        let textNode1 = TextNode(text: textPart1)
-        let textNode2 = TextNode(text: textPart2)
+        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
+        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
 
-        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
-        let underline = ElementNode(name: "u", attributes: [], children: [textNode2])
-        let div = ElementNode(name: "div", attributes: [], children: [em, underline])
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let underline = ElementNode(name: "u", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [em, underline], registerUndo: { _ in })
 
         let range = NSRange(location: 2, length: 8)
 
@@ -879,9 +879,9 @@ class ElementNodeTests: XCTestCase {
     ///     - The output should match the input.
     ///
     func testWrapChildrenIntersectingRangeWithEquivalentNodeNames1() {
-        let textNode = TextNode(text: "Hello there")
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode])
-        let divNode = ElementNode(name: "div", attributes: [], children: [boldNode])
+        let textNode = TextNode(text: "Hello there", registerUndo: { _ in })
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode], registerUndo: { _ in })
+        let divNode = ElementNode(name: "div", attributes: [], children: [boldNode], registerUndo: { _ in })
         
         let range = NSRange(location: 0, length: 11)
         
@@ -911,13 +911,13 @@ class ElementNodeTests: XCTestCase {
     ///     - the range should be unchanged
     ///
     func testChildNodesIntersectingRange1() {
-        let textNode = TextNode(text: "This is a test string.")
+        let textNode = TextNode(text: "This is a test string.", registerUndo: { _ in })
         let rangeLocation = 5
         XCTAssert(rangeLocation < textNode.length(),
                   "For this text we need to make sure the range location is inside the test node.")
 
         let range = NSRange(location: rangeLocation, length: 0)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
 
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range)
 
@@ -941,13 +941,13 @@ class ElementNodeTests: XCTestCase {
     ///     - the range should be unchanged
     ///
     func testChildNodesIntersectingRange2() {
-        let textNode = TextNode(text: "This is a test string.")
+        let textNode = TextNode(text: "This is a test string.", registerUndo: { _ in })
         let rangeLocation = 0
         XCTAssert(rangeLocation < textNode.length(),
                   "For this text we need to make sure the range location is inside the test node.")
 
         let range = NSRange(location: rangeLocation, length: 0)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
 
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range)
 
@@ -972,8 +972,8 @@ class ElementNodeTests: XCTestCase {
     ///
     func testChildNodesIntersectingRange3() {
 
-        let textNode1 = TextNode(text: "Hello")
-        let textNode2 = TextNode(text: "Hello again!")
+        let textNode1 = TextNode(text: "Hello", registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello again!", registerUndo: { _ in })
 
         let rangeLocation = 5
         XCTAssert(rangeLocation == textNode1.length(),
@@ -981,9 +981,9 @@ class ElementNodeTests: XCTestCase {
 
         let range = NSRange(location: rangeLocation, length: 0)
 
-        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1])
-        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2])
+        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2], registerUndo: { _ in })
 
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range, preferLeftNode: true)
 
@@ -1008,8 +1008,8 @@ class ElementNodeTests: XCTestCase {
     ///
     func testChildNodesIntersectingRange4() {
 
-        let textNode1 = TextNode(text: "Hello")
-        let textNode2 = TextNode(text: "Hello again!")
+        let textNode1 = TextNode(text: "Hello", registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello again!", registerUndo: { _ in })
 
         let rangeLocation = 5
         XCTAssert(rangeLocation == textNode1.length(),
@@ -1017,9 +1017,9 @@ class ElementNodeTests: XCTestCase {
 
         let range = NSRange(location: rangeLocation, length: 0)
 
-        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1])
-        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2])
+        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2], registerUndo: { _ in })
 
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range, preferLeftNode: false)
 
@@ -1042,11 +1042,11 @@ class ElementNodeTests: XCTestCase {
     ///     - Output should be: <p>---<b>Hello1</b><b>Hello2</b></p>
     ///
     func testInsertStringAt1() {
-        let textNode1 = TextNode(text: "Hello1")
-        let textNode2 = TextNode(text: "Hello2")
-        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
-        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
+        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2], registerUndo: { _ in })
         
         let textToInsert = "---"
         
@@ -1073,11 +1073,11 @@ class ElementNodeTests: XCTestCase {
     ///     - Output should be: <p><b>Hello1</b>---<b>Hello2</b></p>
     ///
     func testInsertStringAt2() {
-        let textNode1 = TextNode(text: "Hello1")
-        let textNode2 = TextNode(text: "Hello2")
-        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
-        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
+        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2], registerUndo: { _ in })
         
         let textToInsert = "---"
         
@@ -1104,11 +1104,11 @@ class ElementNodeTests: XCTestCase {
     ///     - Output should be: <p><b>Hello1</b><b>Hello2</b>---</p>
     ///
     func testInsertStringAt3() {
-        let textNode1 = TextNode(text: "Hello1")
-        let textNode2 = TextNode(text: "Hello2")
-        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
-        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
+        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2], registerUndo: { _ in })
         
         let textToInsert = "---"
         
@@ -1139,11 +1139,11 @@ class ElementNodeTests: XCTestCase {
         
         let adjacentText = "Hello1"
         
-        let textNode1 = TextNode(text: adjacentText)
-        let textNode2 = TextNode(text: "Hello2")
-        let textNode3 = TextNode(text: "Hello3")
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        let textNode1 = TextNode(text: adjacentText, registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
+        let textNode3 = TextNode(text: "Hello3", registerUndo: { _ in })
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
         
         let textToInsert = "---"
         
@@ -1174,11 +1174,11 @@ class ElementNodeTests: XCTestCase {
         
         let adjacentText = "Hello1"
         
-        let textNode1 = TextNode(text: adjacentText)
-        let textNode2 = TextNode(text: "Hello2")
-        let textNode3 = TextNode(text: "Hello3")
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        let textNode1 = TextNode(text: adjacentText, registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
+        let textNode3 = TextNode(text: "Hello3", registerUndo: { _ in })
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
         
         let textToInsert = "---"
         
@@ -1209,11 +1209,11 @@ class ElementNodeTests: XCTestCase {
         
         let adjacentText = "Hello3"
         
-        let textNode1 = TextNode(text: "Hello1")
-        let textNode2 = TextNode(text: "Hello2")
-        let textNode3 = TextNode(text: adjacentText)
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
+        let textNode3 = TextNode(text: adjacentText, registerUndo: { _ in })
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
         
         let textToInsert = "---"
         
@@ -1245,11 +1245,11 @@ class ElementNodeTests: XCTestCase {
         
         let adjacentText = "Hello3"
         
-        let textNode1 = TextNode(text: "Hello1")
-        let textNode2 = TextNode(text: "Hello2")
-        let textNode3 = TextNode(text: adjacentText)
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
+        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
+        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
+        let textNode3 = TextNode(text: adjacentText, registerUndo: { _ in })
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
         
         let textToInsert = "---"
         
@@ -1277,10 +1277,10 @@ class ElementNodeTests: XCTestCase {
     /// - Output: `<p>Click on this <a href="http://www.wordpress.com">link!</a></p>`
     ///
     func testReplaceCharactersInRangeWithString() {
-        let linkText = TextNode(text: "link")
-        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText])
-        let preLinkText = TextNode(text: "Click on this ")
-        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement])
+        let linkText = TextNode(text: "link", registerUndo: { _ in })
+        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText], registerUndo: { _ in })
+        let preLinkText = TextNode(text: "Click on this ", registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement], registerUndo: { _ in })
         
         let range = NSRange(location: 14, length: 4)
         let newString = "link!"
@@ -1313,10 +1313,10 @@ class ElementNodeTests: XCTestCase {
     func testReplaceCharactersInRangeWithString2() {
         let text1 = "Click on this "
         let text2 = "link"
-        let linkText = TextNode(text: text2)
-        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText])
-        let preLinkText = TextNode(text: text1)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement])
+        let linkText = TextNode(text: text2, registerUndo: { _ in })
+        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText], registerUndo: { _ in })
+        let preLinkText = TextNode(text: text1, registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement], registerUndo: { _ in })
         
         let range = NSRange(location: 14, length: 4)
         let newString = "link!"
@@ -1346,11 +1346,11 @@ class ElementNodeTests: XCTestCase {
     func testReplaceCharactersInRangeWithString3() {
         let text1 = "Click on this "
         let text2 = "link"
-        let linkText = TextNode(text: text2)
-        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText])
-        let preLinkText = TextNode(text: text1)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement])
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
+        let linkText = TextNode(text: text2, registerUndo: { _ in })
+        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText], registerUndo: { _ in })
+        let preLinkText = TextNode(text: text1, registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement], registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph], registerUndo: { _ in })
         
         let range = NSRange(location: 14, length: 4)
         let newString = "link!"
@@ -1388,8 +1388,8 @@ class ElementNodeTests: XCTestCase {
         let startText = "Look at this photo:"
         let middleText = "image"
         let endText = ".It's amazing"
-        let paragraphText = TextNode(text: startText + middleText + endText)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [paragraphText])
+        let paragraphText = TextNode(text: startText + middleText + endText, registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [paragraphText], registerUndo: { _ in })
 
         let range = NSRange(location: startText.characters.count, length: middleText.characters.count)
         let imgSrc = "https://httpbin.org/image/jpeg"
@@ -1436,11 +1436,11 @@ class ElementNodeTests: XCTestCase {
     ///
     func testPushUpLeftSideDescendant() {
         
-        let text1 = TextNode(text: "Hello ")
-        let text2 = TextNode(text: "there!")
-        let bold = ElementNode(name: "b", attributes: [], children: [text1])
-        let strike = ElementNode(name: "strike", attributes: [], children: [bold, text2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [strike])
+        let text1 = TextNode(text: "Hello ", registerUndo: { _ in })
+        let text2 = TextNode(text: "there!", registerUndo: { _ in })
+        let bold = ElementNode(name: "b", attributes: [], children: [text1], registerUndo: { _ in })
+        let strike = ElementNode(name: "strike", attributes: [], children: [bold, text2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [strike], registerUndo: { _ in })
         
         let result = strike.pushUp(leftSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
@@ -1483,9 +1483,9 @@ class ElementNodeTests: XCTestCase {
     ///
     func testPushUpLeftSideDescendantWithNilResult() {
         
-        let text = TextNode(text: "Hello there!")
-        let strike = ElementNode(name: "strike", attributes: [], children: [text])
-        _ = ElementNode(name: "p", attributes: [], children: [strike])
+        let text = TextNode(text: "Hello there!", registerUndo: { _ in })
+        let strike = ElementNode(name: "strike", attributes: [], children: [text], registerUndo: { _ in })
+        _ = ElementNode(name: "p", attributes: [], children: [strike], registerUndo: { _ in })
         
         let result = strike.pushUp(leftSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
@@ -1506,11 +1506,11 @@ class ElementNodeTests: XCTestCase {
     ///
     func testPushUpRightSideDescendant() {
         
-        let text1 = TextNode(text: "Hello ")
-        let text2 = TextNode(text: "there!")
-        let bold = ElementNode(name: "b", attributes: [], children: [text2])
-        let strike = ElementNode(name: "strike", attributes: [], children: [text1, bold])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [strike])
+        let text1 = TextNode(text: "Hello ", registerUndo: { _ in })
+        let text2 = TextNode(text: "there!", registerUndo: { _ in })
+        let bold = ElementNode(name: "b", attributes: [], children: [text2], registerUndo: { _ in })
+        let strike = ElementNode(name: "strike", attributes: [], children: [text1, bold], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [strike], registerUndo: { _ in })
         
         let _ = strike.pushUp(rightSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
@@ -1552,9 +1552,9 @@ class ElementNodeTests: XCTestCase {
     ///
     func testPushUpRightSideDescendantWithNilResult() {
         
-        let text = TextNode(text: "Hello there!")
-        let strike = ElementNode(name: "strike", attributes: [], children: [text])
-        let _ = ElementNode(name: "p", attributes: [], children: [strike])
+        let text = TextNode(text: "Hello there!", registerUndo: { _ in })
+        let strike = ElementNode(name: "strike", attributes: [], children: [text], registerUndo: { _ in })
+        let _ = ElementNode(name: "p", attributes: [], children: [strike], registerUndo: { _ in })
         
         let result = strike.pushUp(rightSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
@@ -1577,10 +1577,10 @@ class ElementNodeTests: XCTestCase {
     func testInsertNewlineAfterDivShouldNotCrash() {
         let text1 = "This is a paragraph in a div"
         let text2 = "\nThis is some unwrapped text"
-        let divText = TextNode(text: text1)
-        let div = ElementNode(name: "div", attributes: [], children: [divText])
-        let unwrappedText = TextNode(text: text2)
-        let rootNode = RootNode(children: [div, unwrappedText])
+        let divText = TextNode(text: text1, registerUndo: { _ in })
+        let div = ElementNode(name: "div", attributes: [], children: [divText], registerUndo: { _ in })
+        let unwrappedText = TextNode(text: text2, registerUndo: { _ in })
+        let rootNode = RootNode(children: [div, unwrappedText], registerUndo: { _ in })
         let location = text1.characters.count
 
         rootNode.insert("\n", atLocation: location)

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -25,9 +25,9 @@ class ElementNodeTests: XCTestCase {
     /// returns the element node, as expected.
     ///
     func testThatLowestElementNodeWrappingRangeWorksWithASingleElementNode() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here")
-        let text3 = TextNode(text: "text3 goes here")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: {})
+        let text2 = TextNode(text: "text2 goes here", registerUndo: {})
+        let text3 = TextNode(text: "text3 goes here", registerUndo: {})
 
         let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: text1.length(), length: text2.length())
@@ -40,9 +40,9 @@ class ElementNodeTests: XCTestCase {
     /// Whenever the range is inside a child node, make sure that child node is returned.
     ///
     func testThatLowestElementNodeWrappingRangeWorksWithAChildNode1() {
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here")
-        let text3 = TextNode(text: "text3 goes here")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: {})
+        let text2 = TextNode(text: "text2 goes here", registerUndo: {})
+        let text3 = TextNode(text: "text3 goes here", registerUndo: {})
 
         let childNode = ElementNode(name: "em", attributes: [], children: [text2])
 

--- a/AztecTests/HTML/NodeTests.swift
+++ b/AztecTests/HTML/NodeTests.swift
@@ -18,7 +18,7 @@ class NodeTests: XCTestCase {
     }
 
     func testElementNodesToRoot() {
-
+        
         let text = TextNode(text: "text1 goes here")
 
         let node1 = ElementNode(name: "p", attributes: [], children: [text])

--- a/AztecTests/HTML/NodeTests.swift
+++ b/AztecTests/HTML/NodeTests.swift
@@ -24,9 +24,9 @@ class NodeTests: XCTestCase {
         
         let text = TextNode(text: "text1 goes here", registerUndo: { _ in })
 
-        let node1 = createElementNode(name: "p", attributes: [], children: [text], registerUndo: { _ in })
-        let node2 = createElementNode(name: "p", attributes: [], children: [node1], registerUndo: { _ in })
-        let node3 = createElementNode(name: "p", attributes: [], children: [node2], registerUndo: { _ in })
+        let node1 = ElementNode(name: "p", attributes: [], children: [text], registerUndo: { _ in })
+        let node2 = ElementNode(name: "p", attributes: [], children: [node1], registerUndo: { _ in })
+        let node3 = ElementNode(name: "p", attributes: [], children: [node2], registerUndo: { _ in })
 
         let parentNodes = text.elementNodesToRoot()
 
@@ -50,34 +50,34 @@ class NodeTests: XCTestCase {
 
     func testFirstElementNodeInCommon2() {
 
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
 
-        let element1 = ElementNode(name: "p", attributes: [], children: [text1])
-        let element2 = ElementNode(name: "p", attributes: [], children: [text2])
-        let element3 = ElementNode(name: "p", attributes: [], children: [element1, element2])
+        let element1 = ElementNode(name: "p", attributes: [], children: [text1], registerUndo: { _ in })
+        let element2 = ElementNode(name: "p", attributes: [], children: [text2], registerUndo: { _ in })
+        let element3 = ElementNode(name: "p", attributes: [], children: [element1, element2], registerUndo: { _ in })
 
         XCTAssertEqual(text1.firstElementNodeInCommon(withNode: text2), element3)
     }
 
     func testFirstElementNodeInCommonNotFound() {
 
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
 
-        let _ = ElementNode(name: "p", attributes: [], children: [text1])
+        let _ = ElementNode(name: "p", attributes: [], children: [text1], registerUndo: { _ in })
 
         XCTAssertEqual(text1.firstElementNodeInCommon(withNode: text2), nil)
     }
 
     func testFirstElementNodeInCommonWithUpToBlockLevel() {
 
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
 
-        let element1 = ElementNode(name: "p", attributes: [], children: [text1])
-        let element2 = ElementNode(name: "p", attributes: [], children: [text2])
-        let _ = ElementNode(name: "p", attributes: [], children: [element1, element2])
+        let element1 = ElementNode(name: "p", attributes: [], children: [text1], registerUndo: { _ in })
+        let element2 = ElementNode(name: "p", attributes: [], children: [text2], registerUndo: { _ in })
+        let _ = ElementNode(name: "p", attributes: [], children: [element1, element2], registerUndo: { _ in })
 
         XCTAssertEqual(text1.firstElementNodeInCommon(withNode: text2, interruptAtBlockLevel: true), nil)
     }

--- a/AztecTests/HTML/NodeTests.swift
+++ b/AztecTests/HTML/NodeTests.swift
@@ -3,10 +3,11 @@ import XCTest
 
 class NodeTests: XCTestCase {
 
+    typealias Attribute = Libxml2.Attribute
     typealias ElementNode = Libxml2.ElementNode
     typealias Node = Libxml2.Node
     typealias TextNode = Libxml2.TextNode
-
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -16,14 +17,16 @@ class NodeTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
+    
+    // MARK: - Tests
 
     func testElementNodesToRoot() {
         
-        let text = TextNode(text: "text1 goes here")
+        let text = TextNode(text: "text1 goes here", registerUndo: { _ in })
 
-        let node1 = ElementNode(name: "p", attributes: [], children: [text])
-        let node2 = ElementNode(name: "p", attributes: [], children: [node1])
-        let node3 = ElementNode(name: "p", attributes: [], children: [node2])
+        let node1 = createElementNode(name: "p", attributes: [], children: [text], registerUndo: { _ in })
+        let node2 = createElementNode(name: "p", attributes: [], children: [node1], registerUndo: { _ in })
+        let node3 = createElementNode(name: "p", attributes: [], children: [node2], registerUndo: { _ in })
 
         let parentNodes = text.elementNodesToRoot()
 
@@ -34,11 +37,11 @@ class NodeTests: XCTestCase {
 
     func testFirstElementNodeInCommon1() {
 
-        let text1 = TextNode(text: "text1 goes here")
-        let text2 = TextNode(text: "text2 goes here.")
-        let text3 = TextNode(text: "text3 goes here..")
+        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
+        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
+        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
 
         XCTAssertEqual(mainNode, text1.firstElementNodeInCommon(withNode: text2))
         XCTAssertEqual(mainNode, text2.firstElementNodeInCommon(withNode: text3))

--- a/AztecTests/HTML/TextNodeTests.swift
+++ b/AztecTests/HTML/TextNodeTests.swift
@@ -19,7 +19,7 @@ class TextNodeTests: XCTestCase {
         let text1 = "Hello"
         let text2 = " World!"
 
-        let textNode = TextNode(text: "\(text1)\(text2)")
+        let textNode = TextNode(text: "\(text1)\(text2)", registerUndo: {})
         let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
         
         let splitLocation = text1.characters.count

--- a/AztecTests/HTML/TextNodeTests.swift
+++ b/AztecTests/HTML/TextNodeTests.swift
@@ -19,8 +19,8 @@ class TextNodeTests: XCTestCase {
         let text1 = "Hello"
         let text2 = " World!"
 
-        let textNode = TextNode(text: "\(text1)\(text2)", registerUndo: {})
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let textNode = TextNode(text: "\(text1)\(text2)", registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
         
         let splitLocation = text1.characters.count
         
@@ -49,8 +49,8 @@ class TextNodeTests: XCTestCase {
     ///     - No splitting should occur, the selected text node should match the whole string.
     ///
     func testSplitAtLocation2() {
-        let textNode = TextNode(text: "Hello World!")
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let textNode = TextNode(text: "Hello World!", registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
         
         let splitLocation = 0
         
@@ -69,8 +69,8 @@ class TextNodeTests: XCTestCase {
     ///     - No splitting should occur, the selected text node should match the whole string.
     ///
     func testSplitAtLocation3() {
-        let textNode = TextNode(text: "Hello World!")
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let textNode = TextNode(text: "Hello World!", registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
         
         let splitLocation = textNode.length()
         

--- a/AztecTests/Importer/HTMLToAttributedStringTests.swift
+++ b/AztecTests/Importer/HTMLToAttributedStringTests.swift
@@ -26,7 +26,7 @@ class HTMLToAttributedStringTests: XCTestCase {
         let tagNames = ["bold", "italic", "customTag", "div", "p", "a"]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: {})
 
             let nodeText = "Hello"
             let html = "<\(tagName)>\(nodeText)</\(tagName)>"

--- a/AztecTests/Importer/HTMLToAttributedStringTests.swift
+++ b/AztecTests/Importer/HTMLToAttributedStringTests.swift
@@ -26,7 +26,7 @@ class HTMLToAttributedStringTests: XCTestCase {
         let tagNames = ["bold", "italic", "customTag", "div", "p", "a"]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: {})
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
 
             let nodeText = "Hello"
             let html = "<\(tagName)>\(nodeText)</\(tagName)>"
@@ -70,7 +70,7 @@ class HTMLToAttributedStringTests: XCTestCase {
         let tagNames = ["bold", "italic", "customTag", "div", "p", "a"]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
 
             let firstText = "Hello "
             let secondText = "world"
@@ -123,7 +123,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
 
             let text = "Hello"
             let html = "<\(tagName.0)><\(tagName.1)>\(text)</\(tagName.1)></\(tagName.0)>"
@@ -181,7 +181,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
 
             let firstText = "Hello "
             let secondText = "world"
@@ -260,7 +260,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold", "italic")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
 
             let firstText = "Hello "
             let secondText = "world"

--- a/AztecTests/Importer/InHTMLConverterTests.swift
+++ b/AztecTests/Importer/InHTMLConverterTests.swift
@@ -20,7 +20,7 @@ class InHTMLConverterTests: XCTestCase {
     }
 
     func testSimpleHTMLConversion() {
-        let parser = Libxml2.In.HTMLConverter(registerUndo: {})
+        let parser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
 
         let html = "<bold>Hello!</bold>"
 
@@ -49,7 +49,7 @@ class InHTMLConverterTests: XCTestCase {
     }
 
     func testComplexHTMLConversion() {
-        let parser = Libxml2.In.HTMLConverter()
+        let parser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
 
         let html = "<div styLe='a' nostyle peace='123'>Hello <b>World</b>!</div>"
 
@@ -101,7 +101,7 @@ class InHTMLConverterTests: XCTestCase {
     }
 
     func testNonASCIIConversion() {
-        let parser = Libxml2.In.HTMLConverter()
+        let parser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
 
         let html = "Otro año más"
 

--- a/AztecTests/Importer/InHTMLConverterTests.swift
+++ b/AztecTests/Importer/InHTMLConverterTests.swift
@@ -20,7 +20,7 @@ class InHTMLConverterTests: XCTestCase {
     }
 
     func testSimpleHTMLConversion() {
-        let parser = Libxml2.In.HTMLConverter()
+        let parser = Libxml2.In.HTMLConverter(registerUndo: {})
 
         let html = "<bold>Hello!</bold>"
 

--- a/AztecTests/Importer/InNodeConverterTests.swift
+++ b/AztecTests/Importer/InNodeConverterTests.swift
@@ -31,7 +31,7 @@ class InNodeConverterTests: XCTestCase {
             return
         }
         
-        let outNode = Libxml2.In.NodeConverter().convert(node.pointee)
+        let outNode = Libxml2.In.NodeConverter(registerUndo: {}).convert(node.pointee)
         xmlFreeNode(node)
 
         guard let elementNode = outNode as? ElementNode else {

--- a/AztecTests/Importer/InNodeConverterTests.swift
+++ b/AztecTests/Importer/InNodeConverterTests.swift
@@ -31,7 +31,7 @@ class InNodeConverterTests: XCTestCase {
             return
         }
         
-        let outNode = Libxml2.In.NodeConverter(registerUndo: {}).convert(node.pointee)
+        let outNode = Libxml2.In.NodeConverter(registerUndo: { _ in }).convert(node.pointee)
         xmlFreeNode(node)
 
         guard let elementNode = outNode as? ElementNode else {
@@ -56,7 +56,8 @@ class InNodeConverterTests: XCTestCase {
             return
         }
         
-        let outNode = Libxml2.In.NodeConverter().convert(node.pointee)
+        let converter = Libxml2.In.NodeConverter(registerUndo: { _ in })
+        let outNode = converter.convert(node.pointee)
         xmlFreeNode(node)
 
         guard let textNode = outNode as? TextNode else {
@@ -83,7 +84,8 @@ class InNodeConverterTests: XCTestCase {
 
         xmlAddChild(parentNode, childNode)
 
-        let outParentNode = Libxml2.In.NodeConverter().convert(parentNode.pointee)
+        let converter = Libxml2.In.NodeConverter(registerUndo: { _ in })
+        let outParentNode = converter.convert(parentNode.pointee)
 
         xmlFreeNode(parentNode) // frees all children
 


### PR DESCRIPTION
Relates to #60 

Improves the undo management code to avoid having to propagate `UndoManager` to every single node in the DOM tree.

Unit tests have to provide an empty block, since nodes are not supposed to exist without an undo block (by design, at least in this v1 of undo management - we can review this later on).

**How to test:**

- Delete text from single node.
- Move the caret around and repeat.
- Shake to undo any times you deem necessary.
- Check the HTML is as expected.
- Shake to redo any times you deem necessary.
- Check the HTML is as expected.