### PR TITLE
AttributeFormatter: Removing Blockquote Selection

### DIFF
--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -151,8 +151,9 @@ extension ParagraphAttributeFormatter {
 
         if applicationRange.length == 0 || textView.textStorage.length == 0 {
             insertEmptyAttribute(inString: textView.textStorage, at: applicationRange.location)
-            textView.selectedRange = NSRange(location: applicationRange.location, length: 1)
+            textView.selectedRange = NSRange(location: textView.textStorage.length, length: 0)
         }
+
         toggleAttribute(inString: textView.textStorage, atRange: applicationRange)
     }
 


### PR DESCRIPTION
### Steps:
1. Launch the demo app
2. Open the `Empty Editor Demo` controller
3. Press the **Blockquote** format bar action

Please, verify that there is no selection onscreen.

Closes #189

@diegoreymendez may i bug you with a quick review?
Thanks!
