### PR TITLE
Updating ParagraphFormatter(s) Toggle Logic

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		59FEA0751D8BDFA700D138DF /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA0661D8BDFA700D138DF /* NodeTests.swift */; };
 		59FEA0781D8BDFA700D138DF /* HTMLToAttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06A1D8BDFA700D138DF /* HTMLToAttributedStringTests.swift */; };
 		59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */; };
+		B580A1EA1E2142EC00C393C6 /* StringConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B580A1E91E2142EC00C393C6 /* StringConstants.swift */; };
 		B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */; };
 		B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */; };
 		B5B86D3C1DA41A550083DB3F /* TextListFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */; };
@@ -155,6 +156,7 @@
 		59FEA06B1D8BDFA700D138DF /* InAttributeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAttributeConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InHTMLConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
+		B580A1E91E2142EC00C393C6 /* StringConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringConstants.swift; sourceTree = "<group>"; };
 		B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Traits.swift"; sourceTree = "<group>"; };
 		B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatter.swift; sourceTree = "<group>"; };
 		B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIPasteboard+Helpers.swift"; sourceTree = "<group>"; };
@@ -340,8 +342,9 @@
 		599F251F1D8BC9A1002871D6 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
-				599F25201D8BC9A1002871D6 /* HTMLConstants.swift */,
 				599F25211D8BC9A1002871D6 /* Metrics.swift */,
+				599F25201D8BC9A1002871D6 /* HTMLConstants.swift */,
+				B580A1E91E2142EC00C393C6 /* StringConstants.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -649,6 +652,7 @@
 				B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */,
 				599F25391D8BC9A1002871D6 /* InHTMLConverter.swift in Sources */,
 				599F25411D8BC9A1002871D6 /* EditableNode.swift in Sources */,
+				B580A1EA1E2142EC00C393C6 /* StringConstants.swift in Sources */,
 				F1A218151E02D5B3000AF5EB /* UndoManager.swift in Sources */,
 				FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Archive.swift in Sources */,
 				599F253E1D8BC9A1002871D6 /* OutHTMLNodeConverter.swift in Sources */,

--- a/Aztec/Classes/Constants/HTMLConstants.swift
+++ b/Aztec/Classes/Constants/HTMLConstants.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+
+/// HTML Attributes
+///
 public enum HTMLLinkAttribute: String {
+
     case Href = "href"
 }

--- a/Aztec/Classes/Constants/Metrics.swift
+++ b/Aztec/Classes/Constants/Metrics.swift
@@ -4,12 +4,10 @@ import Foundation
 /// A collection of constants and metrics shared between the Aztec importer
 /// and the editor.
 ///
