### PR TITLE
TextView: Missing Cursor Workaround

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -136,7 +136,7 @@ open class TextView: UITextView {
         insertionRange.length = 1
         refreshListAfterInsertion(of: text, at: insertionRange)
         refreshBlockquoteAfterInsertion(of: text, at: insertionRange)
-        forceRedrawCursor()
+        forceRedrawCursorAfterDelay()
     }
 
     open override func deleteBackward() {
@@ -626,7 +626,7 @@ open class TextView: UITextView {
     open func toggleBlockquote(range: NSRange) {
         let formatter = BlockquoteFormatter()
         formatter.toggleAttribute(inTextView: self, atRange: range)
-        forceRedrawCursor()
+        forceRedrawCursorAfterDelay()
     }
 
 
@@ -682,14 +682,15 @@ open class TextView: UITextView {
             } else {
                 selectedRange = NSRange(location: range.location, length: 0)
             }
+        }
+    }
 
 
-    /// Force the SDK to Redraw the cursor, after the specified delay. This method was meant as a workaround
+    /// Force the SDK to Redraw the cursor, asynchronously, after a delay. This method was meant as a workaround
     /// for Issue #144: the Caret might end up redrawn below the Blockquote's custom background.
     ///
-    /// - Parameter delay: Timespan that must elapse before we'll force the Caret to be redrawn.
-    ///
-    private func forceRedrawCursor(after delay: TimeInterval = 0.1) {
+    func forceRedrawCursorAfterDelay() {
+        let delay = 0.1
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             let pristine = self.selectedRange
             self.selectedRange = .zero

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1,5 +1,6 @@
 
 import UIKit
+import Foundation
 import Gridicons
 
 public protocol TextViewMediaDelegate: class {
@@ -136,7 +137,7 @@ open class TextView: UITextView {
         insertionRange.length = 1
         refreshListAfterInsertion(of: text, at: insertionRange)
         refreshBlockquoteAfterInsertion(of: text, at: insertionRange)
-        forceRedrawCursorAfterDelay()
+        forceRedrawCursorIfNeeded(afterInserting: text)
     }
 
     open override func deleteBackward() {
@@ -683,6 +684,18 @@ open class TextView: UITextView {
                 selectedRange = NSRange(location: range.location, length: 0)
             }
         }
+    }
+
+
+    /// Force the SDK to Redraw the cursor, asynchronously, if the newly-inserted text requires it. 
+    /// This method was meant as a workaround for Issue #144.
+    ///
+    func forceRedrawCursorIfNeeded(afterInserting text: String) {
+        guard text == "\n" else {
+            return
+        }
+
+        forceRedrawCursorAfterDelay()
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -707,7 +707,8 @@ open class TextView: UITextView {
         let delay = 0.05
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             let pristine = self.selectedRange
-            self.selectedRange = .zero
+            let updated = NSMakeRange(max(pristine.location - 1, 0), 0)
+            self.selectedRange = updated
             self.selectedRange = pristine
         }
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -690,7 +690,7 @@ open class TextView: UITextView {
     /// for Issue #144: the Caret might end up redrawn below the Blockquote's custom background.
     ///
     func forceRedrawCursorAfterDelay() {
-        let delay = 0.1
+        let delay = 0.05
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             let pristine = self.selectedRange
             self.selectedRange = .zero

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -136,6 +136,7 @@ open class TextView: UITextView {
         insertionRange.length = 1
         refreshListAfterInsertion(of: text, at: insertionRange)
         refreshBlockquoteAfterInsertion(of: text, at: insertionRange)
+        forceRedrawCursor()
     }
 
     open override func deleteBackward() {
@@ -625,6 +626,7 @@ open class TextView: UITextView {
     open func toggleBlockquote(range: NSRange) {
         let formatter = BlockquoteFormatter()
         formatter.toggleAttribute(inTextView: self, atRange: range)
+        forceRedrawCursor()
     }
 
 
@@ -680,6 +682,18 @@ open class TextView: UITextView {
             } else {
                 selectedRange = NSRange(location: range.location, length: 0)
             }
+
+
+    /// Force the SDK to Redraw the cursor, after the specified delay. This method was meant as a workaround
+    /// for Issue #144: the Caret might end up redrawn below the Blockquote's custom background.
+    ///
+    /// - Parameter delay: Timespan that must elapse before we'll force the Caret to be redrawn.
+    ///
+    private func forceRedrawCursor(after delay: TimeInterval = 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            let pristine = self.selectedRange
+            self.selectedRange = .zero
+            self.selectedRange = pristine
         }
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -137,7 +137,7 @@ open class TextView: UITextView {
         insertionRange.length = 1
         refreshListAfterInsertion(of: text, at: insertionRange)
         refreshBlockquoteAfterInsertion(of: text, at: insertionRange)
-        forceRedrawCursorIfNeeded(afterInserting: text)
+        forceRedrawCursorIfNeeded(afterEditing: text)
     }
 
     open override func deleteBackward() {
@@ -159,6 +159,7 @@ open class TextView: UITextView {
 
         refreshListAfterDeletion(of: deletedString, at: deletionRange)
         refreshBlockquoteAfterDeletion(of: deletedString, at: deletionRange)
+        forceRedrawCursorIfNeeded(afterEditing: deletedString.string)
     }
 
     // MARK: - UIView Overrides
@@ -687,10 +688,10 @@ open class TextView: UITextView {
     }
 
 
-    /// Force the SDK to Redraw the cursor, asynchronously, if the newly-inserted text requires it. 
+    /// Force the SDK to Redraw the cursor, asynchronously, if the edited text (inserted / deleted) requires it.
     /// This method was meant as a workaround for Issue #144.
     ///
-    func forceRedrawCursorIfNeeded(afterInserting text: String) {
+    func forceRedrawCursorIfNeeded(afterEditing text: String) {
         guard text == "\n" else {
             return
         }


### PR DESCRIPTION
### Details:
We've got several flows (adding a blockquote // newline while in a blockquote) that cause the "Cursor Missing in Action" scenario.

In this PR we're adding a workaround to, at least, temporarily prevent this bug, until a proper fix is found (OR the SDK gets patched). It's not a fancy snippet, still, gets the job done.

@diegoreymendez May i bug you, yet again? (Thanks!!)
Closes #144

### Scenario A: Newline
1. Launch the empty editor
2. Press the Blockquote button

Verify that the cursor is visible and blinking

### Scenario B: Expansion
1. Launch the empty editor
2. Press the Blockquote button
3. Hit return. The blockquote should expand

Verify that the cursor is, still, visible

### Scenario C: Backspace
1. Launch the empty editor
2. Press the Blockquote button, and enter a couple lines of text (or empty lines!)
3. Hit backspace to delete one of the new lines

Verify that the cursor shows up in the previous line (as expected), and that it does not get covered by the blockquote BG.


### Scenario D: Vertical Flicker
1. Launch the empty editor
2. Enter (lots of) empty lines. Enough to cover the screen, and cause TextView Y-Scrolling
3. Hit the Backspace Button

Verify that there's no vertical flicker in the Vertical Scrolling position.
