### PR TITLE
LayoutManager: Blockquote End of Document Fix

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -26,23 +26,32 @@ class LayoutManager: NSLayoutManager {
         let characterRange = self.characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
         //draw blockquotes
         textStorage.enumerateAttribute(NSParagraphStyleAttributeName, in: characterRange, options: []){ (object, range, stop) in
-            guard let paragraphStyle = object as? ParagraphStyle,
-                  paragraphStyle.blockquote != nil
-                else {
-                    return
+            guard let paragraphStyle = object as? ParagraphStyle, paragraphStyle.blockquote != nil else {
+                return
             }
 
             let blockquoteGlyphRange = glyphRange(forCharacterRange: range, actualCharacterRange: nil)
 
             enumerateLineFragments(forGlyphRange: blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
                 let lineRect = rect.offsetBy(dx: origin.x, dy: origin.y)
-                self.blockquoteBackgroundColor.setFill()
-                context.fill(lineRect)
-                let borderRect = CGRect(origin: lineRect.origin, size: CGSize(width: 2, height: lineRect.height))
-                self.blockquoteBorderColor.setFill()
-                context.fill(borderRect)
+                self.drawBlockquote(in: lineRect, with: context)
+            }
+
+            if range.endLocation == textStorage.rangeOfEntireString.endLocation {
+                let extraLineRect = extraLineFragmentRect.offsetBy(dx: origin.x, dy: origin.y)
+                drawBlockquote(in: extraLineRect, with: context)
             }
         }
+
+    }
+
+    private func drawBlockquote(in rect: CGRect, with context: CGContext) {
+        blockquoteBackgroundColor.setFill()
+        context.fill(rect)
+
+        let borderRect = CGRect(origin: rect.origin, size: CGSize(width: 2, height: rect.height))
+        blockquoteBorderColor.setFill()
+        context.fill(borderRect)
     }
 
     private func drawLists(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {


### PR DESCRIPTION
### Steps: Issue 190
1. Launch Aztec's Demo
2. Open the `Empty Editor Demo`
3. Open the Keyboard and press the **Blockquote** action
4. Type a random word
5. Press the **Intro** Key

Verify that the Blockquote effectively grows!

### Steps: Issue 191
1. Launch Aztec's Demo
2. Open the `Empty Editor Demo`
3. Open the Keyboard and press the **Blockquote** action
4. Type some random text (`Hello`)
5. Delete the text you've just enteded, using Backspace

Verify that the blockquote remains onscreen, even when the last entered character is removed.

Closes #190 
Closes #191

@diegoreymendez **Thank you** for fixing this one!!!. Just pushing your patch, in this PR  
