### PR TITLE
Fix: Blockquote Crash

### DIFF
--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -50,13 +50,10 @@ protocol AttributeFormatter {
 extension AttributeFormatter {
     /// Checks if the attribute is present in a text view at the specified index.
     ///
-    func attribute(inTextView textView: UITextView, at index: Int) -> Bool {
-        let string = textView.textStorage
-        let range = applicationRange(forRange: NSRange(location: index, length: 0), inString: string)
-        let attributes = range.length > 0
-            ? string.attributes(at: index, effectiveRange: nil)
-            : textView.typingAttributes
-        return present(inAttributes: attributes as [String : AnyObject])
+    func present(in storage: NSTextStorage, at index: Int) -> Bool {
+        let safeIndex = min(max(index, storage.length - 1), 0)
+        let attributes = storage.attributes(at: safeIndex, effectiveRange: nil) as [String : AnyObject]
+        return present(inAttributes: attributes)
     }
 }
 

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -18,14 +18,14 @@ protocol AttributeFormatter {
     /// - Parameter attributes: the original attributes to apply to
     /// - Returns: the resulting attributes dictionary
     ///
-    func apply(toAttributes attributes:[String: Any]) -> [String: Any]
+    func apply(toAttributes attributes: [String: Any]) -> [String: Any]
 
     /// Remove the compound attributes from the provided list.
     ///
     /// - Parameter attributes: the original attributes to remove from
     /// - Returns: the resulting attributes dictionary
     ///
-    func remove(fromAttributes attributes:[String: Any]) -> [String: Any]
+    func remove(fromAttributes attributes: [String: Any]) -> [String: Any]
 
     /// The range to apply the attributes to.
     ///

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -134,8 +134,8 @@ open class TextView: UITextView {
         var insertionRange = selectedRange
         super.insertText(text)
         insertionRange.length = 1
-        refreshListAfterInsertionOf(text: text, range: insertionRange)
-        refreshBlockquoteAfterInsertionOf(text: text, range: insertionRange)
+        refreshListAfterInsertion(of: text, at: insertionRange)
+        refreshBlockquoteAfterInsertion(of: text, at: insertionRange)
     }
 
     open override func deleteBackward() {
@@ -155,8 +155,8 @@ open class TextView: UITextView {
             return
         }
 
-        refreshListAfterDeletionOf(text: deletedString, atRange: deletionRange)
-        refreshBlockquoteAfterDeletionOf(text: deletedString, atRange: deletionRange)
+        refreshListAfterDeletion(of: deletedString, at: deletionRange)
+        refreshBlockquoteAfterDeletion(of: deletedString, at: deletionRange)
     }
 
     // MARK: - UIView Overrides
@@ -525,7 +525,8 @@ open class TextView: UITextView {
     /// - Parameters:
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
-    private func refreshListAfterInsertionOf(text:String, range:NSRange) {
+    ///
+    private func refreshListAfterInsertion(of text: String, at range: NSRange) {
         //check if new text is part of a list
         guard let textList = storage.textListAttribute(atIndex: range.location) else {
             return
@@ -561,7 +562,8 @@ open class TextView: UITextView {
     /// - Parameters:
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
-    private func refreshListAfterDeletionOf(text deletedText: NSAttributedString, atRange range:NSRange) {
+    ///
+    private func refreshListAfterDeletion(of deletedText: NSAttributedString, at range: NSRange) {
         guard let textList = deletedText.textListAttribute(atIndex: 0),
               deletedText.string == "\n" || range.location == 0 else {
             return
@@ -617,7 +619,7 @@ open class TextView: UITextView {
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
     ///
-    private func refreshBlockquoteAfterDeletionOf(text deletedText: NSAttributedString, atRange range:NSRange) {
+    private func refreshBlockquoteAfterDeletion(of text: NSAttributedString, at range: NSRange) {
         let formatter = BlockquoteFormatter()
         guard formatter.attribute(inTextView: self, at: range.location),
             deletedText.string == "\n" || range.location == 0 else {
@@ -635,7 +637,7 @@ open class TextView: UITextView {
     ///   - text: the text being added
     ///   - range: the range of the insertion of the new text
     ///
-    private func refreshBlockquoteAfterInsertionOf(text: String, range:NSRange) {
+    private func refreshBlockquoteAfterInsertion(of text: String, at range: NSRange) {
         let formatter = BlockquoteFormatter()
         guard formatter.attribute(inTextView: self, at: range.location) else {
             return

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -635,8 +635,7 @@ open class TextView: UITextView {
     ///   - range: the range of the insertion of the new text
     ///
     private func refreshBlockquoteAfterInsertion(of text: String, at range: NSRange) {
-        let formatter = BlockquoteFormatter()
-        guard formatter.present(in: textStorage, at: range.location) else {
+        guard formattingAtIndexContainsBlockquote(range.location) else {
             return
         }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -645,7 +645,6 @@ open class TextView: UITextView {
             return
         }
 
-        let formatter = BlockquoteFormatter()
         let afterRange = NSRange(location: range.location + 1, length: 1)
         let beforeRange = NSRange(location: range.location - 1, length: 1)
 
@@ -661,6 +660,7 @@ open class TextView: UITextView {
         let isBegginingOfListItem = storage.isStartOfNewLine(atLocation: range.location)
 
         if text == "\n" && beforeString == "\n" && afterString == "\n" && isBegginingOfListItem {
+            let formatter = BlockquoteFormatter()
             formatter.toggleAttribute(inTextView: self, atRange: range)
             if afterRange.endLocation < storage.length {
                 formatter.toggleAttribute(inTextView: self, atRange: afterRange)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -645,6 +645,7 @@ open class TextView: UITextView {
             return
         }
 
+        let formatter = BlockquoteFormatter()
         let afterRange = NSRange(location: range.location + 1, length: 1)
         let beforeRange = NSRange(location: range.location - 1, length: 1)
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -621,14 +621,11 @@ open class TextView: UITextView {
     ///
     private func refreshBlockquoteAfterDeletion(of text: NSAttributedString, at range: NSRange) {
         let formatter = BlockquoteFormatter()
-        guard formatter.attribute(inTextView: self, at: range.location),
-            deletedText.string == "\n" || range.location == 0 else {
-                return
+        guard formatter.present(in: textStorage, at: range.location), range.location == 0 else {
+            return
         }
 
-        if (range.location == 0) {
-            formatter.toggleAttribute(inTextView: self, atRange: range)
-        }
+        formatter.toggleAttribute(inTextView: self, atRange: range)
     }
 
     /// Refresh blockquotes attributes when inserting new text in the specified range
@@ -639,7 +636,7 @@ open class TextView: UITextView {
     ///
     private func refreshBlockquoteAfterInsertion(of text: String, at range: NSRange) {
         let formatter = BlockquoteFormatter()
-        guard formatter.attribute(inTextView: self, at: range.location) else {
+        guard formatter.present(in: textStorage, at: range.location) else {
             return
         }
 
@@ -1029,7 +1026,7 @@ open class TextView: UITextView {
     ///
     open func formattingAtIndexContainsBlockquote(_ index: Int) -> Bool {
         let formatter = BlockquoteFormatter()
-        return formatter.attribute(inTextView: self, at: index)
+        return formatter.present(in: textStorage, at: index)
     }
 
 


### PR DESCRIPTION
### Testing

1. Launch the editor, and pick the editor demo with content.
2. Select all.
3. Delete (so that the editor is empty).
4. Type a word.
5. Press backspace once.
6. Make sure nothing crashes


@diegoreymendez i've simplified things, and will be introducing further changes in the AttributesFormatter class, so that it's decoupled from the view, in another PR.

Mind taking a look?
Fixes #185

Thanks in advance!
