### PR TITLE
Undo / redo for text input in single nodes.

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -303,7 +303,7 @@ extension NSAttributedString
             }
         }
 
-        // Make sure the ranges are sorted in ascending order
+        // Check the ranges are sorted in ascending order
         return adjustedRanges.sorted {
             $0.location < $1.location
         }

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1130,7 +1130,7 @@ extension Libxml2 {
                 if let childEditableNode = child as? EditableNode {
                     if index == 0 && replaceTextFromFirstChild {
                         childEditableNode.replaceCharacters(inRange: intersection, withString: string, inheritStyle: inheritStyle)
-                    } else {
+                    } else if intersection.length > 0 {
                         childEditableNode.deleteCharacters(inRange: intersection)
                     }
                 } else {

--- a/Aztec/Classes/Libxml2/DOM/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/TextNode.swift
@@ -91,7 +91,7 @@ extension Libxml2 {
             if postRange.lowerBound != postRange.upperBound {
                 let newNode = TextNode(text: text().substring(with: postRange), registerUndo: registerUndo)
                 
-                contents.removeSubrange(postRange)
+                deleteCharacters(inRange: postRange)
                 parent.insert(newNode, at: nodeIndex + 1)
             }
         }
@@ -114,14 +114,14 @@ extension Libxml2 {
             if !postRange.isEmpty {
                 let newNode = TextNode(text: contents.substring(with: postRange), registerUndo: registerUndo)
 
-                contents.removeSubrange(postRange)
+                deleteCharacters(inRange: postRange)
                 parent.insert(newNode, at: nodeIndex + 1)
             }
             
             if !preRange.isEmpty {
                 let newNode = TextNode(text: contents.substring(with: preRange), registerUndo: registerUndo)
 
-                contents.removeSubrange(preRange)
+                deleteCharacters(inRange: preRange)
                 parent.insert(newNode, at: nodeIndex)
             }
         }

--- a/AztecTests/HTML/TextNodeTests.swift
+++ b/AztecTests/HTML/TextNodeTests.swift
@@ -92,9 +92,9 @@ class TextNodeTests: XCTestCase {
     ///     - Text to append: "Hello there!"
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "Hello there!."
-    ///     - Make sure that the final text node content (after undoing) is: ""
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "Hello there!."
+    ///     - Check that after undoing the text node edit, its content is: ""
     /// 
     func testThatAppendIsUndoable1() {
         
@@ -124,9 +124,9 @@ class TextNodeTests: XCTestCase {
     ///     - Text to append: " there!."
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "Hello there!."
-    ///     - Make sure that the final text node content (after undoing) is: ""
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "Hello there!."
+    ///     - Check that after undoing the text node edit, its content is: ""
     ///
     func testThatAppendIsUndoable2() {
         let text1 = "Hello"
@@ -158,9 +158,9 @@ class TextNodeTests: XCTestCase {
     ///     - Range: (loc: 0, len: 5)
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: " there!"
-    ///     - Make sure that the final text node content (after undoing) is: "Hello there!"
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: " there!"
+    ///     - Check that after undoing the text node edit, its content is: "Hello there!"
     ///
     func testThatDeleteCharactersIsUndoable1() {
         let text1 = "Hello"
@@ -193,9 +193,9 @@ class TextNodeTests: XCTestCase {
     ///     - Range: (loc: 5, len: 7)
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "Hello"
-    ///     - Make sure that the final text node content (after undoing) is: "Hello there!"
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "Hello"
+    ///     - Check that after undoing the text node edit, its content is: "Hello there!"
     ///
     func testThatDeleteCharactersIsUndoable2() {
         let text1 = "Hello"
@@ -228,9 +228,9 @@ class TextNodeTests: XCTestCase {
     ///     - Text to prepend: "Hello there!"
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "Hello there!."
-    ///     - Make sure that the final text node content (after undoing) is: ""
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "Hello there!."
+    ///     - Check that after undoing the text node edit, its content is: ""
     ///
     func testThatPrependIsUndoable1() {
         
@@ -261,9 +261,9 @@ class TextNodeTests: XCTestCase {
     ///     - Text to prepend: "Hello"
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "Hello there!."
-    ///     - Make sure that the final text node content (after undoing) is: ""
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "Hello there!."
+    ///     - Check that after undoing the text node edit, its content is: ""
     ///
     func testThatPrependIsUndoable2() {
         let text1 = " there!"
@@ -296,9 +296,9 @@ class TextNodeTests: XCTestCase {
     ///     - New string: "-"
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "Hello-there!"
-    ///     - Make sure that the final text node content (after undoing) is: "Hello there!"
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "Hello-there!"
+    ///     - Check that after undoing the text node edit, its content is: "Hello there!"
     ///
     func testThatReplaceCharactersIsUndoable1() {
         let text1 = "Hello"
@@ -337,9 +337,9 @@ class TextNodeTests: XCTestCase {
     ///     - New string: "-"
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "- there!"
-    ///     - Make sure that the final text node content (after undoing) is: "Hello there!"
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "- there!"
+    ///     - Check that after undoing the text node edit, its content is: "Hello there!"
     ///
     func testThatReplaceCharactersIsUndoable2() {
         let text1 = "Hello"
@@ -378,9 +378,9 @@ class TextNodeTests: XCTestCase {
     ///     - New string: "-"
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "Hello -"
-    ///     - Make sure that the final text node content (after undoing) is: "Hello there!"
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "Hello -"
+    ///     - Check that after undoing the text node edit, its content is: "Hello there!"
     ///
     func testThatReplaceCharactersIsUndoable3() {
         let text1 = "Hello"
@@ -419,9 +419,9 @@ class TextNodeTests: XCTestCase {
     ///     - New string: "-"
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "-"
-    ///     - Make sure that the final text node content (after undoing) is: "Hello there!"
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "-"
+    ///     - Check that after undoing the text node edit, its content is: "Hello there!"
     ///
     func testThatReplaceCharactersIsUndoable4() {
         let text1 = "Hello"
@@ -459,9 +459,9 @@ class TextNodeTests: XCTestCase {
     ///     - New string: ""
     ///
     /// Verifications:
-    ///     - Make sure that the undo event is properly registered.
-    ///     - Make sure that the intermediate text node content is: "-"
-    ///     - Make sure that the final text node content (after undoing) is: "Hello there!"
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: ""
+    ///     - Check that after undoing the text node edit, its content is: "Hello there!"
     ///
     func testThatReplaceCharactersIsUndoable5() {
         let text1 = "Hello"


### PR DESCRIPTION
<h3>Details:</h3>

Adds support for undo / redo of text input in single nodes.

Additionally, adds unit tests covering all operations that currently support undo operations.

<h3>Testing:</h3>

**Test 1:**

Run the unit tests and make sure none fails.

**Test 2:**
1. Open the editor with content.
2. Insert text in any single node (you can insert in several but the range must not intersect more than one node).
3. Undo.
4. Check against the HTML to make sure everything is synchronized.