### PR TITLE
Lists: Rendering Marker at the EOF

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -119,13 +119,16 @@ extension NSAttributedString
     /// - Parameters:
     ///   - list: The list.
     ///   - location: The location of the item.
+    ///
     /// - Returns: Returns the index within the list.
+    ///
     func itemNumber(in list: TextList, at location: Int) -> Int {
         guard let rangeOfList = range(of:list, at: location) else {
             return NSNotFound
         }
         var numberInList = 1
         let paragraphRanges = self.paragraphRanges(spanningRange: rangeOfList)
+
         for range in paragraphRanges {
             if NSLocationInRange(location, range) {
                 return numberInList

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -51,7 +51,7 @@ extension AttributeFormatter {
     /// Checks if the attribute is present in a text view at the specified index.
     ///
     func present(in storage: NSTextStorage, at index: Int) -> Bool {
-        let safeIndex = min(max(index, storage.length - 1), 0)
+        let safeIndex = max(min(index, storage.length - 1), 0)
         let attributes = storage.attributes(at: safeIndex, effectiveRange: nil) as [String : AnyObject]
         return present(inAttributes: attributes)
     }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -77,7 +77,7 @@ private extension LayoutManager {
         let characterRange = self.characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
         // draw list markers
         textStorage.enumerateAttribute(NSParagraphStyleAttributeName, in: characterRange, options: []) { (object, range, stop) in
-            guard let paragraphStyle = object as? ParagraphStyle, paragraphStyle.textList != nil else {
+            guard let paragraphStyle = object as? ParagraphStyle, let textList = paragraphStyle.textList else {
                 return
             }
 
@@ -87,9 +87,7 @@ private extension LayoutManager {
                 let lineRect = rect.offsetBy(dx: origin.x, dy: origin.y)
                 let lineRange = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
 
-                guard let textList = textStorage.textListAttribute(atIndex: lineRange.location),
-                    textStorage.isStartOfNewLine(atLocation: lineRange.location) else
-                {
+                guard textStorage.isStartOfNewLine(atLocation: lineRange.location) else {
                     return
                 }
 

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -7,9 +7,17 @@ import QuartzCore
 //
 class LayoutManager: NSLayoutManager {
 
+    /// Blockquote's Left Border Color
+    ///
     var blockquoteBorderColor: UIColor = UIColor(red: 0.52, green: 0.65, blue: 0.73, alpha: 1.0)
+
+    /// Blockquote's Background Color
+    ///
     var blockquoteBackgroundColor = UIColor(red: 0.91, green: 0.94, blue: 0.95, alpha: 1.0)
 
+
+    /// Draws the background, associated to a given Text Range
+    ///
     override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
         super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
 
@@ -23,6 +31,8 @@ class LayoutManager: NSLayoutManager {
 //
 private extension LayoutManager {
 
+    /// Draws a Blockquote associated to a Range + Graphics Origin.
+    ///
     func drawBlockquotes(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
         guard let textStorage = textStorage else {
             return
@@ -54,6 +64,8 @@ private extension LayoutManager {
 
     }
 
+    /// Draws a single Blockquote Line Fragment, in the specified Rectangle, using a given Graphics Context.
+    ///
     private func drawBlockquote(in rect: CGRect, with context: CGContext) {
         blockquoteBackgroundColor.setFill()
         context.fill(rect)
@@ -69,40 +81,75 @@ private extension LayoutManager {
 //
 private extension LayoutManager {
 
+    /// Draws a TextList associated to a Range + Graphics Origin.
+    ///
     func drawLists(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
         guard let textStorage = textStorage else {
             return
         }
 
         let characterRange = self.characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
-        // draw list markers
         textStorage.enumerateAttribute(NSParagraphStyleAttributeName, in: characterRange, options: []) { (object, range, stop) in
-            guard let paragraphStyle = object as? ParagraphStyle, let textList = paragraphStyle.textList else {
+            guard let paragraphStyle = object as? ParagraphStyle, let list = paragraphStyle.textList else {
                 return
             }
 
             let listGlyphRange = glyphRange(forCharacterRange:range, actualCharacterRange: nil)
 
+            // Draw Paragraph Markers
             enumerateLineFragments(forGlyphRange: listGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
-                let lineRect = rect.offsetBy(dx: origin.x, dy: origin.y)
-                let lineRange = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
-
-                guard textStorage.isStartOfNewLine(atLocation: lineRange.location) else {
+                let location = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil).location
+                guard textStorage.isStartOfNewLine(atLocation: location) else {
                     return
                 }
 
-                let paragraphAttributes = textStorage.attributes(at: lineRange.location, effectiveRange: nil)
-                let markerAttributes = self.markerAttributesBasedOnParagraph(attributes: paragraphAttributes)
+                let markerNumber = textStorage.itemNumber(in: list, at: location)
+                let lineRect = rect.offsetBy(dx: origin.x, dy: origin.y)
 
-                let itemNumber = textStorage.itemNumber(in: textList, at: lineRange.location)
-                let markerRect = lineRect.offsetBy(dx: paragraphStyle.headIndent - Metrics.defaultIndentation, dy: paragraphStyle.paragraphSpacingBefore)
-                let markerText = NSAttributedString(string:textList.style.markerText(forItemNumber: itemNumber), attributes:markerAttributes)
-
-                markerText.draw(in: markerRect)
+                self.drawItem(number: markerNumber, in: lineRect, from: list, using: paragraphStyle, at: location)
             }
+
+            // Draw the Last Line's Item
+            guard range.endLocation == textStorage.rangeOfEntireString.endLocation, !extraLineFragmentRect.isEmpty else {
+                return
+            }
+
+            let location = range.endLocation - 1
+            let lineRect = extraLineFragmentRect.offsetBy(dx: origin.x, dy: origin.y)
+            let markerNumber = textStorage.itemNumber(in: list, at: location) + 1
+
+            drawItem(number: markerNumber, in: lineRect, from: list, using: paragraphStyle, at: location)
         }
     }
 
+
+    /// Draws the specified List Item Number, at a given location.
+    ///
+    /// - Parameters:
+    ///     - number: Marker Number of the item to be drawn
+    ///     - rect: Visible Rect in which the Marker should be rendered
+    ///     - list: Associated TextList
+    ///     - style: ParagraphStyle associated to the list
+    ///     - location: Text Location that should get the marker rendered.
+    ///
+    private func drawItem(number: Int, in rect: CGRect, from list: TextList, using style: ParagraphStyle, at location: Int) {
+        guard let textStorage = textStorage else {
+            return
+        }
+
+        let paragraphAttributes = textStorage.attributes(at: location, effectiveRange: nil)
+        let markerAttributes = markerAttributesBasedOnParagraph(attributes: paragraphAttributes)
+
+        let markerRect = rect.offsetBy(dx: style.headIndent - Metrics.defaultIndentation, dy: style.paragraphSpacingBefore)
+        let markerPlain = list.style.markerText(forItemNumber: number)
+        let markerText = NSAttributedString(string: markerPlain, attributes: markerAttributes)
+
+        markerText.draw(in: markerRect)
+    }
+
+
+    /// Returns the Marker Text Attributes, based on a collection that defines Regular Text Attributes.
+    ///
     private func markerAttributesBasedOnParagraph(attributes: [String: Any]) -> [String: Any] {
         var resultAttributes = attributes
         resultAttributes[NSParagraphStyleAttributeName] = ParagraphStyle.default

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -65,6 +65,26 @@ class BlockquoteFormatterTests: XCTestCase {
         formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
         XCTAssertTrue(original.isEqual(to: textView.storage))
     }
+
+    func testPresentInStorageAtIndexReturnsTrueWhenBlockquoteIsEffectivelyThere() {
+        let textView = testTextView
+        let storage = textView.storage
+        let paragraphs = paragraphRanges(inString: storage)
+
+        let formatter = BlockquoteFormatter()
+        let blockquoteRange = paragraphs[1]
+        formatter.toggleAttribute(inText: storage, atRange: blockquoteRange)
+
+        for i in 0..<storage.length {
+            let present = formatter.present(in: storage, at: i)
+
+            if NSLocationInRange(i, blockquoteRange) {
+                XCTAssertTrue(present)
+            } else {
+                XCTAssertFalse(present)
+            }
+        }
+    }
 }
 
 private extension BlockquoteFormatterTests {

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -427,6 +427,28 @@ class TextListFormatterTests: XCTestCase
         XCTAssert(list.itemNumber(in: items[0], at: 0) == 1)
         XCTAssert(list.itemNumber(in: items[0], at: 13)  == 2)
     }
+
+
+    // Verifies that the `prsent(in: at:)` helper effectively returns true, as needed.
+    //
+    func testPresentInStorageAtIndexReturnsTrueWhenTextListIsEffectivelyThere() {
+        let list = NSTextStorage(string: plainText)
+        let plainRanges = plainTextParagraphRanges
+        let unorderedListFormatter = TextListFormatter(style: .unordered)
+
+        let listRange = plainRanges[1]
+        unorderedListFormatter.toggleAttribute(inText: list, atRange: listRange)
+
+        for i in 0..<list.length {
+            let present = unorderedListFormatter.present(in: list, at: i)
+
+            if NSLocationInRange(i, listRange) {
+                XCTAssertTrue(present)
+            } else {
+                XCTAssertFalse(present)
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
### Steps:
1. Launch the empty editor demo
2. Hit the `Lists` Format Bar Action
3. Hit `Return`

Verify that the "New Line"'s list marker gets displayed immediately.

Closes #203

cc @diegoreymendez 
Thanks in advance Diego!
