### PR TITLE
AttributeFormatter: Fixing Boundaries Check

### DIFF
--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -51,7 +51,7 @@ extension AttributeFormatter {
     /// Checks if the attribute is present in a text view at the specified index.
     ///
     func present(in storage: NSTextStorage, at index: Int) -> Bool {
-        let safeIndex = min(max(index, storage.length - 1), 0)
+        let safeIndex = max(min(index, storage.length - 1), 0)
         let attributes = storage.attributes(at: safeIndex, effectiveRange: nil) as [String : AnyObject]
         return present(inAttributes: attributes)
     }

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -65,6 +65,26 @@ class BlockquoteFormatterTests: XCTestCase {
         formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
         XCTAssertTrue(original.isEqual(to: textView.storage))
     }
+
+    func testPresentInStorageAtIndexReturnsTrueWhenBlockquoteIsEffectivelyThere() {
+        let textView = testTextView
+        let storage = textView.storage
+        let paragraphs = paragraphRanges(inString: storage)
+
+        let formatter = BlockquoteFormatter()
+        let blockquoteRange = paragraphs[1]
+        formatter.toggleAttribute(inText: storage, atRange: blockquoteRange)
+
+        for i in 0..<storage.length {
+            let present = formatter.present(in: storage, at: i)
+
+            if NSLocationInRange(i, blockquoteRange) {
+                XCTAssertTrue(present)
+            } else {
+                XCTAssertFalse(present)
+            }
+        }
+    }
 }
 
 private extension BlockquoteFormatterTests {

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -427,6 +427,28 @@ class TextListFormatterTests: XCTestCase
         XCTAssert(list.itemNumber(in: items[0], at: 0) == 1)
         XCTAssert(list.itemNumber(in: items[0], at: 13)  == 2)
     }
+
+
+    // Verifies that the `prsent(in: at:)` helper effectively returns true, as needed.
+    //
+    func testPresentInStorageAtIndexReturnsTrueWhenTextListIsEffectivelyThere() {
+        let list = NSTextStorage(string: plainText)
+        let plainRanges = plainTextParagraphRanges
+        let unorderedListFormatter = TextListFormatter(style: .unordered)
+
+        let listRange = plainRanges[1]
+        unorderedListFormatter.toggleAttribute(inText: list, atRange: listRange)
+
+        for i in 0..<list.length {
+            let present = unorderedListFormatter.present(in: list, at: i)
+
+            if NSLocationInRange(i, listRange) {
+                XCTAssertTrue(present)
+            } else {
+                XCTAssertFalse(present)
+            }
+        }
+    }
 }
 
 

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -429,7 +429,7 @@ class TextListFormatterTests: XCTestCase
     }
 
 
-    // Verifies that the `prsent(in: at:)` helper effectively returns true, as needed.
+    // Verifies that the `present(in: at:)` helper effectively returns true, as needed.
     //
     func testPresentInStorageAtIndexReturnsTrueWhenTextListIsEffectivelyThere() {
         let list = NSTextStorage(string: plainText)


### PR DESCRIPTION
### Details:
Issue #195 is actually a side effect of #187's patch. Apologies about that, everything was caused by a faulty boundaries check!.

### Steps:
1. Launch the Empty Editor Demo
2. Press the **Blockquote** Format bar button
3. Verify that the blockqute style is onscreen
4. Press **new line**
5. Verify that the blockquote is gone
6. Press **new line** again

Verify that the Blockquote does not show up again.

**Plus:** Run the (new) Unit Tests, and verify they pass!

Needs Review: @diegoreymendez 
Closes #195

Thanks Diego!


