### PR TITLE
Decoupling AttributeFormatters from UITextView

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -180,7 +180,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         if isBlockquote(node) {
             let formatter = BlockquoteFormatter()
-            attributes = formatter.apply(to:attributes)
+            attributes = formatter.apply(to: attributes)
         }
 
         if isImage(node) {

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -180,7 +180,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         if isBlockquote(node) {
             let formatter = BlockquoteFormatter()
-            attributes = formatter.apply(toAttributes:attributes)
+            attributes = formatter.apply(to:attributes)
         }
 
         if isImage(node) {
@@ -210,12 +210,12 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         if node.isNodeType(.ol) {
             let formatter = TextListFormatter(style: .ordered)
-            attributes = formatter.apply(toAttributes: attributes)
+            attributes = formatter.apply(to: attributes)
         }
 
         if node.isNodeType(.ul) {
             let formatter = TextListFormatter(style: .unordered)
-            attributes = formatter.apply(toAttributes: attributes)
+            attributes = formatter.apply(to: attributes)
         }
 
         return attributes

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -35,16 +35,12 @@ protocol AttributeFormatter {
     ///
     func applicationRange(forRange range: NSRange, inString string: NSAttributedString) -> NSRange
 
-    /// Toggles an attribute in the specified range of a text view.
-    ///
-    /// If there is existing text to apply the attribute to, the formatter will
-    /// do that. Otherwise, it will toggle the attributes in the text view's
-    /// `typingAttributes` property.
+    /// Toggles an attribute in the specified range of a text storage.
     ///
     /// The application range might be different than the passed range, as
-    /// explained in `applicationRange(forRange:inString:)`
+    /// explained in `applicationRange(for:in:)`
     ///
-    func toggleAttribute(inTextView textView: UITextView, atRange range: NSRange)
+    func toggleAttribute(in text: NSMutableAttributedString, at range: NSRange)
 }
 
 extension AttributeFormatter {
@@ -127,34 +123,12 @@ private extension AttributeFormatter {
 protocol CharacterAttributeFormatter: AttributeFormatter {
 }
 
-extension CharacterAttributeFormatter {
-    func toggleAttribute(inTextView textView: UITextView, atRange range: NSRange) {
-        let applicationRange = self.applicationRange(forRange: range, inString: textView.textStorage)
-
-        guard applicationRange.length > 0 || textView.textStorage.length > 0 else {
-            return
-        }
-        toggleAttribute(inString: textView.textStorage, atRange: applicationRange)
-    }
-}
-
 protocol ParagraphAttributeFormatter: AttributeFormatter {
 }
 
 extension ParagraphAttributeFormatter {
     func applicationRange(forRange range: NSRange, inString string: NSAttributedString) -> NSRange {
         return string.paragraphRange(for: range)
-    }
-
-    func toggleAttribute(inTextView textView: UITextView, atRange range: NSRange) {
-        let applicationRange = self.applicationRange(forRange: range, inString: textView.textStorage)
-
-        if applicationRange.length == 0 || textView.textStorage.length == 0 {
-            insertEmptyAttribute(inString: textView.textStorage, at: applicationRange.location)
-            textView.selectedRange = NSRange(location: textView.textStorage.length, length: 0)
-        }
-
-        toggleAttribute(inString: textView.textStorage, atRange: applicationRange)
     }
 
     func toggleAttribute(inText text: NSMutableAttributedString, atRange range: NSRange) {

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -152,7 +152,6 @@ extension ParagraphAttributeFormatter {
         if applicationRange.length == 0 || text.length == 0 {
             insertEmptyPlaceholderString(in: text, at: applicationRange.location)
             newSelectedRange = NSRange(location: text.length, length: 0)
-            NSLog("Returning New Selected Range \(text.length)")
         }
 
         toggleAttributes(in: text, at: applicationRange)

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -76,12 +76,13 @@ private extension AttributeFormatter {
     /// The string to be used when adding attributes to an empty line.
     ///
     var placeholderForAttributedEmptyLine: String {
+        // "Zero Width Space" Character
         return "\u{200B}"
     }
 
     /// Inserts an empty placeholder, into a given string, at the specified index.
     ///
-    func insertEmptyAttribute(in string: NSMutableAttributedString, at index: Int) {
+    func insertEmptyPlaceholderString(in string: NSMutableAttributedString, at index: Int) {
         let attributes = apply(to: [:])
         let attributedSpace = NSAttributedString(string: placeholderForAttributedEmptyLine, attributes: attributes)
         string.insert(attributedSpace, at: index)
@@ -90,7 +91,7 @@ private extension AttributeFormatter {
     /// Toggles the Attribute Format, into a given string, at the specified range.
     ///
     func toggleAttributes(in string: NSMutableAttributedString, at range: NSRange) {
-        guard range.length > 0 || string.length > 0 else {
+        guard range.location < string.length else {
             return
         }
 
@@ -144,9 +145,8 @@ extension ParagraphAttributeFormatter {
 
     func toggle(in text: NSMutableAttributedString, at range: NSRange) {
         let applicationRange = self.applicationRange(for: range, in: text)
-
         if applicationRange.length == 0 || text.length == 0 {
-            insertEmptyAttribute(in: text, at: applicationRange.location)
+            insertEmptyPlaceholderString(in: text, at: applicationRange.location)
         }
 
         toggleAttributes(in: text, at: applicationRange)

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -70,27 +70,12 @@ extension AttributeFormatter {
 // MARK: - Private methods
 
 private extension AttributeFormatter {
-    func toggleTypingAttribute(inTextView textView: UITextView) {
-        if present(inAttributes: textView.typingAttributes as [String : AnyObject]) {
-            removeTypingAttribute(fromTextView: textView)
-        } else {
-            addTypingAttribute(toTextView: textView)
-        }
-    }
 
-    func addTypingAttribute(toTextView textView: UITextView) {
-        textView.typingAttributes = apply(toAttributes: textView.typingAttributes)
-    }
-
-    func removeTypingAttribute(fromTextView textView: UITextView) {
-        textView.typingAttributes = remove(fromAttributes: textView.typingAttributes)
-    }
-
-    func toggleAttribute(inString string: NSMutableAttributedString, atRange range: NSRange) {
+    func toggleAttribute(in string: NSMutableAttributedString, at range: NSRange) {
         if attribute(inString: string, at: range.location) {
-            removeAttributes(fromString: string, atRange: range)
+            removeAttributes(fromString: string, at: range)
         } else {
-            applyAttributes(toString: string, atRange: range)
+            applyAttributes(toString: string, at: range)
         }
     }
 
@@ -131,12 +116,17 @@ extension ParagraphAttributeFormatter {
         return string.paragraphRange(for: range)
     }
 
-    func toggleAttribute(inText text: NSMutableAttributedString, atRange range: NSRange) {
-        let applicationRange = self.applicationRange(forRange: range, inString: text)
+    func toggleAttribute(in text: NSMutableAttributedString, at range: NSRange) {
+        let applicationRange = self.applicationRange(for: range, in: text)
 
         if applicationRange.length == 0 || text.length == 0 {
             insertEmptyAttribute(inString: text, at: applicationRange.location)
         }
-        toggleAttribute(inString: text, atRange: applicationRange)
+
+        if attribute(inString: text, at: range.location) {
+            removeAttributes(fromString: text, at: applicationRange)
+        } else {
+            applyAttributes(toString: text, at: applicationRange)
+        }
     }
 }

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -10,12 +10,14 @@ import UIKit
 ///
 protocol AttributeFormatter {
 
-    /// Toggles an attribute in the specified range of a text storage.
+    /// Toggles an attribute in the specified range of a text storage, and returns the new 
+    /// Selected Range. This is required because, in several scenarios, we may need to add a "Zero Width Space",
+    /// just to get the style to render properly
     ///
     /// The application range might be different than the passed range, as
     /// explained in `applicationRange(for:in:)`
     ///
-    func toggle(in text: NSMutableAttributedString, at range: NSRange)
+    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange?
 
     /// Apply the compound attributes to the provided attributes dictionary
     ///
@@ -143,12 +145,18 @@ extension ParagraphAttributeFormatter {
         return string.paragraphRange(for: range)
     }
 
-    func toggle(in text: NSMutableAttributedString, at range: NSRange) {
+    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {
         let applicationRange = self.applicationRange(for: range, in: text)
+        var newSelectedRange: NSRange?
+
         if applicationRange.length == 0 || text.length == 0 {
             insertEmptyPlaceholderString(in: text, at: applicationRange.location)
+            newSelectedRange = NSRange(location: text.length, length: 0)
+            NSLog("Returning New Selected Range \(text.length)")
         }
 
         toggleAttributes(in: text, at: applicationRange)
+
+        return newSelectedRange
     }
 }

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -11,21 +11,21 @@ import UIKit
 protocol AttributeFormatter {
     /// Checks if the attribute is present in a dictionary of attributes.
     ///
-    func present(inAttributes attributes: [String: AnyObject]) -> Bool
+    func present(in attributes: [String: AnyObject]) -> Bool
 
     /// Apply the compound attributes to the provided attributes dictionary
     ///
     /// - Parameter attributes: the original attributes to apply to
     /// - Returns: the resulting attributes dictionary
     ///
-    func apply(toAttributes attributes: [String: Any]) -> [String: Any]
+    func apply(to attributes: [String: Any]) -> [String: Any]
 
     /// Remove the compound attributes from the provided list.
     ///
     /// - Parameter attributes: the original attributes to remove from
     /// - Returns: the resulting attributes dictionary
     ///
-    func remove(fromAttributes attributes: [String: Any]) -> [String: Any]
+    func remove(from attributes: [String: Any]) -> [String: Any]
 
     /// The range to apply the attributes to.
     ///
@@ -33,7 +33,7 @@ protocol AttributeFormatter {
     /// protocol might want to extend the range to apply the attribute to a
     /// different range (e.g. a paragraph)
     ///
-    func applicationRange(forRange range: NSRange, inString string: NSAttributedString) -> NSRange
+    func applicationRange(for range: NSRange, in string: NSAttributedString) -> NSRange
 
     /// Toggles an attribute in the specified range of a text storage.
     ///
@@ -49,14 +49,14 @@ extension AttributeFormatter {
     func present(in storage: NSTextStorage, at index: Int) -> Bool {
         let safeIndex = max(min(index, storage.length - 1), 0)
         let attributes = storage.attributes(at: safeIndex, effectiveRange: nil) as [String : AnyObject]
-        return present(inAttributes: attributes)
+        return present(in: attributes)
     }
 }
 
 // MARK: - Default implementations
 
 extension AttributeFormatter {
-    func applicationRange(forRange range: NSRange, inString string: NSAttributedString) -> NSRange {
+    func applicationRange(for range: NSRange, in string: NSAttributedString) -> NSRange {
         return range
     }
 
@@ -79,25 +79,25 @@ private extension AttributeFormatter {
         }
     }
 
-    func applyAttributes(toString string: NSMutableAttributedString, atRange range: NSRange) {
+    func applyAttributes(toString string: NSMutableAttributedString, at range: NSRange) {
         let currentAttributes = string.attributes(at: range.location, effectiveRange: nil)
-        let attributes = apply(toAttributes: currentAttributes)
+        let attributes = apply(to: currentAttributes)
         string.addAttributes(attributes, range: range)
     }
 
-    func removeAttributes(fromString string: NSMutableAttributedString, atRange range: NSRange) {
+    func removeAttributes(fromString string: NSMutableAttributedString, at range: NSRange) {
         let currentAttributes = string.attributes(at: range.location, effectiveRange: nil)
-        let attributes = remove(fromAttributes: currentAttributes)
+        let attributes = remove(from: currentAttributes)
         string.addAttributes(attributes, range: range)
     }
 
     func attribute(inString string: NSAttributedString, at index: Int) -> Bool {
         let attributes = string.attributes(at: index, effectiveRange: nil)
-        return present(inAttributes: attributes as [String : AnyObject])
+        return present(in: attributes as [String : AnyObject])
     }
 
     func insertEmptyAttribute(inString string: NSMutableAttributedString, at index: Int) {
-        let attributes = apply(toAttributes: [:])
+        let attributes = apply(to: [:])
         let attributedSpace = NSAttributedString(string: placeholderForAttributedEmptyLine, attributes: attributes)
         string.insert(attributedSpace, at: index)
     }
@@ -112,7 +112,7 @@ protocol ParagraphAttributeFormatter: AttributeFormatter {
 }
 
 extension ParagraphAttributeFormatter {
-    func applicationRange(forRange range: NSRange, inString string: NSAttributedString) -> NSRange {
+    func applicationRange(for range: NSRange, in string: NSAttributedString) -> NSRange {
         return string.paragraphRange(for: range)
     }
 

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -128,6 +128,8 @@ protocol CharacterAttributeFormatter: AttributeFormatter {
 }
 
 extension CharacterAttributeFormatter {
+
+    @discardableResult
     func toggle(in text: NSMutableAttributedString, at range: NSRange) {
         let applicationRange = self.applicationRange(for: range, in: text)
         toggleAttributes(in: text, at: applicationRange)
@@ -141,10 +143,12 @@ protocol ParagraphAttributeFormatter: AttributeFormatter {
 }
 
 extension ParagraphAttributeFormatter {
+
     func applicationRange(for range: NSRange, in string: NSAttributedString) -> NSRange {
         return string.paragraphRange(for: range)
     }
 
+    @discardableResult
     func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {
         let applicationRange = self.applicationRange(for: range, in: text)
         var newSelectedRange: NSRange?

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -22,7 +22,7 @@ class Blockquote: NSObject, NSCoding {
 struct BlockquoteFormatter: ParagraphAttributeFormatter {
 
 
-    func apply(toAttributes attributes: [String : Any]) -> [String: Any] {
+    func apply(to attributes: [String : Any]) -> [String: Any] {
         var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
@@ -38,7 +38,7 @@ struct BlockquoteFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(fromAttributes attributes:[String: Any]) -> [String: Any] {
+    func remove(from attributes:[String: Any]) -> [String: Any] {
         var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
         guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
@@ -56,7 +56,7 @@ struct BlockquoteFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(inAttributes attributes: [String : AnyObject]) -> Bool {
+    func present(in attributes: [String : AnyObject]) -> Bool {
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle {
             return paragraphStyle.blockquote != nil
         }

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -9,7 +9,7 @@ struct TextListFormatter: ParagraphAttributeFormatter {
         self.listStyle = style
     }
 
-    func apply(toAttributes attributes: [String : Any]) -> [String: Any] {
+    func apply(to attributes: [String : Any]) -> [String: Any] {
         var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
@@ -24,7 +24,7 @@ struct TextListFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(fromAttributes attributes:[String: Any]) -> [String: Any] {
+    func remove(from attributes:[String: Any]) -> [String: Any] {
         var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
         guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
@@ -40,7 +40,7 @@ struct TextListFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(inAttributes attributes: [String : AnyObject]) -> Bool {
+    func present(in attributes: [String : AnyObject]) -> Bool {
         guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
               let textList = paragraphStyle.textList else {
             return false

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -590,7 +590,7 @@ open class TextView: UITextView {
     ///
     fileprivate func remove(list: TextList, at range: NSRange) {
         let formatter = TextListFormatter(style: list.style)
-        formatter.toggleAttribute(inTextView: self, atRange: range)
+        formatter.toggleAttribute(in: textStorage, at: range)
     }
 
 
@@ -600,7 +600,7 @@ open class TextView: UITextView {
     ///
     open func toggleOrderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(inTextView: self, atRange: range)
+        formatter.toggleAttribute(in: textStorage, at: range)
     }
 
 
@@ -610,7 +610,7 @@ open class TextView: UITextView {
     ///
     open func toggleUnorderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggleAttribute(inTextView: self, atRange: range)
+        formatter.toggleAttribute(in: textStorage, at: range)
     }
 
 
@@ -627,7 +627,7 @@ open class TextView: UITextView {
     ///
     open func toggleBlockquote(range: NSRange) {
         let formatter = BlockquoteFormatter()
-        formatter.toggleAttribute(inTextView: self, atRange: range)
+        formatter.toggleAttribute(in: textStorage, at: range)
         forceRedrawCursorAfterDelay()
     }
 
@@ -646,7 +646,7 @@ open class TextView: UITextView {
             return
         }
 
-        formatter.toggleAttribute(inTextView: self, atRange: range)
+        formatter.toggleAttribute(in: textStorage, at: range)
     }
 
 
@@ -677,9 +677,9 @@ open class TextView: UITextView {
 
         if text == "\n" && beforeString == "\n" && afterString == "\n" && isBegginingOfListItem {
             let formatter = BlockquoteFormatter()
-            formatter.toggleAttribute(inTextView: self, atRange: range)
+            formatter.toggleAttribute(in: textStorage, at: range)
             if afterRange.endLocation < storage.length {
-                formatter.toggleAttribute(inTextView: self, atRange: afterRange)
+                formatter.toggleAttribute(in: textStorage, at: afterRange)
                 deleteBackward()
             } else {
                 selectedRange = NSRange(location: range.location, length: 0)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -590,7 +590,7 @@ open class TextView: UITextView {
     ///
     fileprivate func remove(list: TextList, at range: NSRange) {
         let formatter = TextListFormatter(style: list.style)
-        formatter.toggleAttribute(in: textStorage, at: range)
+        formatter.toggle(in: textStorage, at: range)
     }
 
 
@@ -600,7 +600,7 @@ open class TextView: UITextView {
     ///
     open func toggleOrderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(in: textStorage, at: range)
+        formatter.toggle(in: textStorage, at: range)
     }
 
 
@@ -610,7 +610,7 @@ open class TextView: UITextView {
     ///
     open func toggleUnorderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggleAttribute(in: textStorage, at: range)
+        formatter.toggle(in: textStorage, at: range)
     }
 
 
@@ -627,7 +627,7 @@ open class TextView: UITextView {
     ///
     open func toggleBlockquote(range: NSRange) {
         let formatter = BlockquoteFormatter()
-        formatter.toggleAttribute(in: textStorage, at: range)
+        formatter.toggle(in: textStorage, at: range)
         forceRedrawCursorAfterDelay()
     }
 
@@ -646,7 +646,7 @@ open class TextView: UITextView {
             return
         }
 
-        formatter.toggleAttribute(in: textStorage, at: range)
+        formatter.toggle(in: textStorage, at: range)
     }
 
 
@@ -677,9 +677,9 @@ open class TextView: UITextView {
 
         if text == "\n" && beforeString == "\n" && afterString == "\n" && isBegginingOfListItem {
             let formatter = BlockquoteFormatter()
-            formatter.toggleAttribute(in: textStorage, at: range)
+            formatter.toggle(in: textStorage, at: range)
             if afterRange.endLocation < storage.length {
-                formatter.toggleAttribute(in: textStorage, at: afterRange)
+                formatter.toggle(in: textStorage, at: afterRange)
                 deleteBackward()
             } else {
                 selectedRange = NSRange(location: range.location, length: 0)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -590,7 +590,8 @@ open class TextView: UITextView {
     ///
     fileprivate func remove(list: TextList, at range: NSRange) {
         let formatter = TextListFormatter(style: list.style)
-        formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        selectedRange = newSelectedRange ?? selectedRange
     }
 
 
@@ -600,7 +601,8 @@ open class TextView: UITextView {
     ///
     open func toggleOrderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        selectedRange = newSelectedRange ?? selectedRange
     }
 
 
@@ -610,7 +612,8 @@ open class TextView: UITextView {
     ///
     open func toggleUnorderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        selectedRange = newSelectedRange ?? selectedRange
     }
 
 
@@ -627,7 +630,8 @@ open class TextView: UITextView {
     ///
     open func toggleBlockquote(range: NSRange) {
         let formatter = BlockquoteFormatter()
-        formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        selectedRange = newSelectedRange ?? selectedRange
         forceRedrawCursorAfterDelay()
     }
 
@@ -646,7 +650,8 @@ open class TextView: UITextView {
             return
         }
 
-        formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        selectedRange = newSelectedRange ?? selectedRange
     }
 
 
@@ -674,17 +679,19 @@ open class TextView: UITextView {
         }
 
         let isBegginingOfListItem = storage.isStartOfNewLine(atLocation: range.location)
-
-        if text == "\n" && beforeString == "\n" && afterString == "\n" && isBegginingOfListItem {
-            let formatter = BlockquoteFormatter()
-            formatter.toggle(in: textStorage, at: range)
-            if afterRange.endLocation < storage.length {
-                formatter.toggle(in: textStorage, at: afterRange)
-                deleteBackward()
-            } else {
-                selectedRange = NSRange(location: range.location, length: 0)
-            }
+        guard text == "\n" && beforeString == "\n" && afterString == "\n" && isBegginingOfListItem else {
+            return
         }
+
+        let formatter = BlockquoteFormatter()
+        var newSelectedRange = formatter.toggle(in: textStorage, at: range)
+
+        if afterRange.endLocation < storage.length {
+            newSelectedRange = formatter.toggle(in: textStorage, at: afterRange) ?? newSelectedRange
+            deleteBackward()
+        }
+
+        selectedRange = newSelectedRange ?? selectedRange
     }
 
 

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -9,7 +9,7 @@ class BlockquoteFormatterTests: XCTestCase {
         let paragraphs = paragraphRanges(inString: storage)
 
         let formatter = BlockquoteFormatter()
-        _ = formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
+        formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
     }
@@ -23,7 +23,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[0])
-        _ = formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
+        formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
     }
@@ -37,7 +37,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[1])
-        _ = formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[1]))
@@ -52,7 +52,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[0])
-        _ = formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[1]))
@@ -66,8 +66,8 @@ class BlockquoteFormatterTests: XCTestCase {
 
         let formatter = BlockquoteFormatter()
         let original = textView.storage.copy() as! NSAttributedString
-        _ = formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
-        _ = formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
         XCTAssertTrue(original.isEqual(to: textView.storage))
     }
 
@@ -78,7 +78,7 @@ class BlockquoteFormatterTests: XCTestCase {
 
         let formatter = BlockquoteFormatter()
         let blockquoteRange = paragraphs[1]
-        _ = formatter.toggle(in: storage, at: blockquoteRange)
+        formatter.toggle(in: storage, at: blockquoteRange)
 
         for i in 0..<storage.length {
             let present = formatter.present(in: storage, at: i)

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -9,7 +9,7 @@ class BlockquoteFormatterTests: XCTestCase {
         let paragraphs = paragraphRanges(inString: storage)
 
         let formatter = BlockquoteFormatter()
-        formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
+        _ = formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
     }
@@ -23,7 +23,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[0])
-        formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
+        _ = formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
     }
@@ -37,7 +37,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[1])
-        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        _ = formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[1]))
@@ -52,7 +52,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[0])
-        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        _ = formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[1]))
@@ -66,8 +66,8 @@ class BlockquoteFormatterTests: XCTestCase {
 
         let formatter = BlockquoteFormatter()
         let original = textView.storage.copy() as! NSAttributedString
-        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
-        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        _ = formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        _ = formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
         XCTAssertTrue(original.isEqual(to: textView.storage))
     }
 
@@ -78,7 +78,7 @@ class BlockquoteFormatterTests: XCTestCase {
 
         let formatter = BlockquoteFormatter()
         let blockquoteRange = paragraphs[1]
-        formatter.toggle(in: storage, at: blockquoteRange)
+        _ = formatter.toggle(in: storage, at: blockquoteRange)
 
         for i in 0..<storage.length {
             let present = formatter.present(in: storage, at: i)

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -9,7 +9,7 @@ class BlockquoteFormatterTests: XCTestCase {
         let paragraphs = paragraphRanges(inString: storage)
 
         let formatter = BlockquoteFormatter()
-        formatter.toggleAttribute(in: storage, at: NSRange(location: 1, length: 1))
+        formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
     }
@@ -23,7 +23,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[0])
-        formatter.toggleAttribute(in: storage, at: NSRange(location: 1, length: 1))
+        formatter.toggle(in: storage, at: NSRange(location: 1, length: 1))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
     }
@@ -37,7 +37,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[1])
-        formatter.toggleAttribute(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[1]))
@@ -52,7 +52,7 @@ class BlockquoteFormatterTests: XCTestCase {
         var attributes = [String:Any]()
         attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[0])
-        formatter.toggleAttribute(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[1]))
@@ -66,8 +66,8 @@ class BlockquoteFormatterTests: XCTestCase {
 
         let formatter = BlockquoteFormatter()
         let original = textView.storage.copy() as! NSAttributedString
-        formatter.toggleAttribute(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
-        formatter.toggleAttribute(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
         XCTAssertTrue(original.isEqual(to: textView.storage))
     }
 
@@ -78,7 +78,7 @@ class BlockquoteFormatterTests: XCTestCase {
 
         let formatter = BlockquoteFormatter()
         let blockquoteRange = paragraphs[1]
-        formatter.toggleAttribute(in: storage, at: blockquoteRange)
+        formatter.toggle(in: storage, at: blockquoteRange)
 
         for i in 0..<storage.length {
             let present = formatter.present(in: storage, at: i)

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -5,36 +5,39 @@ import Gridicons
 class BlockquoteFormatterTests: XCTestCase {
     func testApplyingBlockquoteOnFirstParagraph() {
         let textView = testTextView
-        let paragraphs = paragraphRanges(inString: textView.storage)
+        let storage = textView.storage
+        let paragraphs = paragraphRanges(inString: storage)
 
         let formatter = BlockquoteFormatter()
-        formatter.toggleAttribute(inTextView: textView, atRange: NSRange(location: 1, length: 1))
+        formatter.toggleAttribute(in: storage, at: NSRange(location: 1, length: 1))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
     }
 
     func testRemovingBlockQuoteOnFirstParagraph() {
         let textView = testTextView
-        let paragraphs = paragraphRanges(inString: textView.storage)
+        let storage = textView.storage
+        let paragraphs = paragraphRanges(inString: storage)
 
         let formatter = BlockquoteFormatter()
         var attributes = [String:Any]()
-        attributes = formatter.apply(toAttributes: attributes)
+        attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[0])
-        formatter.toggleAttribute(inTextView: textView, atRange: NSRange(location: 1, length: 1))
+        formatter.toggleAttribute(in: storage, at: NSRange(location: 1, length: 1))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
     }
 
     func testApplyingBlockquoteOnFirstParagraphWhenSecondHasBlockquote() {
         let textView = testTextView
-        let paragraphs = paragraphRanges(inString: textView.storage)
+        let storage = textView.storage
+        let paragraphs = paragraphRanges(inString: storage)
 
         let formatter = BlockquoteFormatter()
         var attributes = [String:Any]()
-        attributes = formatter.apply(toAttributes: attributes)
+        attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[1])
-        formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggleAttribute(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
         XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[1]))
@@ -42,13 +45,14 @@ class BlockquoteFormatterTests: XCTestCase {
 
     func testRemovingBlockQuoteOnFirstParagraphWhenSecondDoesNotHaveBlockquote() {
         let textView = testTextView
-        let paragraphs = paragraphRanges(inString: textView.storage)
+        let storage = textView.storage
+        let paragraphs = paragraphRanges(inString: storage)
 
         let formatter = BlockquoteFormatter()
         var attributes = [String:Any]()
-        attributes = formatter.apply(toAttributes: attributes)
+        attributes = formatter.apply(to: attributes)
         textView.storage.setAttributes(attributes, range: paragraphs[0])
-        formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggleAttribute(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
         XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[1]))
@@ -56,13 +60,14 @@ class BlockquoteFormatterTests: XCTestCase {
 
     func testToggleBlockquoteTwiceLeavesReturnsIdenticalString() {
         let textView = testTextView
+        let storage = textView.storage
         textView.storage.setAttributes([NSParagraphStyleAttributeName: ParagraphStyle.default], range: textView.storage.rangeOfEntireString)
-        let paragraphs = paragraphRanges(inString: textView.storage)
+        let paragraphs = paragraphRanges(inString: storage)
 
         let formatter = BlockquoteFormatter()
         let original = textView.storage.copy() as! NSAttributedString
-        formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
-        formatter.toggleAttribute(inTextView: textView, atRange: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggleAttribute(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+        formatter.toggleAttribute(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
         XCTAssertTrue(original.isEqual(to: textView.storage))
     }
 
@@ -73,7 +78,7 @@ class BlockquoteFormatterTests: XCTestCase {
 
         let formatter = BlockquoteFormatter()
         let blockquoteRange = paragraphs[1]
-        formatter.toggleAttribute(inText: storage, atRange: blockquoteRange)
+        formatter.toggleAttribute(in: storage, at: blockquoteRange)
 
         for i in 0..<storage.length {
             let present = formatter.present(in: storage, at: i)

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -84,7 +84,7 @@ class TextListFormatterTests: XCTestCase
         let string = NSMutableAttributedString(string: plainText)
 
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(in: string, at: NSRange(location: 0, length: 1))
+        formatter.toggle(in: string, at: NSRange(location: 0, length: 1))
 
         let ranges = paragraphRanges(inString: string)
         let lists = textListAttributes(inString: string, atRanges: ranges)
@@ -113,10 +113,10 @@ class TextListFormatterTests: XCTestCase
         let formatter = TextListFormatter(style: .ordered)
 
         // Toggle the 1st line as an Ordered List
-        formatter.toggleAttribute(in: string, at: NSRange(location: 0, length: 1))
+        formatter.toggle(in: string, at: NSRange(location: 0, length: 1))
 
         // And... undo?
-        formatter.toggleAttribute(in: string, at: NSRange(location: 0, length: 1))
+        formatter.toggle(in: string, at: NSRange(location: 0, length: 1))
 
         let ranges = paragraphRanges(inString: string)
         let lists = textListAttributes(inString: string, atRanges: ranges)
@@ -141,7 +141,7 @@ class TextListFormatterTests: XCTestCase
         let ranges = paragraphRanges(inString: list)
 
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(in: list, at: ranges[0])
+        formatter.toggle(in: list, at: ranges[0])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -174,7 +174,7 @@ class TextListFormatterTests: XCTestCase
 
         // Toggle Ordered List on the first line
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggleAttribute(in: list, at: ranges[2])
+        formatter.toggle(in: list, at: ranges[2])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -206,7 +206,7 @@ class TextListFormatterTests: XCTestCase
         let ranges = paragraphRanges(inString: list)
 
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggleAttribute(in: list, at: ranges[0])
+        formatter.toggle(in: list, at: ranges[0])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -234,7 +234,7 @@ class TextListFormatterTests: XCTestCase
 
         // Toggle Ordered List on the first line
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(in: list, at: ranges[0])
+        formatter.toggle(in: list, at: ranges[0])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -268,7 +268,7 @@ class TextListFormatterTests: XCTestCase
 
         // Toggle Ordered List on the full string's range
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(in: list, at: list.rangeOfEntireString)
+        formatter.toggle(in: list, at: list.rangeOfEntireString)
 
         // Verify we got a single big orderedList
         let ranges = paragraphRanges(inString: list)
@@ -304,11 +304,11 @@ class TextListFormatterTests: XCTestCase
 
         // Apply the Ordered List style to the last three paragraphs
         for (index, range) in paragraphRanges(inString: string).enumerated() where index >= 2 {
-            formatter.toggleAttribute(in: string, at: range)
+            formatter.toggle(in: string, at: range)
         }
 
         // Now... toggle an Ordered List on the full text
-        formatter.toggleAttribute(in: string, at: string.rangeOfEntireString)
+        formatter.toggle(in: string, at: string.rangeOfEntireString)
 
         // Verify
         let paragraphs = paragraphRanges(inString: string)
@@ -341,10 +341,10 @@ class TextListFormatterTests: XCTestCase
 
         // Line 3 > Unordered List
         let ranges = paragraphRanges(inString: string)
-        unorderedListFormatter.toggleAttribute(in: string, at: ranges[2])
+        unorderedListFormatter.toggle(in: string, at: ranges[2])
 
         // Entire Text > Ordered List
-        orderedListFormatter.toggleAttribute(in: string, at: string.rangeOfEntireString)
+        orderedListFormatter.toggle(in: string, at: string.rangeOfEntireString)
 
         // Verify
         let paragraphs = paragraphRanges(inString: string)
@@ -377,7 +377,7 @@ class TextListFormatterTests: XCTestCase
 
         // Toggle Ordered List on the full string's range
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggleAttribute(in: list, at: list.rangeOfEntireString)
+        formatter.toggle(in: list, at: list.rangeOfEntireString)
 
         // Verify we got a single big orderedList
         let ranges = paragraphRanges(inString: list)
@@ -409,7 +409,7 @@ class TextListFormatterTests: XCTestCase
         let length = plainRanges[1].location + plainRanges[1].length
         let range = NSRange(location: 0, length: length)
 
-        unorderedListFormatter.toggleAttribute(in: list, at: range)
+        unorderedListFormatter.toggle(in: list, at: range)
 
         let textList = list.textListAttribute(atIndex: 0)
         XCTAssert(textList != nil)
@@ -417,7 +417,7 @@ class TextListFormatterTests: XCTestCase
         XCTAssert(NSEqualRanges(list.range(of: textList!, at: 0)!,range))
 
         // Toggle
-        orderedListFormatter.toggleAttribute(in: list, at: list.rangeOfEntireString)
+        orderedListFormatter.toggle(in: list, at: list.rangeOfEntireString)
 
         // Verify
         let items = textListAttributes(inString: list, atRanges: paragraphRanges(inString: list))
@@ -437,7 +437,7 @@ class TextListFormatterTests: XCTestCase
         let unorderedListFormatter = TextListFormatter(style: .unordered)
 
         let listRange = plainRanges[1]
-        unorderedListFormatter.toggleAttribute(in: list, at: listRange)
+        unorderedListFormatter.toggle(in: list, at: listRange)
 
         for i in 0..<list.length {
             let present = unorderedListFormatter.present(in: list, at: i)
@@ -478,7 +478,7 @@ private extension TextListFormatterTests
         let string = NSMutableAttributedString(string: plainText)
         let formatter = TextListFormatter(style: .ordered)
 
-        formatter.toggleAttribute(in: string, at: string.rangeOfEntireString)
+        formatter.toggle(in: string, at: string.rangeOfEntireString)
 
         return string
     }
@@ -490,7 +490,7 @@ private extension TextListFormatterTests
         var currentFormatter = unorderedListFormatter
 
         for range in plainTextParagraphRanges.reversed() {
-            currentFormatter.toggleAttribute(in: string, at: range)
+            currentFormatter.toggle(in: string, at: range)
 
             currentFormatter = (currentFormatter.listStyle == .unordered) ? orderedListFormatter : unorderedListFormatter
         }

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -84,7 +84,7 @@ class TextListFormatterTests: XCTestCase
         let string = NSMutableAttributedString(string: plainText)
 
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(inText: string, atRange: NSRange(location: 0, length: 1))
+        formatter.toggleAttribute(in: string, at: NSRange(location: 0, length: 1))
 
         let ranges = paragraphRanges(inString: string)
         let lists = textListAttributes(inString: string, atRanges: ranges)
@@ -113,10 +113,10 @@ class TextListFormatterTests: XCTestCase
         let formatter = TextListFormatter(style: .ordered)
 
         // Toggle the 1st line as an Ordered List
-        formatter.toggleAttribute(inText: string, atRange: NSRange(location: 0, length: 1))
+        formatter.toggleAttribute(in: string, at: NSRange(location: 0, length: 1))
 
         // And... undo?
-        formatter.toggleAttribute(inText: string, atRange: NSRange(location: 0, length: 1))
+        formatter.toggleAttribute(in: string, at: NSRange(location: 0, length: 1))
 
         let ranges = paragraphRanges(inString: string)
         let lists = textListAttributes(inString: string, atRanges: ranges)
@@ -141,7 +141,7 @@ class TextListFormatterTests: XCTestCase
         let ranges = paragraphRanges(inString: list)
 
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(inText: list, atRange: ranges[0])
+        formatter.toggleAttribute(in: list, at: ranges[0])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -174,7 +174,7 @@ class TextListFormatterTests: XCTestCase
 
         // Toggle Ordered List on the first line
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggleAttribute(inText: list, atRange: ranges[2])
+        formatter.toggleAttribute(in: list, at: ranges[2])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -206,7 +206,7 @@ class TextListFormatterTests: XCTestCase
         let ranges = paragraphRanges(inString: list)
 
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggleAttribute(inText: list, atRange: ranges[0])
+        formatter.toggleAttribute(in: list, at: ranges[0])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -234,7 +234,7 @@ class TextListFormatterTests: XCTestCase
 
         // Toggle Ordered List on the first line
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(inText: list, atRange: ranges[0])
+        formatter.toggleAttribute(in: list, at: ranges[0])
 
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
@@ -268,7 +268,7 @@ class TextListFormatterTests: XCTestCase
 
         // Toggle Ordered List on the full string's range
         let formatter = TextListFormatter(style: .ordered)
-        formatter.toggleAttribute(inText: list, atRange: list.rangeOfEntireString)
+        formatter.toggleAttribute(in: list, at: list.rangeOfEntireString)
 
         // Verify we got a single big orderedList
         let ranges = paragraphRanges(inString: list)
@@ -304,11 +304,11 @@ class TextListFormatterTests: XCTestCase
 
         // Apply the Ordered List style to the last three paragraphs
         for (index, range) in paragraphRanges(inString: string).enumerated() where index >= 2 {
-            formatter.toggleAttribute(inText: string, atRange: range)
+            formatter.toggleAttribute(in: string, at: range)
         }
 
         // Now... toggle an Ordered List on the full text
-        formatter.toggleAttribute(inText: string, atRange: string.rangeOfEntireString)
+        formatter.toggleAttribute(in: string, at: string.rangeOfEntireString)
 
         // Verify
         let paragraphs = paragraphRanges(inString: string)
@@ -341,10 +341,10 @@ class TextListFormatterTests: XCTestCase
 
         // Line 3 > Unordered List
         let ranges = paragraphRanges(inString: string)
-        unorderedListFormatter.toggleAttribute(inText: string, atRange: ranges[2])
+        unorderedListFormatter.toggleAttribute(in: string, at: ranges[2])
 
         // Entire Text > Ordered List
-        orderedListFormatter.toggleAttribute(inText: string, atRange: string.rangeOfEntireString)
+        orderedListFormatter.toggleAttribute(in: string, at: string.rangeOfEntireString)
 
         // Verify
         let paragraphs = paragraphRanges(inString: string)
@@ -377,7 +377,7 @@ class TextListFormatterTests: XCTestCase
 
         // Toggle Ordered List on the full string's range
         let formatter = TextListFormatter(style: .unordered)
-        formatter.toggleAttribute(inText: list, atRange: list.rangeOfEntireString)
+        formatter.toggleAttribute(in: list, at: list.rangeOfEntireString)
 
         // Verify we got a single big orderedList
         let ranges = paragraphRanges(inString: list)
@@ -409,7 +409,7 @@ class TextListFormatterTests: XCTestCase
         let length = plainRanges[1].location + plainRanges[1].length
         let range = NSRange(location: 0, length: length)
 
-        unorderedListFormatter.toggleAttribute(inText: list, atRange: range)
+        unorderedListFormatter.toggleAttribute(in: list, at: range)
 
         let textList = list.textListAttribute(atIndex: 0)
         XCTAssert(textList != nil)
@@ -417,7 +417,7 @@ class TextListFormatterTests: XCTestCase
         XCTAssert(NSEqualRanges(list.range(of: textList!, at: 0)!,range))
 
         // Toggle
-        orderedListFormatter.toggleAttribute(inText: list, atRange: list.rangeOfEntireString)
+        orderedListFormatter.toggleAttribute(in: list, at: list.rangeOfEntireString)
 
         // Verify
         let items = textListAttributes(inString: list, atRanges: paragraphRanges(inString: list))
@@ -437,7 +437,7 @@ class TextListFormatterTests: XCTestCase
         let unorderedListFormatter = TextListFormatter(style: .unordered)
 
         let listRange = plainRanges[1]
-        unorderedListFormatter.toggleAttribute(inText: list, atRange: listRange)
+        unorderedListFormatter.toggleAttribute(in: list, at: listRange)
 
         for i in 0..<list.length {
             let present = unorderedListFormatter.present(in: list, at: i)
@@ -478,7 +478,7 @@ private extension TextListFormatterTests
         let string = NSMutableAttributedString(string: plainText)
         let formatter = TextListFormatter(style: .ordered)
 
-        formatter.toggleAttribute(inText: string, atRange: string.rangeOfEntireString)
+        formatter.toggleAttribute(in: string, at: string.rangeOfEntireString)
 
         return string
     }
@@ -490,7 +490,7 @@ private extension TextListFormatterTests
         var currentFormatter = unorderedListFormatter
 
         for range in plainTextParagraphRanges.reversed() {
-            currentFormatter.toggleAttribute(inText: string, atRange: range)
+            currentFormatter.toggleAttribute(in: string, at: range)
 
             currentFormatter = (currentFormatter.listStyle == .unordered) ? orderedListFormatter : unorderedListFormatter
         }


### PR DESCRIPTION
### Details:
- AttributeFormatter's API has been updated, with Swift 3 in mind
- UITextView is nowhere to be seen, within any of the formatters
- Added some extra method documentation here and there
- Unit Tests updated accordingly

### Testing:
Please, try out `Lists (Ordered / Unordered)` and `Blockquotes`, in any possible scenarios:

- Empty Documents
- At the beginning / middle / bototm of a document

We're aware of several Lists / Blockquote glitches (all of them are filed, to the best of my knowledge).
We'll be addressing them ASAP.

Needs Review: @diegoreymendez 
Thanks in advance!
