### PR TITLE
Bumps Gridicons dependency up to 0.4 for Swift 3.

### DIFF
--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -38,6 +38,6 @@ Pod::Spec.new do |s|
   s.xcconfig = {'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2'}
   s.preserve_paths = 'Aztec/Modulemaps/libxml2/*'
 
-  s.dependency 'Gridicons', '0.3'
+  s.dependency 'Gridicons', '0.4'
 
 end


### PR DESCRIPTION
Need 0.4 for shared dependencies on WPiOS. Maybe give this a couple weeks or so:

We can merge this once Swift 3 is fully merged into WPiOS and current working branches are updated. Otherwise, current Swift 2.3 branches of WPiOS will fail to install as they are linking Aztec’s develop branch, which conflicts if Gridicons is updated to 0.4 in develop.