-enum Metrics
-{
+enum Metrics {
 
     static let defaultIndentation = CGFloat(12)
     static let maxIndentation = CGFloat(200)
     static let tabStepInterval = 8
     static let tabStepCount = 12
-
 }

--- a/Aztec/Classes/Constants/StringConstants.swift
+++ b/Aztec/Classes/Constants/StringConstants.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+
+/// Collection of String Helpers
+///
+struct StringConstants {
+    static let zeroWidthSpace   = "\u{200B}"
+    static let newline          = "\n"
+}

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -126,16 +126,14 @@ extension ParagraphAttributeFormatter {
 
     /// Toggles an attribute in the specified range of a text storage, and returns the new Selected Range.
     ///
-    /// - Note: Before anything, we'll determine if the attribute should be applied at the specified range, or not.
-    ///   Order is important. Why? because we *may need* to insert an empty string placeholder, and this operation may
-    ///   alter this result!.
+    /// - Note: Whenever either the application paragraph is empty, or the entire storage is empty,
+    ///   we'll need to insert a placeholder (Zero Width String). Reason why? Because some formatters
+    ///   (TextList / Blockquote) need to display a custom UI, even when there is no content to display.
+    ///   In those scenarios, TextView's TypingAttributes just don't do the trick.
     ///
-    /// - Note: We need a Zero Width Placeholder, whenever either the application paragraph is empty, or the entire
-    ///   storage is empty, because otherwise there just won't be anything to apply the attribute to.
-    ///
-    /// - Note: Again, why?. Because in the TextList / Blockquote Formatter scenario, we need to render format,
-    ///   even when there is no content to display. TextView's TypingAttributes just don't do the trick.
-    ///
+    /// - Note: For the reasons mentioned above, the first thing we'll do is to determine if the attribute should
+    ///   be applied or not. Order of events is important. 
+    ///   Why? because we *may need* to insert an empty string placeholder, and this operation may alter this result!
     ///
     @discardableResult
     func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -13,7 +13,7 @@ protocol AttributeFormatter {
     /// Selected Range. This is required because, in several scenarios, we may need to add a "Zero Width Space",
     /// just to get the style to render properly.
     ///
-    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange?
+    func toggle(in text: NSMutableAttributedString, at range: NSRange, with attributes: [String: Any]?) -> NSRange?
 
     /// Checks if the attribute is present in a given Attributed String at the specified index.
     ///
@@ -59,9 +59,8 @@ private extension AttributeFormatter {
 
     /// The string to be used when adding attributes to an empty line.
     ///
-    var placeholderForAttributedEmptyLine: NSAttributedString {
-        // "Zero Width Space" Character
-        return NSAttributedString(string: "\u{200B}")
+    func placeholderForEmptyLine(with attributes: [String: Any]?) -> NSAttributedString {
+        return NSAttributedString(string: StringConstants.zeroWidthSpace, attributes: attributes)
     }
 
     /// Helper that indicates whether if we should format the specified range, or not. 
@@ -103,7 +102,7 @@ extension CharacterAttributeFormatter {
     /// Toggles the Attribute Format, into a given string, at the specified range.
     ///
     @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange) {
+    func toggle(in text: NSMutableAttributedString, at range: NSRange, with attributes: [String: Any]? = nil) {
         guard range.location < text.length else {
             return
         }
@@ -136,13 +135,14 @@ extension ParagraphAttributeFormatter {
     ///   Why? because we *may need* to insert an empty string placeholder, and this operation may alter this result!
     ///
     @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {
+    func toggle(in text: NSMutableAttributedString, at range: NSRange, with attributes: [String: Any]? = nil) -> NSRange? {
         let shouldApply = shouldApplyAttributes(to: text, at: range)
         var applicationRange = text.paragraphRange(for: range)
         var newSelectedRange: NSRange?
 
         if applicationRange.length == 0 || text.length == 0 {
-            text.insert(placeholderForAttributedEmptyLine, at: applicationRange.location)
+            let placeholder = placeholderForEmptyLine(with: attributes)
+            text.insert(placeholder, at: applicationRange.location)
             newSelectedRange = NSRange(location: text.length, length: 0)
             applicationRange = NSMakeRange(text.length - 1, 1)
         }

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -123,10 +123,19 @@ protocol CharacterAttributeFormatter: AttributeFormatter {
 
 extension CharacterAttributeFormatter {
 
+    /// Toggles the Attribute Format, into a given string, at the specified range.
+    ///
     @discardableResult
     func toggle(in text: NSMutableAttributedString, at range: NSRange) {
-        let applicationRange = self.applicationRange(for: range, in: text)
-        toggleAttributes(in: text, at: applicationRange)
+        guard range.location < text.length else {
+            return
+        }
+
+        if shouldApplyAttributes(to: text, at: range) {
+            applyAttributes(to: text, at: range)
+        } else {
+            removeAttributes(from: text, at: range)
+        }
     }
 }
 

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -1,25 +1,25 @@
 import UIKit
 
-/// A type that provides support for toggling compound attributes in an
-/// attributed string.
+
+/// A type that provides support for toggling compound attributes in an attributed string.
 ///
-/// When you want to represent an attribute that does not have a 1-1
-/// correspondence with a standard attribute, it is useful to have a virtual
-/// attribute. Toggling this attribute would also toggle the attributes for its
-/// defined style.
+/// When you want to represent an attribute that does not have a 1-1 correspondence with a standard
+/// attribute, it is useful to have a virtual attribute. 
+/// Toggling this attribute would also toggle the attributes for its defined style.
 ///
 protocol AttributeFormatter {
 
     /// Toggles an attribute in the specified range of a text storage, and returns the new 
     /// Selected Range. This is required because, in several scenarios, we may need to add a "Zero Width Space",
-    /// just to get the style to render properly
-    ///
-    /// The application range might be different than the passed range, as
-    /// explained in `applicationRange(for:in:)`
+    /// just to get the style to render properly.
     ///
     func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange?
 
-    /// Apply the compound attributes to the provided attributes dictionary
+    /// Checks if the attribute is present in a given Attributed String at the specified index.
+    ///
+    func present(in text: NSAttributedString, at index: Int) -> Bool
+
+    /// Apply the compound attributes to the provided attributes dictionary.
     ///
     /// - Parameter attributes: the original attributes to apply to
     /// - Returns: the resulting attributes dictionary
@@ -36,10 +36,6 @@ protocol AttributeFormatter {
     /// Checks if the attribute is present in a dictionary of attributes.
     ///
     func present(in attributes: [String: AnyObject]) -> Bool
-
-    /// Checks if the attribute is present in a given Attributed String at the specified index.
-    ///
-    func present(in text: NSAttributedString, at index: Int) -> Bool
 
     /// The range to apply the attributes to.
     ///

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -9,6 +9,10 @@ import UIKit
 ///
 protocol AttributeFormatter {
 
+    /// Attributes to be used the Content Placeholder, when / if needed.
+    ///
+    var placeholderAttributes: [String: Any]? { get }
+
     /// Toggles an attribute in the specified range of a text storage, and returns the new 
     /// Selected Range. This is required because, in several scenarios, we may need to add a "Zero Width Space",
     /// just to get the style to render properly.
@@ -16,9 +20,8 @@ protocol AttributeFormatter {
     /// - Parameters:
     ///     - text: Text that should be formatted.
     ///     - range: Segment of text which format should be toggled.
-    ///     - attributes: Attributes to be used the Content Placeholder, when / if needed.
     ///
-    func toggle(in text: NSMutableAttributedString, at range: NSRange, with placeholderAttributes: [String: Any]?) -> NSRange?
+    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange?
 
     /// Checks if the attribute is present in a given Attributed String at the specified index.
     ///
@@ -107,7 +110,7 @@ extension CharacterAttributeFormatter {
     /// Toggles the Attribute Format, into a given string, at the specified range.
     ///
     @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange, with placeholderAttributes: [String: Any]? = nil) {
+    func toggle(in text: NSMutableAttributedString, at range: NSRange) {
         guard range.location < text.length else {
             return
         }
@@ -140,7 +143,7 @@ extension ParagraphAttributeFormatter {
     ///   Why? because we *may need* to insert an empty string placeholder, and this operation may alter this result!
     ///
     @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange, with placeholderAttributes: [String: Any]? = nil) -> NSRange? {
+    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {
         let shouldApply = shouldApplyAttributes(to: text, at: range)
         var applicationRange = text.paragraphRange(for: range)
         var newSelectedRange: NSRange?

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -64,19 +64,15 @@ private extension AttributeFormatter {
         return NSAttributedString(string: "\u{200B}")
     }
 
+    /// Helper that indicates whether if we should format the specified range, or not. 
+    /// -   Note: For convenience reasons, whenever the Text is empty, this helper will return *true*.
     ///
-    /// Toggles the Attribute Format, into a given string, at the specified range.
-    ///
-    func toggleAttributes(in string: NSMutableAttributedString, at range: NSRange) {
-        guard range.location < string.length else {
-            return
+    func shouldApplyAttributes(to text: NSAttributedString, at range: NSRange) -> Bool {
+        guard text.length > 0 else {
+            return true
         }
 
-        if present(in: string, at: range.location) {
-            removeAttributes(from: string, at: range)
-        } else {
-            applyAttributes(to: string, at: range)
-        }
+        return present(in: text, at: range.location) == false
     }
 
     /// Applies the Formatter's Attributes into a given string, at the specified range.

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -77,17 +77,15 @@ private extension AttributeFormatter {
 
     /// The string to be used when adding attributes to an empty line.
     ///
-    var placeholderForAttributedEmptyLine: String {
+    var placeholderForAttributedEmptyLine: NSAttributedString {
         // "Zero Width Space" Character
-        return "\u{200B}"
+        return NSAttributedString(string: "\u{200B}")
     }
 
     /// Inserts an empty placeholder, into a given string, at the specified index.
     ///
     func insertEmptyPlaceholderString(in string: NSMutableAttributedString, at index: Int) {
-        let attributes = apply(to: [:])
-        let attributedSpace = NSAttributedString(string: placeholderForAttributedEmptyLine, attributes: attributes)
-        string.insert(attributedSpace, at: index)
+        string.insert(placeholderForAttributedEmptyLine, at: index)
     }
 
     /// Toggles the Attribute Format, into a given string, at the specified range.

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -64,12 +64,7 @@ private extension AttributeFormatter {
         return NSAttributedString(string: "\u{200B}")
     }
 
-    /// Inserts an empty placeholder, into a given string, at the specified index.
     ///
-    func insertEmptyPlaceholderString(in string: NSMutableAttributedString, at index: Int) {
-        string.insert(placeholderForAttributedEmptyLine, at: index)
-    }
-
     /// Toggles the Attribute Format, into a given string, at the specified range.
     ///
     func toggleAttributes(in string: NSMutableAttributedString, at range: NSRange) {

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -36,14 +36,6 @@ protocol AttributeFormatter {
     /// Checks if the attribute is present in a dictionary of attributes.
     ///
     func present(in attributes: [String: AnyObject]) -> Bool
-
-    /// The range to apply the attributes to.
-    ///
-    /// By default, this returns the passed `range`, but implementations of this
-    /// protocol might want to extend the range to apply the attribute to a
-    /// different range (e.g. a paragraph)
-    ///
-    func applicationRange(for range: NSRange, in string: NSAttributedString) -> NSRange
 }
 
 
@@ -57,12 +49,6 @@ extension AttributeFormatter {
         let safeIndex = max(min(index, text.length - 1), 0)
         let attributes = text.attributes(at: safeIndex, effectiveRange: nil) as [String : AnyObject]
         return present(in: attributes)
-    }
-
-    /// The range to apply the attributes to.
-    ///
-    func applicationRange(for range: NSRange, in string: NSAttributedString) -> NSRange {
-        return range
     }
 }
 
@@ -146,10 +132,6 @@ protocol ParagraphAttributeFormatter: AttributeFormatter {
 }
 
 extension ParagraphAttributeFormatter {
-
-    func applicationRange(for range: NSRange, in string: NSAttributedString) -> NSRange {
-        return string.paragraphRange(for: range)
-    }
 
     @discardableResult
     func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -13,7 +13,12 @@ protocol AttributeFormatter {
     /// Selected Range. This is required because, in several scenarios, we may need to add a "Zero Width Space",
     /// just to get the style to render properly.
     ///
-    func toggle(in text: NSMutableAttributedString, at range: NSRange, with attributes: [String: Any]?) -> NSRange?
+    /// - Parameters:
+    ///     - text: Text that should be formatted.
+    ///     - range: Segment of text which format should be toggled.
+    ///     - attributes: Attributes to be used the Content Placeholder, when / if needed.
+    ///
+    func toggle(in text: NSMutableAttributedString, at range: NSRange, with placeholderAttributes: [String: Any]?) -> NSRange?
 
     /// Checks if the attribute is present in a given Attributed String at the specified index.
     ///
@@ -59,7 +64,7 @@ private extension AttributeFormatter {
 
     /// The string to be used when adding attributes to an empty line.
     ///
-    func placeholderForEmptyLine(with attributes: [String: Any]?) -> NSAttributedString {
+    func placeholderForEmptyLine(using attributes: [String: Any]?) -> NSAttributedString {
         return NSAttributedString(string: StringConstants.zeroWidthSpace, attributes: attributes)
     }
 
@@ -102,7 +107,7 @@ extension CharacterAttributeFormatter {
     /// Toggles the Attribute Format, into a given string, at the specified range.
     ///
     @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange, with attributes: [String: Any]? = nil) {
+    func toggle(in text: NSMutableAttributedString, at range: NSRange, with placeholderAttributes: [String: Any]? = nil) {
         guard range.location < text.length else {
             return
         }
@@ -135,13 +140,13 @@ extension ParagraphAttributeFormatter {
     ///   Why? because we *may need* to insert an empty string placeholder, and this operation may alter this result!
     ///
     @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange, with attributes: [String: Any]? = nil) -> NSRange? {
+    func toggle(in text: NSMutableAttributedString, at range: NSRange, with placeholderAttributes: [String: Any]? = nil) -> NSRange? {
         let shouldApply = shouldApplyAttributes(to: text, at: range)
         var applicationRange = text.paragraphRange(for: range)
         var newSelectedRange: NSRange?
 
         if applicationRange.length == 0 || text.length == 0 {
-            let placeholder = placeholderForEmptyLine(with: attributes)
+            let placeholder = placeholderForEmptyLine(using: placeholderAttributes)
             text.insert(placeholder, at: applicationRange.location)
             newSelectedRange = NSRange(location: text.length, length: 0)
             applicationRange = NSMakeRange(text.length - 1, 1)

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -20,7 +20,11 @@ class Blockquote: NSObject, NSCoding {
 }
 
 struct BlockquoteFormatter: ParagraphAttributeFormatter {
+    let placeholderAttributes: [String : Any]?
 
+    init(placeholderAttributes: [String : Any]? = nil) {
+        self.placeholderAttributes = placeholderAttributes
+    }
 
     func apply(to attributes: [String : Any]) -> [String: Any] {
         var resultingAttributes = attributes

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -4,9 +4,11 @@ import UIKit
 struct TextListFormatter: ParagraphAttributeFormatter {
 
     let listStyle: TextList.Style
+    let placeholderAttributes: [String : Any]?
 
-    init(style: TextList.Style) {
+    init(style: TextList.Style, placeholderAttributes: [String : Any]? = nil) {
         self.listStyle = style
+        self.placeholderAttributes = placeholderAttributes
     }
 
     func apply(to attributes: [String : Any]) -> [String: Any] {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -590,7 +590,7 @@ open class TextView: UITextView {
     ///
     fileprivate func remove(list: TextList, at range: NSRange) {
         let formatter = TextListFormatter(style: list.style)
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
         selectedRange = newSelectedRange ?? selectedRange
     }
 
@@ -601,7 +601,7 @@ open class TextView: UITextView {
     ///
     open func toggleOrderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .ordered)
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
         selectedRange = newSelectedRange ?? selectedRange
     }
 
@@ -612,7 +612,7 @@ open class TextView: UITextView {
     ///
     open func toggleUnorderedList(range: NSRange) {
         let formatter = TextListFormatter(style: .unordered)
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
         selectedRange = newSelectedRange ?? selectedRange
     }
 
@@ -630,7 +630,7 @@ open class TextView: UITextView {
     ///
     open func toggleBlockquote(range: NSRange) {
         let formatter = BlockquoteFormatter()
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
         selectedRange = newSelectedRange ?? selectedRange
         forceRedrawCursorAfterDelay()
     }
@@ -650,7 +650,7 @@ open class TextView: UITextView {
             return
         }
 
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
         selectedRange = newSelectedRange ?? selectedRange
     }
 
@@ -684,10 +684,10 @@ open class TextView: UITextView {
         }
 
         let formatter = BlockquoteFormatter()
-        var newSelectedRange = formatter.toggle(in: textStorage, at: range)
+        var newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
 
         if afterRange.endLocation < storage.length {
-            newSelectedRange = formatter.toggle(in: textStorage, at: afterRange) ?? newSelectedRange
+            newSelectedRange = formatter.toggle(in: textStorage, at: afterRange, with: typingAttributes) ?? newSelectedRange
             deleteBackward()
         }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -589,8 +589,8 @@ open class TextView: UITextView {
     ///     - range: Range of the list to be removed.
     ///
     fileprivate func remove(list: TextList, at range: NSRange) {
-        let formatter = TextListFormatter(style: list.style)
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
+        let formatter = TextListFormatter(style: list.style, placeholderAttributes: typingAttributes)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
         selectedRange = newSelectedRange ?? selectedRange
     }
 
@@ -600,8 +600,8 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleOrderedList(range: NSRange) {
-        let formatter = TextListFormatter(style: .ordered)
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
+        let formatter = TextListFormatter(style: .ordered, placeholderAttributes: typingAttributes)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
         selectedRange = newSelectedRange ?? selectedRange
     }
 
@@ -611,8 +611,8 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleUnorderedList(range: NSRange) {
-        let formatter = TextListFormatter(style: .unordered)
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
+        let formatter = TextListFormatter(style: .unordered, placeholderAttributes: typingAttributes)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
         selectedRange = newSelectedRange ?? selectedRange
     }
 
@@ -629,8 +629,8 @@ open class TextView: UITextView {
     ///     - range: The NSRange to edit.
     ///
     open func toggleBlockquote(range: NSRange) {
-        let formatter = BlockquoteFormatter()
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
+        let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributes)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
         selectedRange = newSelectedRange ?? selectedRange
         forceRedrawCursorAfterDelay()
     }
@@ -645,12 +645,12 @@ open class TextView: UITextView {
     ///   - range: the deletion range
     ///
     private func refreshBlockquoteAfterDeletion(of text: NSAttributedString, at range: NSRange) {
-        let formatter = BlockquoteFormatter()
+        let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributes)
         guard formatter.present(in: textStorage, at: range.location), range.location == 0 else {
             return
         }
 
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
+        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
         selectedRange = newSelectedRange ?? selectedRange
     }
 
@@ -683,11 +683,11 @@ open class TextView: UITextView {
             return
         }
 
-        let formatter = BlockquoteFormatter()
-        var newSelectedRange = formatter.toggle(in: textStorage, at: range, with: typingAttributes)
+        let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributes)
+        var newSelectedRange = formatter.toggle(in: textStorage, at: range)
 
         if afterRange.endLocation < storage.length {
-            newSelectedRange = formatter.toggle(in: textStorage, at: afterRange, with: typingAttributes) ?? newSelectedRange
+            newSelectedRange = formatter.toggle(in: textStorage, at: afterRange) ?? newSelectedRange
             deleteBackward()
         }
 


### PR DESCRIPTION
### Description:
This PR fixes two issues:
- Lists / Blockquotes now can be removed, whenever you're at the end of the document.
- Indentation is being effectively restored, whenever a list / blockquote is removed.

### Details:
- For readability / consistency's reasons, i've removed few **AttributeFormatter**'s helpers, and implemented custom logic in `CharacterAttributeFormatter` / `ParagraphAttributeFormatter`
- Paragraph Formatters now have a tailored down "Toggle" logic:
 - Before anything, we determine if the format should be applied or removed
 - We, then, proceed to insert (if needed) a **Zero Width** placeholder. See the `ParagraphFormatter`'s **toggle** method documentation, for more details.
 - At last, we return the "Selection Range", if needed.

Please, note that i'll be nuking the entire "Selection Range" update in another PR.

Closes #204
Closes #208
Closes #210

### Testing: **Cannot Remove**
1. Launch the Empty Editor Demo
2. Press the Lists / Blockquote Format Bar Action
3. Press Return
4. Press the same action you've done in (3), to toggle

Verify that the List / Blockquote gets effectively removed.

### Testing: **Indentation**
1. Launch the Empty Editor
2. Press the Blockquote (OR) Lists button
3. Hit backspace

Verify that the original indentation gets restored.

### Testing: **Default Font**
1. Launch the Empty Editor Demo
2. Press any of these actions: **Blockquote** / **Ordered List**  / **Unordered List**
3. Type some random text

Verify that the typing attributes are respected (Font should be 14 points, and Bold / Italics / Underline settings should be respected).

Needs Review: @diegoreymendez  / @SergioEstevao 
Thanks in advance gentlemen!!

Diego: Thanks so much for the brainstorming session!
