### PR TITLE
Undo / redo improvements

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -68,7 +68,7 @@
 		F1288BAF1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1288BAD1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift */; };
 		F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1288BAE1DD0B1EF00E67ABC /* HTMLToAttributedString.swift */; };
 		F15C9B881DD58D8B00833C39 /* ElementNodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15C9B871DD58D8B00833C39 /* ElementNodeDescriptor.swift */; };
-		F15F61C91E0323EC00CD6DD8 /* UndoStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F61C81E0323EC00CD6DD8 /* UndoStack.swift */; };
+		F15F61C91E0323EC00CD6DD8 /* EditContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F61C81E0323EC00CD6DD8 /* EditContext.swift */; };
 		F18733C81DA09737005AEB80 /* NSRangeComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */; };
 		F1A218151E02D5B3000AF5EB /* UndoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A218141E02D5B3000AF5EB /* UndoManager.swift */; };
 		F1CF272A1DBA8CDB0001C61D /* DOMString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF27291DBA8CDB0001C61D /* DOMString.swift */; };
@@ -168,7 +168,7 @@
 		F1288BAD1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLNodeToNSAttributedString.swift; sourceTree = "<group>"; };
 		F1288BAE1DD0B1EF00E67ABC /* HTMLToAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLToAttributedString.swift; sourceTree = "<group>"; };
 		F15C9B871DD58D8B00833C39 /* ElementNodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ElementNodeDescriptor.swift; path = Descriptors/ElementNodeDescriptor.swift; sourceTree = "<group>"; };
-		F15F61C81E0323EC00CD6DD8 /* UndoStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UndoStack.swift; sourceTree = "<group>"; };
+		F15F61C81E0323EC00CD6DD8 /* EditContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditContext.swift; sourceTree = "<group>"; };
 		F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRange+Helpers.swift"; sourceTree = "<group>"; };
 		F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSRangeComparisonTests.swift; path = Extensions/NSRangeComparisonTests.swift; sourceTree = "<group>"; };
 		F1A218141E02D5B3000AF5EB /* UndoManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UndoManager.swift; sourceTree = "<group>"; };
@@ -284,7 +284,7 @@
 				599F25131D8BC9A1002871D6 /* DOM */,
 				599F251A1D8BC9A1002871D6 /* Libxml2.swift */,
 				F1CF27291DBA8CDB0001C61D /* DOMString.swift */,
-				F15F61C81E0323EC00CD6DD8 /* UndoStack.swift */,
+				F15F61C81E0323EC00CD6DD8 /* EditContext.swift */,
 			);
 			path = Libxml2;
 			sourceTree = "<group>";
@@ -628,7 +628,7 @@
 				B5B86D3C1DA41A550083DB3F /* TextListFormatter.swift in Sources */,
 				599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */,
 				599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */,
-				F15F61C91E0323EC00CD6DD8 /* UndoStack.swift in Sources */,
+				F15F61C91E0323EC00CD6DD8 /* EditContext.swift in Sources */,
 				F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */,
 				E11B77641DBA6ADC0024E455 /* AttributeFormatter.swift in Sources */,
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,

--- a/Aztec/Classes/Converters/HTMLToAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLToAttributedString.swift
@@ -3,29 +3,29 @@ import UIKit
 
 class HTMLToAttributedString: Converter {
 
+    typealias EditContext = Libxml2.EditContext
     typealias RootNode = Libxml2.RootNode
     typealias TextNode = Libxml2.TextNode
-    typealias UndoRegistrationClosure = Libxml2.Node.UndoRegistrationClosure
 
     /// The default font descriptor that will be used as a base for conversions.
     ///
     let defaultFontDescriptor: UIFontDescriptor
     
-    let registerUndo: UndoRegistrationClosure
+    let editContext: EditContext?
 
-    required init(usingDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor, registerUndo: @escaping UndoRegistrationClosure) {
+    required init(usingDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor, editContext: EditContext? = nil) {
         self.defaultFontDescriptor = defaultFontDescriptor
-        self.registerUndo = registerUndo
+        self.editContext = editContext
     }
 
     func convert(_ html: String) throws -> (rootNode: RootNode, attributedString: NSAttributedString) {
-        let htmlToNode = Libxml2.In.HTMLConverter(registerUndo: registerUndo)
+        let htmlToNode = Libxml2.In.HTMLConverter(editContext: editContext)
         let nodeToAttributedString = HMTLNodeToNSAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
 
         let rootNode = try htmlToNode.convert(html)
 
         if rootNode.children.count == 0 {
-            rootNode.append(TextNode(text: html, registerUndo: registerUndo))
+            rootNode.append(TextNode(text: html, editContext: editContext))
         }
 
         let attributedString = nodeToAttributedString.convert(rootNode)

--- a/Aztec/Classes/Libxml2/Converters/In/InHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InHTMLConverter.swift
@@ -4,19 +4,17 @@ import libxml2
 extension Libxml2.In {
     class HTMLConverter: Converter {
 
+        typealias EditContext = Libxml2.EditContext
         typealias RootNode = Libxml2.RootNode
-        typealias UndoRegistrationClosure = Libxml2.Node.UndoRegistrationClosure
         
         enum Error: String, Swift.Error {
             case NoRootNode = "No root node"
         }
         
-        let registerUndo: UndoRegistrationClosure
+        let editContext: EditContext?
 
-        /// Not sure why, but the compiler is requiring this initializer.
-        ///
-        required init(registerUndo: @escaping UndoRegistrationClosure) {
-            self.registerUndo = registerUndo
+        required init(editContext: EditContext? = nil) {
+            self.editContext = editContext
         }
 
         /// Converts HTML data into an HTML Node representing the same data.
@@ -88,7 +86,7 @@ extension Libxml2.In {
                 // It may be a good idea to wrap the HTML in a single fake root node before parsing
                 // it to bypass this behaviour.
                 //
-                let nodeConverter = NodeConverter(registerUndo: registerUndo)
+                let nodeConverter = NodeConverter(editContext: editContext)
 
                 guard let node = nodeConverter.convert(rootNode) as? RootNode else {
                     throw Error.NoRootNode

--- a/Aztec/Classes/Libxml2/Converters/In/InNodesConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodesConverter.swift
@@ -6,11 +6,11 @@ extension Libxml2.In {
     /// Converts a C linked list of xmlNode to [HTML.Node].
     ///
     class NodesConverter: SafeCLinkedListToArrayConverter<NodeConverter> {
-
-        typealias UndoRegistrationClosure = Libxml2.Node.UndoRegistrationClosure
         
-        required init(registerUndo: @escaping UndoRegistrationClosure) {
-            super.init(elementConverter: NodeConverter(registerUndo: registerUndo), next: { return $0.next })
+        typealias EditContext = Libxml2.EditContext
+        
+        required init(editContext: EditContext? = nil) {
+            super.init(elementConverter: NodeConverter(editContext: editContext), next: { return $0.next })
         }
     }
 }

--- a/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
@@ -4,10 +4,10 @@ import libxml2
 extension Libxml2.Out {
     class HTMLConverter: Converter {
         
+        typealias EditContext = Libxml2.EditContext
         typealias Node = Libxml2.Node
         typealias ElementNode = Libxml2.ElementNode
         typealias RootNode = Libxml2.RootNode
-        typealias UndoRegistrationClosure = Node.UndoRegistrationClosure
         
         required init() {
         }

--- a/Aztec/Classes/Libxml2/DOM/CommentNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/CommentNode.swift
@@ -17,10 +17,10 @@ extension Libxml2 {
         
         // MARK: - Initializers
         
-        init(text: String, registerUndo: @escaping UndoRegistrationClosure) {
+        init(text: String, editContext: EditContext? = nil) {
             comment = text
 
-            super.init(name: "comment", registerUndo: registerUndo)
+            super.init(name: "comment", editContext: editContext)
         }
 
         /// Node length.

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -673,11 +673,7 @@ extension Libxml2 {
         ///     - child: the node to append.
         ///
         func append(_ child: Node) {
-
-            if let parent = child.parent {
-                parent.remove([child])
-            }
-
+            child.removeFromParent()
             children.append(child)
             child.parent = self
         }
@@ -688,25 +684,18 @@ extension Libxml2 {
         ///     - child: the node to append.
         ///
         func append(_ children: [Node]) {
-            
             for child in children {
                 append(child)
             }
         }
-        
+
         /// Prepends a node to the list of children for this element.
         ///
         /// - Parameters:
         ///     - child: the node to prepend.
         ///
         func prepend(_ child: Node) {
-            
-            if let parent = child.parent {
-                parent.remove([child])
-            }
-            
-            children.insert(child, at: 0)
-            child.parent = self
+            insert(child, at: 0)
         }
 
         /// Prepends children to the list of children for this element.
@@ -715,7 +704,6 @@ extension Libxml2 {
         ///     - children: the nodes to prepend.
         ///
         func prepend(_ children: [Node]) {
-            
             for index in stride(from: (children.count - 1), through: 0, by: -1) {
                 prepend(children[index])
             }
@@ -728,11 +716,7 @@ extension Libxml2 {
         ///     - index: the position where to insert the node.
         ///
         func insert(_ child: Node, at index: Int) {
-
-            if let parent = child.parent {
-                parent.remove([child])
-            }
-
+            child.removeFromParent()
             children.insert(child, at: index)
             child.parent = self
         }

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -36,11 +36,11 @@ extension Libxml2 {
         
         // MARK: - Initializers
 
-        init(name: String, attributes: [Attribute], children: [Node], registerUndo: @escaping UndoRegistrationClosure) {
+        init(name: String, attributes: [Attribute], children: [Node], editContext: EditContext? = nil) {
             self.attributes.append(contentsOf: attributes)
             self.children = children
 
-            super.init(name: name, registerUndo: registerUndo)
+            super.init(name: name, editContext: editContext)
 
             for child in children {
 
@@ -52,8 +52,8 @@ extension Libxml2 {
             }
         }
         
-        convenience init(descriptor: ElementNodeDescriptor, children: [Node] = [], registerUndo: @escaping UndoRegistrationClosure) {
-            self.init(name: descriptor.name, attributes: descriptor.attributes, children: children, registerUndo: registerUndo)
+        convenience init(descriptor: ElementNodeDescriptor, children: [Node] = [], editContext: EditContext? = nil) {
+            self.init(name: descriptor.name, attributes: descriptor.attributes, children: children, editContext: editContext)
         }
         
         // MARK: - Node Overrides
@@ -1055,7 +1055,7 @@ extension Libxml2 {
             } else if index < children.count, let nextTextNode = children[index] as? TextNode {
                 nextTextNode.prepend(string)
             } else {
-                insert(TextNode(text: string, registerUndo: registerUndo), at: index)
+                insert(TextNode(text: string, editContext: editContext), at: index)
             }
         }
 
@@ -1142,7 +1142,7 @@ extension Libxml2 {
             let localRange = NSRange(location: targetRange.location - absoluteLocation, length: targetRange.length)
             textNode.split(forRange: localRange)
             
-            let imgNode = ElementNode(descriptor: elementDescriptor, registerUndo: registerUndo)
+            let imgNode = ElementNode(descriptor: elementDescriptor, editContext: editContext)
             
             guard let index = textNode.parent?.children.index(of: textNode) else {
                 assertionFailure("Can't remove a node that's not a child.")
@@ -1182,7 +1182,7 @@ extension Libxml2 {
             let postNodes = splitChildren(after: location)
             
             if postNodes.count > 0 {
-                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes, registerUndo: registerUndo)
+                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes, editContext: editContext)
                 
                 parent.insert(newElement, at: nodeIndex + 1)
                 remove(postNodes, updateParent: false)
@@ -1212,7 +1212,7 @@ extension Libxml2 {
             let postNodes = splitChildren(after: range.location + range.length)
 
             if postNodes.count > 0 {
-                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes, registerUndo: registerUndo)
+                let newElement = ElementNode(name: name, attributes: attributes, children: postNodes, editContext: editContext)
 
                 parent.insert(newElement, at: nodeIndex + 1)
                 remove(postNodes, updateParent: false)
@@ -1221,7 +1221,7 @@ extension Libxml2 {
             let preNodes = splitChildren(before: range.location)
 
             if preNodes.count > 0 {
-                let newElement = ElementNode(name: name, attributes: attributes, children: preNodes, registerUndo: registerUndo)
+                let newElement = ElementNode(name: name, attributes: attributes, children: preNodes, editContext: editContext)
 
                 parent.insert(newElement, at: nodeIndex)
                 remove(preNodes, updateParent: false)
@@ -1476,7 +1476,7 @@ extension Libxml2 {
 
             guard newChildren.count > 0 else {
                 assertionFailure("Avoid calling this method with no nodes.")
-                return ElementNode(descriptor: elementDescriptor, registerUndo: registerUndo)
+                return ElementNode(descriptor: elementDescriptor, editContext: editContext)
             }
 
             guard let firstNodeIndex = children.index(of: newChildren[0]) else {
@@ -1525,7 +1525,7 @@ extension Libxml2 {
             if let result = result {
                 return result
             } else {
-                let newNode = ElementNode(descriptor: elementDescriptor, children: childrenToWrap, registerUndo: registerUndo)
+                let newNode = ElementNode(descriptor: elementDescriptor, children: childrenToWrap, editContext: editContext)
                 
                 children.insert(newNode, at: firstNodeIndex)
                 newNode.parent = self
@@ -1559,8 +1559,8 @@ extension Libxml2 {
         
         // MARK: - Initializers
 
-        init(children: [Node], registerUndo: @escaping UndoRegistrationClosure) {
-            super.init(name: type(of: self).name, attributes: [], children: children, registerUndo: registerUndo)
+        init(children: [Node], editContext: EditContext? = nil) {
+            super.init(name: type(of: self).name, attributes: [], children: children, editContext: editContext)
         }
     }
 }

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -10,19 +10,15 @@ extension Libxml2 {
     ///
     class DOMString {
         
-        typealias UndoRegistrationClosure = Node.UndoRegistrationClosure
-        
-        private lazy var registerUndo: Node.UndoRegistrationClosure = { (undoTask: @escaping () -> ()) -> () in
-            self.domUndoManager.registerUndo(withTarget: self, handler: { target in
-                undoTask()
-            })
-        }
+        private lazy var editContext: EditContext = {
+            return EditContext(undoManager: self.domUndoManager)
+        }()
         
         private lazy var rootNode: RootNode = {
             
-            let textNode = TextNode(text: "", registerUndo: self.registerUndo)
+            let textNode = TextNode(text: "", editContext: self.editContext)
             
-            return RootNode(children: [textNode], registerUndo: self.registerUndo)
+            return RootNode(children: [textNode], editContext: self.editContext)
         }()
         
         private var parentUndoManager: UndoManager?
@@ -98,7 +94,7 @@ extension Libxml2 {
         ///
         func setHTML(_ html: String, withDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) -> NSAttributedString {
             
-            let converter = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor, registerUndo: registerUndo)
+            let converter = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor, editContext: editContext)
             let output: (rootNode: RootNode, attributedString: NSAttributedString)
             
             do {

--- a/Aztec/Classes/Libxml2/EditContext.swift
+++ b/Aztec/Classes/Libxml2/EditContext.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Libxml2 {
+    /// The Edit Context class is useful for specifying whatever editing state needs to be shared
+    /// across the full DOM tree.
+    ///
+    class EditContext {
+        
+        // MARK: - Properties: Undo support
+        
+        let undoManager: UndoManager
+        
+        init(undoManager: UndoManager) {
+            self.undoManager = undoManager
+        }
+    }
+}

--- a/Aztec/Classes/Libxml2/UndoStack.swift
+++ b/Aztec/Classes/Libxml2/UndoStack.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-class UndoStack {
-    
-}

--- a/AztecTests/AztecVisualEditorTests.swift
+++ b/AztecTests/AztecVisualEditorTests.swift
@@ -216,10 +216,6 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.unorderedListFormattingSpansRange(range))
     }
 
-    func testInsertLink() {
-        // TODO
-    }
-
     // MARK: - Test Attributes Exist
 
     func testBoldSpansRange() {

--- a/AztecTests/Exporter/OutHTMLConverterTests.swift
+++ b/AztecTests/Exporter/OutHTMLConverterTests.swift
@@ -20,7 +20,7 @@ class OutHTMLConverterTests: XCTestCase {
     }
 
     func testSimpleNodeConversion() {
-        let inParser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
+        let inParser = Libxml2.In.HTMLConverter()
         let outParser = Libxml2.Out.HTMLConverter()
 
         let html = "<bold><i>Hello!</i></bold>"
@@ -36,7 +36,7 @@ class OutHTMLConverterTests: XCTestCase {
     }
 
     func testCommentNodeConversion() {
-        let inParser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
+        let inParser = Libxml2.In.HTMLConverter()
         let outParser = Libxml2.Out.HTMLConverter()
 
         let html = "<!--Hello Sample--><bold><i>Hello!</i></bold>"

--- a/AztecTests/Exporter/OutNodeConverterTests.swift
+++ b/AztecTests/Exporter/OutNodeConverterTests.swift
@@ -24,7 +24,7 @@ class OutNodeConverterTests: XCTestCase {
 
         let nodeName = "text"
         let nodeText = "This is the text."
-        let textNode = TextNode(text: nodeText, registerUndo: { _ in })
+        let textNode = TextNode(text: nodeText)
         let xmlNodePtr = Libxml2.Out.NodeConverter().convert(textNode)
         let xmlNode = xmlNodePtr.pointee
 
@@ -46,10 +46,10 @@ class OutNodeConverterTests: XCTestCase {
     func testElementAndChildElementNodeConversion() {
         
         let innerNodeName = "innerNode"
-        let innerNode = ElementNode(name: innerNodeName, attributes: [], children: [], registerUndo: { _ in })
+        let innerNode = ElementNode(name: innerNodeName, attributes: [], children: [])
         
         let outerNodeName = "element"
-        let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode], registerUndo: { _ in })
+        let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode])
         
         let xmlOuterNodePtr = Libxml2.Out.NodeConverter().convert(testNode)
         let xmlOuterNode = xmlOuterNodePtr.pointee
@@ -80,10 +80,10 @@ class OutNodeConverterTests: XCTestCase {
     func testElementAndChildTextNodeConversion() {
 
         let innerNodeText = "some text"
-        let innerNode = TextNode(text: innerNodeText, registerUndo: { _ in })
+        let innerNode = TextNode(text: innerNodeText)
 
         let outerNodeName = "element"
-        let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode], registerUndo: { _ in })
+        let testNode = ElementNode(name: outerNodeName, attributes: [], children: [innerNode])
 
         let xmlOuterNodePtr = Libxml2.Out.NodeConverter().convert(testNode)
         let xmlOuterNode = xmlOuterNodePtr.pointee

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -20,6 +20,43 @@ class ElementNodeTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
+    
+    // MARK: - Prepend
+    
+    /// Tests that `prepend(_ child:)` works.
+    ///
+    /// Inputs:
+    ///     - Original node contents: "Hello there!"
+    ///     - Range: (loc: 6, len: 6)
+    ///     - New string: "-"
+    ///
+    /// Verifications:
+    ///     - Check that the undo event is properly registered.
+    ///     - Check that after editing the text node, its content is: "Hello -"
+    ///     - Check that after undoing the text node edit, its content is: "Hello there!"
+    ///
+    func testPrepend() {
+        let text1 = "Hello"
+        let text2 = " world!"
+        let fullText = "\(text1)\(text2)"
+        
+        let textNode1 = TextNode(text: text1, registerUndo: { _ in })
+        let textNode2 = TextNode(text: text2, registerUndo: { _ in })
+        let boldNode = ElementNode(name: StandardElementType.b.rawValue, attributes: [], children: [textNode2], registerUndo: { _ in })
+        
+        XCTAssertEqual(boldNode.children.count, 1)
+        XCTAssertEqual(boldNode.children[0], textNode2)
+        XCTAssertEqual(boldNode.text(), text2)
+        
+        boldNode.prepend(textNode1)
+        
+        XCTAssertEqual(boldNode.children.count, 2)
+        XCTAssertEqual(boldNode.children[0], textNode1)
+        XCTAssertEqual(boldNode.children[1], textNode2)
+        XCTAssertEqual(boldNode.text(), fullText)
+    }
+    
+    // MARK: - Misc / Unorganized
 
     /// Whenever there's a single element node, make sure method `lowestElementNodeWrapping(range:)`
     /// returns the element node, as expected.
@@ -1563,7 +1600,7 @@ class ElementNodeTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    // MARK: - Bug fixes
+    // MARK: - Composite testing
 
     /// Test that inserting a new line after a DIV tag doesn't crash
     /// See https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/90

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -40,9 +40,9 @@ class ElementNodeTests: XCTestCase {
         let text2 = " world!"
         let fullText = "\(text1)\(text2)"
         
-        let textNode1 = TextNode(text: text1, registerUndo: { _ in })
-        let textNode2 = TextNode(text: text2, registerUndo: { _ in })
-        let boldNode = ElementNode(name: StandardElementType.b.rawValue, attributes: [], children: [textNode2], registerUndo: { _ in })
+        let textNode1 = TextNode(text: text1)
+        let textNode2 = TextNode(text: text2)
+        let boldNode = ElementNode(name: StandardElementType.b.rawValue, attributes: [], children: [textNode2])
         
         XCTAssertEqual(boldNode.children.count, 1)
         XCTAssertEqual(boldNode.children[0], textNode2)
@@ -62,11 +62,11 @@ class ElementNodeTests: XCTestCase {
     /// returns the element node, as expected.
     ///
     func testThatLowestElementNodeWrappingRangeWorksWithASingleElementNode() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here")
+        let text3 = TextNode(text: "text3 goes here")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: text1.length(), length: text2.length())
 
         let node = mainNode.lowestElementNodeWrapping(range)
@@ -77,13 +77,13 @@ class ElementNodeTests: XCTestCase {
     /// Whenever the range is inside a child node, make sure that child node is returned.
     ///
     func testThatLowestElementNodeWrappingRangeWorksWithAChildNode1() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here")
+        let text3 = TextNode(text: "text3 goes here")
 
-        let childNode = ElementNode(name: "em", attributes: [], children: [text2], registerUndo: { _ in })
+        let childNode = ElementNode(name: "em", attributes: [], children: [text2])
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3])
         let range = NSRange(location: text1.length(), length: text2.length())
 
         let node = mainNode.lowestElementNodeWrapping(range)
@@ -95,13 +95,13 @@ class ElementNodeTests: XCTestCase {
     /// returned instead.
     ///
     func testThatLowestElementNodeWrappingRangeWorksWithAChildNode2() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here")
+        let text3 = TextNode(text: "text3 goes here")
 
-        let childNode = ElementNode(name: "em", attributes: [], children: [text2], registerUndo: { _ in })
+        let childNode = ElementNode(name: "em", attributes: [], children: [text2])
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3])
         let range = NSRange(location: text1.length() - 1, length: text2.length() + 2)
 
         let node = mainNode.lowestElementNodeWrapping(range)
@@ -113,11 +113,11 @@ class ElementNodeTests: XCTestCase {
     /// returns the text node, as expected.
     ///
     func testThatLowestTextNodeWrappingRangeWorksWithASingleElementNode() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here")
+        let text3 = TextNode(text: "text3 goes here")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: text1.length(), length: text2.length())
 
         let node = mainNode.lowestTextNodeWrapping(range)
@@ -128,13 +128,13 @@ class ElementNodeTests: XCTestCase {
     /// Whenever the range is inside a child node, make sure that child node is returned.
     ///
     func testThatLowestTextNodeWrappingRangeWorksWithAChildNode1() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here")
+        let text3 = TextNode(text: "text3 goes here")
 
-        let childNode = ElementNode(name: "em", attributes: [], children: [text2], registerUndo: { _ in })
+        let childNode = ElementNode(name: "em", attributes: [], children: [text2])
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3])
         let range = NSRange(location: text1.length(), length: text2.length())
 
         let node = mainNode.lowestTextNodeWrapping(range)
@@ -146,13 +146,13 @@ class ElementNodeTests: XCTestCase {
     /// returned instead.
     ///
     func testThatLowestTextNodeWrappingRangeWorksWithAChildNode2() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here")
+        let text3 = TextNode(text: "text3 goes here")
 
-        let childNode = ElementNode(name: "em", attributes: [], children: [text2], registerUndo: { _ in })
+        let childNode = ElementNode(name: "em", attributes: [], children: [text2])
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, childNode, text3])
         let range = NSRange(location: text1.length() - 1, length: text2.length() + 2)
 
         let node = mainNode.lowestTextNodeWrapping(range)
@@ -171,11 +171,11 @@ class ElementNodeTests: XCTestCase {
     ///
     func testEnumerateBlockLowestElementsIntersectingRange() {
 
-        let textNode1 = TextNode(text: "Hello ", registerUndo: { _ in })
-        let textNode2 = TextNode(text: "world", registerUndo: { _ in })
-        let textNode3 = TextNode(text: "!", registerUndo: { _ in })
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
+        let textNode1 = TextNode(text: "Hello ")
+        let textNode2 = TextNode(text: "world")
+        let textNode3 = TextNode(text: "!")
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
 
         let range = NSRange(location: textNode1.length(), length: textNode2.length())
         let atLeastOneElementFound = expectation(description: "At least one elements should be returned in the enumeration.")
@@ -194,11 +194,11 @@ class ElementNodeTests: XCTestCase {
     }
     
     func testLeafNodesWrappingRange1() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here")
+        let text3 = TextNode(text: "text3 goes here")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: 0, length: mainNode.length())
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -214,11 +214,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange2() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here.")
+        let text3 = TextNode(text: "text3 goes here..")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: 0, length: mainNode.length() - 2)
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -234,11 +234,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange3() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here.")
+        let text3 = TextNode(text: "text3 goes here..")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: 1, length: mainNode.length() - 1)
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -254,11 +254,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange4() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here.")
+        let text3 = TextNode(text: "text3 goes here..")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: text1.length(), length: mainNode.length() - text1.length())
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -272,11 +272,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange5() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here.")
+        let text3 = TextNode(text: "text3 goes here..")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: 0, length: (mainNode.length() - 1) - text3.length())
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -290,11 +290,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange6() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here.")
+        let text3 = TextNode(text: "text3 goes here..")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: text1.length(), length: 0)
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -306,11 +306,11 @@ class ElementNodeTests: XCTestCase {
     }
 
     func testLeafNodesWrappingRange7() {
-        let text1 = TextNode(text: "text1 goes here", registerUndo: { _ in })
-        let text2 = TextNode(text: "text2 goes here.", registerUndo: { _ in })
-        let text3 = TextNode(text: "text3 goes here..", registerUndo: { _ in })
+        let text1 = TextNode(text: "text1 goes here")
+        let text2 = TextNode(text: "text2 goes here.")
+        let text3 = TextNode(text: "text3 goes here..")
 
-        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3], registerUndo: { _ in })
+        let mainNode = ElementNode(name: "p", attributes: [], children: [text1, text2, text3])
         let range = NSRange(location: text1.length() - 1, length: 0)
 
         let nodesAndRanges = mainNode.leafNodesWrapping(range)
@@ -335,9 +335,9 @@ class ElementNodeTests: XCTestCase {
         let text1 = "Hello"
         let text2 = " World!"
         
-        let textNode = TextNode(text: "\(text1)\(text2)", registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph], registerUndo: { _ in })
+        let textNode = TextNode(text: "\(text1)\(text2)")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
         
         let splitLocation = text1.characters.count
         
@@ -368,9 +368,9 @@ class ElementNodeTests: XCTestCase {
     func testSplitAtLocation2() {
         
         let text = "Hello World!"
-        let textNode = TextNode(text: text, registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph], registerUndo: { _ in })
+        let textNode = TextNode(text: text)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
         
         let splitLocation = 0
         
@@ -395,9 +395,9 @@ class ElementNodeTests: XCTestCase {
     func testSplitAtLocation3() {
         
         let text = "Hello World!"
-        let textNode = TextNode(text: text, registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph], registerUndo: { _ in })
+        let textNode = TextNode(text: text)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
         
         let splitLocation = text.characters.count
         
@@ -412,9 +412,9 @@ class ElementNodeTests: XCTestCase {
 
     func testSplitWithFullRange() {
 
-        let textNode = TextNode(text: "Some text goes here", registerUndo: { _ in })
-        let elemNode = ElementNode(name: "SomeNode", attributes: [], children: [textNode], registerUndo: { _ in })
-        let rootNode = RootNode(children: [elemNode], registerUndo: { _ in })
+        let textNode = TextNode(text: "Some text goes here")
+        let elemNode = ElementNode(name: "SomeNode", attributes: [], children: [textNode])
+        let rootNode = RootNode(children: [elemNode])
 
         let splitRange = NSRange(location: 0, length: textNode.length())
 
@@ -434,9 +434,9 @@ class ElementNodeTests: XCTestCase {
         let textPart2 = " text goes here"
         let fullText = "\(textPart1)\(textPart2)"
 
-        let textNode = TextNode(text: fullText, registerUndo: { _ in })
-        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode], registerUndo: { _ in })
-        let rootNode = RootNode(children: [elemNode], registerUndo: { _ in })
+        let textNode = TextNode(text: fullText)
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
+        let rootNode = RootNode(children: [elemNode])
 
         let splitRange = NSRange(location: 0, length: textPart1.characters.count)
 
@@ -481,9 +481,9 @@ class ElementNodeTests: XCTestCase {
         let textPart2 = " text goes here"
         let fullText = "\(textPart1)\(textPart2)"
 
-        let textNode = TextNode(text: fullText, registerUndo: { _ in })
-        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode], registerUndo: { _ in })
-        let rootNode = RootNode(children: [elemNode], registerUndo: { _ in })
+        let textNode = TextNode(text: fullText)
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
+        let rootNode = RootNode(children: [elemNode])
 
         let splitRange = NSRange(location: textPart1.characters.count, length: textPart2.characters.count)
 
@@ -530,9 +530,9 @@ class ElementNodeTests: XCTestCase {
         let textPart3 = "here"
         let fullText = "\(textPart1)\(textPart2)\(textPart3)"
 
-        let textNode = TextNode(text: fullText, registerUndo: { _ in })
-        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode], registerUndo: { _ in })
-        let rootNode = RootNode(children: [elemNode], registerUndo: { _ in })
+        let textNode = TextNode(text: fullText)
+        let elemNode = ElementNode(name: elemNodeName, attributes: [], children: [textNode])
+        let rootNode = RootNode(children: [elemNode])
 
         let splitRange = NSRange(location: textPart1.characters.count, length: textPart2.characters.count)
 
@@ -595,11 +595,11 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there"
 
-        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
-        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
 
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph])
 
         let results = div.lowestBlockLevelElements(intersectingRange: div.range())
 
@@ -626,12 +626,12 @@ class ElementNodeTests: XCTestCase {
         let textPart2 = "there"
         let textPart3 = " man!"
 
-        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
-        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
-        let textNode3 = TextNode(text: textPart3, registerUndo: { _ in })
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
+        let textNode3 = TextNode(text: textPart3)
 
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [textNode1, paragraph, textNode3])
 
         let results = div.lowestBlockLevelElements(intersectingRange: div.range())
 
@@ -661,11 +661,11 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there!"
 
-        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
-        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
 
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph, textNode2])
 
         let results = div.lowestBlockLevelElements(intersectingRange: div.range())
 
@@ -689,8 +689,8 @@ class ElementNodeTests: XCTestCase {
         let text1 = "Hello"
         let text2 = " there!"
         let fullText = "\(text1)\(text2)"
-        let textNode = TextNode(text: fullText, registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let textNode = TextNode(text: fullText)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
         
         let wrapRange = NSRange(location: 0, length: text1.characters.count)
         
@@ -723,8 +723,8 @@ class ElementNodeTests: XCTestCase {
     ///
     func testForceWrapChildren2() {
         let fullText = "Hello there!"
-        let textNode = TextNode(text: fullText, registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let textNode = TextNode(text: fullText)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
         
         let wrapRange = NSRange(location: 0, length: fullText.characters.count)
         
@@ -751,10 +751,10 @@ class ElementNodeTests: XCTestCase {
     func testForceWrapChildren3() {
         let text1 = "Hello"
         let text2 = " there!"
-        let textNode1 = TextNode(text: text1, registerUndo: { _ in })
-        let textNode2 = TextNode(text: text2, registerUndo: { _ in })
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode, textNode2], registerUndo: { _ in })
+        let textNode1 = TextNode(text: text1)
+        let textNode2 = TextNode(text: text2)
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode, textNode2])
 
         let wrapRange = NSRange(location: text1.characters.count, length: text2.characters.count)
         
@@ -787,11 +787,11 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there!"
 
-        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
-        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
 
-        let em = ElementNode(name: "em", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [em, textNode2], registerUndo: { _ in })
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
+        let div = ElementNode(name: "div", attributes: [], children: [em, textNode2])
 
         div.wrapChildren(intersectingRange: range, inElement: ElementNodeDescriptor(elementType: boldElementType))
 
@@ -829,12 +829,12 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there!"
 
-        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
-        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
 
-        let em = ElementNode(name: "em", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let underline = ElementNode(name: "u", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [em, underline], registerUndo: { _ in })
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
+        let underline = ElementNode(name: "u", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [em, underline])
 
         div.wrapChildren(intersectingRange: div.range(), inElement: ElementNodeDescriptor(name: boldNodeName))
 
@@ -872,12 +872,12 @@ class ElementNodeTests: XCTestCase {
         let textPart1 = "Hello "
         let textPart2 = "there!"
 
-        let textNode1 = TextNode(text: textPart1, registerUndo: { _ in })
-        let textNode2 = TextNode(text: textPart2, registerUndo: { _ in })
+        let textNode1 = TextNode(text: textPart1)
+        let textNode2 = TextNode(text: textPart2)
 
-        let em = ElementNode(name: "em", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let underline = ElementNode(name: "u", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [em, underline], registerUndo: { _ in })
+        let em = ElementNode(name: "em", attributes: [], children: [textNode1])
+        let underline = ElementNode(name: "u", attributes: [], children: [textNode2])
+        let div = ElementNode(name: "div", attributes: [], children: [em, underline])
 
         let range = NSRange(location: 2, length: 8)
 
@@ -916,9 +916,9 @@ class ElementNodeTests: XCTestCase {
     ///     - The output should match the input.
     ///
     func testWrapChildrenIntersectingRangeWithEquivalentNodeNames1() {
-        let textNode = TextNode(text: "Hello there", registerUndo: { _ in })
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode], registerUndo: { _ in })
-        let divNode = ElementNode(name: "div", attributes: [], children: [boldNode], registerUndo: { _ in })
+        let textNode = TextNode(text: "Hello there")
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode])
+        let divNode = ElementNode(name: "div", attributes: [], children: [boldNode])
         
         let range = NSRange(location: 0, length: 11)
         
@@ -948,13 +948,13 @@ class ElementNodeTests: XCTestCase {
     ///     - the range should be unchanged
     ///
     func testChildNodesIntersectingRange1() {
-        let textNode = TextNode(text: "This is a test string.", registerUndo: { _ in })
+        let textNode = TextNode(text: "This is a test string.")
         let rangeLocation = 5
         XCTAssert(rangeLocation < textNode.length(),
                   "For this text we need to make sure the range location is inside the test node.")
 
         let range = NSRange(location: rangeLocation, length: 0)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
 
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range)
 
@@ -978,13 +978,13 @@ class ElementNodeTests: XCTestCase {
     ///     - the range should be unchanged
     ///
     func testChildNodesIntersectingRange2() {
-        let textNode = TextNode(text: "This is a test string.", registerUndo: { _ in })
+        let textNode = TextNode(text: "This is a test string.")
         let rangeLocation = 0
         XCTAssert(rangeLocation < textNode.length(),
                   "For this text we need to make sure the range location is inside the test node.")
 
         let range = NSRange(location: rangeLocation, length: 0)
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
 
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range)
 
@@ -1009,8 +1009,8 @@ class ElementNodeTests: XCTestCase {
     ///
     func testChildNodesIntersectingRange3() {
 
-        let textNode1 = TextNode(text: "Hello", registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello again!", registerUndo: { _ in })
+        let textNode1 = TextNode(text: "Hello")
+        let textNode2 = TextNode(text: "Hello again!")
 
         let rangeLocation = 5
         XCTAssert(rangeLocation == textNode1.length(),
@@ -1018,9 +1018,9 @@ class ElementNodeTests: XCTestCase {
 
         let range = NSRange(location: rangeLocation, length: 0)
 
-        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2], registerUndo: { _ in })
+        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2])
 
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range, preferLeftNode: true)
 
@@ -1045,8 +1045,8 @@ class ElementNodeTests: XCTestCase {
     ///
     func testChildNodesIntersectingRange4() {
 
-        let textNode1 = TextNode(text: "Hello", registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello again!", registerUndo: { _ in })
+        let textNode1 = TextNode(text: "Hello")
+        let textNode2 = TextNode(text: "Hello again!")
 
         let rangeLocation = 5
         XCTAssert(rangeLocation == textNode1.length(),
@@ -1054,9 +1054,9 @@ class ElementNodeTests: XCTestCase {
 
         let range = NSRange(location: rangeLocation, length: 0)
 
-        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2], registerUndo: { _ in })
+        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2])
 
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range, preferLeftNode: false)
 
@@ -1079,11 +1079,11 @@ class ElementNodeTests: XCTestCase {
     ///     - Output should be: <p>---<b>Hello1</b><b>Hello2</b></p>
     ///
     func testInsertStringAt1() {
-        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
-        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2], registerUndo: { _ in })
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
         
         let textToInsert = "---"
         
@@ -1110,11 +1110,11 @@ class ElementNodeTests: XCTestCase {
     ///     - Output should be: <p><b>Hello1</b>---<b>Hello2</b></p>
     ///
     func testInsertStringAt2() {
-        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
-        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2], registerUndo: { _ in })
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
         
         let textToInsert = "---"
         
@@ -1141,11 +1141,11 @@ class ElementNodeTests: XCTestCase {
     ///     - Output should be: <p><b>Hello1</b><b>Hello2</b>---</p>
     ///
     func testInsertStringAt3() {
-        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
-        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1], registerUndo: { _ in })
-        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2], registerUndo: { _ in })
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let boldNode1 = ElementNode(name: "b", attributes: [], children: [textNode1])
+        let boldNode2 = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [boldNode1, boldNode2])
         
         let textToInsert = "---"
         
@@ -1176,11 +1176,11 @@ class ElementNodeTests: XCTestCase {
         
         let adjacentText = "Hello1"
         
-        let textNode1 = TextNode(text: adjacentText, registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
-        let textNode3 = TextNode(text: "Hello3", registerUndo: { _ in })
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
+        let textNode1 = TextNode(text: adjacentText)
+        let textNode2 = TextNode(text: "Hello2")
+        let textNode3 = TextNode(text: "Hello3")
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
         
         let textToInsert = "---"
         
@@ -1211,11 +1211,11 @@ class ElementNodeTests: XCTestCase {
         
         let adjacentText = "Hello1"
         
-        let textNode1 = TextNode(text: adjacentText, registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
-        let textNode3 = TextNode(text: "Hello3", registerUndo: { _ in })
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
+        let textNode1 = TextNode(text: adjacentText)
+        let textNode2 = TextNode(text: "Hello2")
+        let textNode3 = TextNode(text: "Hello3")
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
         
         let textToInsert = "---"
         
@@ -1246,11 +1246,11 @@ class ElementNodeTests: XCTestCase {
         
         let adjacentText = "Hello3"
         
-        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
-        let textNode3 = TextNode(text: adjacentText, registerUndo: { _ in })
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let textNode3 = TextNode(text: adjacentText)
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
         
         let textToInsert = "---"
         
@@ -1282,11 +1282,11 @@ class ElementNodeTests: XCTestCase {
         
         let adjacentText = "Hello3"
         
-        let textNode1 = TextNode(text: "Hello1", registerUndo: { _ in })
-        let textNode2 = TextNode(text: "Hello2", registerUndo: { _ in })
-        let textNode3 = TextNode(text: adjacentText, registerUndo: { _ in })
-        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3], registerUndo: { _ in })
+        let textNode1 = TextNode(text: "Hello1")
+        let textNode2 = TextNode(text: "Hello2")
+        let textNode3 = TextNode(text: adjacentText)
+        let boldNode = ElementNode(name: "b", attributes: [], children: [textNode2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode1, boldNode, textNode3])
         
         let textToInsert = "---"
         
@@ -1314,10 +1314,10 @@ class ElementNodeTests: XCTestCase {
     /// - Output: `<p>Click on this <a href="http://www.wordpress.com">link!</a></p>`
     ///
     func testReplaceCharactersInRangeWithString() {
-        let linkText = TextNode(text: "link", registerUndo: { _ in })
-        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText], registerUndo: { _ in })
-        let preLinkText = TextNode(text: "Click on this ", registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement], registerUndo: { _ in })
+        let linkText = TextNode(text: "link")
+        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText])
+        let preLinkText = TextNode(text: "Click on this ")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement])
         
         let range = NSRange(location: 14, length: 4)
         let newString = "link!"
@@ -1350,10 +1350,10 @@ class ElementNodeTests: XCTestCase {
     func testReplaceCharactersInRangeWithString2() {
         let text1 = "Click on this "
         let text2 = "link"
-        let linkText = TextNode(text: text2, registerUndo: { _ in })
-        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText], registerUndo: { _ in })
-        let preLinkText = TextNode(text: text1, registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement], registerUndo: { _ in })
+        let linkText = TextNode(text: text2)
+        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText])
+        let preLinkText = TextNode(text: text1)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement])
         
         let range = NSRange(location: 14, length: 4)
         let newString = "link!"
@@ -1383,11 +1383,11 @@ class ElementNodeTests: XCTestCase {
     func testReplaceCharactersInRangeWithString3() {
         let text1 = "Click on this "
         let text2 = "link"
-        let linkText = TextNode(text: text2, registerUndo: { _ in })
-        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText], registerUndo: { _ in })
-        let preLinkText = TextNode(text: text1, registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement], registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [paragraph], registerUndo: { _ in })
+        let linkText = TextNode(text: text2)
+        let linkElement = ElementNode(name: "a", attributes: [], children: [linkText])
+        let preLinkText = TextNode(text: text1)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [preLinkText, linkElement])
+        let div = ElementNode(name: "div", attributes: [], children: [paragraph])
         
         let range = NSRange(location: 14, length: 4)
         let newString = "link!"
@@ -1425,8 +1425,8 @@ class ElementNodeTests: XCTestCase {
         let startText = "Look at this photo:"
         let middleText = "image"
         let endText = ".It's amazing"
-        let paragraphText = TextNode(text: startText + middleText + endText, registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [paragraphText], registerUndo: { _ in })
+        let paragraphText = TextNode(text: startText + middleText + endText)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [paragraphText])
 
         let range = NSRange(location: startText.characters.count, length: middleText.characters.count)
         let imgSrc = "https://httpbin.org/image/jpeg"
@@ -1473,11 +1473,11 @@ class ElementNodeTests: XCTestCase {
     ///
     func testPushUpLeftSideDescendant() {
         
-        let text1 = TextNode(text: "Hello ", registerUndo: { _ in })
-        let text2 = TextNode(text: "there!", registerUndo: { _ in })
-        let bold = ElementNode(name: "b", attributes: [], children: [text1], registerUndo: { _ in })
-        let strike = ElementNode(name: "strike", attributes: [], children: [bold, text2], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [strike], registerUndo: { _ in })
+        let text1 = TextNode(text: "Hello ")
+        let text2 = TextNode(text: "there!")
+        let bold = ElementNode(name: "b", attributes: [], children: [text1])
+        let strike = ElementNode(name: "strike", attributes: [], children: [bold, text2])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [strike])
         
         let result = strike.pushUp(leftSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
@@ -1520,9 +1520,9 @@ class ElementNodeTests: XCTestCase {
     ///
     func testPushUpLeftSideDescendantWithNilResult() {
         
-        let text = TextNode(text: "Hello there!", registerUndo: { _ in })
-        let strike = ElementNode(name: "strike", attributes: [], children: [text], registerUndo: { _ in })
-        _ = ElementNode(name: "p", attributes: [], children: [strike], registerUndo: { _ in })
+        let text = TextNode(text: "Hello there!")
+        let strike = ElementNode(name: "strike", attributes: [], children: [text])
+        _ = ElementNode(name: "p", attributes: [], children: [strike])
         
         let result = strike.pushUp(leftSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
@@ -1543,11 +1543,11 @@ class ElementNodeTests: XCTestCase {
     ///
     func testPushUpRightSideDescendant() {
         
-        let text1 = TextNode(text: "Hello ", registerUndo: { _ in })
-        let text2 = TextNode(text: "there!", registerUndo: { _ in })
-        let bold = ElementNode(name: "b", attributes: [], children: [text2], registerUndo: { _ in })
-        let strike = ElementNode(name: "strike", attributes: [], children: [text1, bold], registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [strike], registerUndo: { _ in })
+        let text1 = TextNode(text: "Hello ")
+        let text2 = TextNode(text: "there!")
+        let bold = ElementNode(name: "b", attributes: [], children: [text2])
+        let strike = ElementNode(name: "strike", attributes: [], children: [text1, bold])
+        let paragraph = ElementNode(name: "p", attributes: [], children: [strike])
         
         let _ = strike.pushUp(rightSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
@@ -1589,9 +1589,9 @@ class ElementNodeTests: XCTestCase {
     ///
     func testPushUpRightSideDescendantWithNilResult() {
         
-        let text = TextNode(text: "Hello there!", registerUndo: { _ in })
-        let strike = ElementNode(name: "strike", attributes: [], children: [text], registerUndo: { _ in })
-        let _ = ElementNode(name: "p", attributes: [], children: [strike], registerUndo: { _ in })
+        let text = TextNode(text: "Hello there!")
+        let strike = ElementNode(name: "strike", attributes: [], children: [text])
+        let _ = ElementNode(name: "p", attributes: [], children: [strike])
         
         let result = strike.pushUp(rightSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
@@ -1614,10 +1614,10 @@ class ElementNodeTests: XCTestCase {
     func testInsertNewlineAfterDivShouldNotCrash() {
         let text1 = "This is a paragraph in a div"
         let text2 = "\nThis is some unwrapped text"
-        let divText = TextNode(text: text1, registerUndo: { _ in })
-        let div = ElementNode(name: "div", attributes: [], children: [divText], registerUndo: { _ in })
-        let unwrappedText = TextNode(text: text2, registerUndo: { _ in })
-        let rootNode = RootNode(children: [div, unwrappedText], registerUndo: { _ in })
+        let divText = TextNode(text: text1)
+        let div = ElementNode(name: "div", attributes: [], children: [divText])
+        let unwrappedText = TextNode(text: text2)
+        let rootNode = RootNode(children: [div, unwrappedText])
         let location = text1.characters.count
 
         rootNode.insert("\n", atLocation: location)

--- a/AztecTests/HTML/TextNodeTests.swift
+++ b/AztecTests/HTML/TextNodeTests.swift
@@ -3,9 +3,9 @@ import XCTest
 
 class TextNodeTests: XCTestCase {
     
+    typealias EditContext = Libxml2.EditContext
     typealias ElementNode = Libxml2.ElementNode
     typealias TextNode = Libxml2.TextNode
-    typealias UndoClosure = Libxml2.Node.UndoClosure
     
     // MARK: - Editing text nodes
     
@@ -22,8 +22,8 @@ class TextNodeTests: XCTestCase {
         let text1 = "Hello"
         let text2 = " World!"
 
-        let textNode = TextNode(text: "\(text1)\(text2)", registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let textNode = TextNode(text: "\(text1)\(text2)")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
         
         let splitLocation = text1.characters.count
         
@@ -52,8 +52,8 @@ class TextNodeTests: XCTestCase {
     ///     - No splitting should occur, the selected text node should match the whole string.
     ///
     func testSplitAtLocation2() {
-        let textNode = TextNode(text: "Hello World!", registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let textNode = TextNode(text: "Hello World!")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
         
         let splitLocation = 0
         
@@ -72,8 +72,8 @@ class TextNodeTests: XCTestCase {
     ///     - No splitting should occur, the selected text node should match the whole string.
     ///
     func testSplitAtLocation3() {
-        let textNode = TextNode(text: "Hello World!", registerUndo: { _ in })
-        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode], registerUndo: { _ in })
+        let textNode = TextNode(text: "Hello World!")
+        let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
         
         let splitLocation = textNode.length()
         
@@ -99,21 +99,15 @@ class TextNodeTests: XCTestCase {
     func testThatAppendIsUndoable1() {
         
         let textToAppend = "Hello there!"
-        var undoClosure: UndoClosure? = nil
         
-        let textNode = TextNode(text: "") { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
+        let textNode = TextNode(text: "", editContext: editContext)
         
         textNode.append(textToAppend)
         XCTAssertEqual(textNode.text(), textToAppend)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), "")
     }
     
@@ -133,21 +127,15 @@ class TextNodeTests: XCTestCase {
         let text2 = " there!"
         let fullText = "\(text1)\(text2)"
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: text1) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: text1, editContext: editContext)
         
         textNode.append(text2)
         XCTAssertEqual(textNode.text(), fullText)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), text1)
     }
     
@@ -168,21 +156,15 @@ class TextNodeTests: XCTestCase {
         let fullText = "\(text1)\(text2)"
         let range = NSRange(location: 0, length: text1.characters.count)
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: fullText) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: fullText, editContext: editContext)
         
         textNode.deleteCharacters(inRange: range)
         XCTAssertEqual(textNode.text(), text2)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), fullText)
     }
     
@@ -203,21 +185,15 @@ class TextNodeTests: XCTestCase {
         let fullText = "\(text1)\(text2)"
         let range = NSRange(location: text1.characters.count, length: text2.characters.count)
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: fullText) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: fullText, editContext: editContext)
         
         textNode.deleteCharacters(inRange: range)
         XCTAssertEqual(textNode.text(), text1)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), fullText)
     }
     
@@ -235,21 +211,16 @@ class TextNodeTests: XCTestCase {
     func testThatPrependIsUndoable1() {
         
         let textToPrepend = "Hello there!"
-        var undoClosure: UndoClosure? = nil
         
-        let textNode = TextNode(text: "") { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
+        
+        let textNode = TextNode(text: "", editContext: editContext)
         
         textNode.prepend(textToPrepend)
         XCTAssertEqual(textNode.text(), textToPrepend)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), "")
     }
     
@@ -270,21 +241,15 @@ class TextNodeTests: XCTestCase {
         let text2 = "Hello"
         let fullText = "\(text2)\(text1)"
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: text1) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: text1, editContext: editContext)
         
         textNode.prepend(text2)
         XCTAssertEqual(textNode.text(), fullText)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), text1)
     }
     
@@ -311,21 +276,15 @@ class TextNodeTests: XCTestCase {
         let newText = "-"
         let newFullText = "\(text1)\(newText)\(text3)"
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: fullText) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: fullText, editContext: editContext)
         
         textNode.replaceCharacters(inRange: range, withString: newText, inheritStyle: false)
         XCTAssertEqual(textNode.text(), newFullText)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), fullText)
     }
     
@@ -352,21 +311,15 @@ class TextNodeTests: XCTestCase {
         let newText = "-"
         let newFullText = "\(newText)\(text2)\(text3)"
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: fullText) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: fullText, editContext: editContext)
         
         textNode.replaceCharacters(inRange: range, withString: newText, inheritStyle: false)
         XCTAssertEqual(textNode.text(), newFullText)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), fullText)
     }
     
@@ -393,21 +346,15 @@ class TextNodeTests: XCTestCase {
         let newText = "-"
         let newFullText = "\(text1)\(text2)\(newText)"
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: fullText) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: fullText, editContext: editContext)
         
         textNode.replaceCharacters(inRange: range, withString: newText, inheritStyle: false)
         XCTAssertEqual(textNode.text(), newFullText)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), fullText)
     }
     
@@ -433,21 +380,15 @@ class TextNodeTests: XCTestCase {
         
         let newText = "-"
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: fullText) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: fullText, editContext: editContext)
         
         textNode.replaceCharacters(inRange: range, withString: newText, inheritStyle: false)
         XCTAssertEqual(textNode.text(), newText)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), fullText)
     }
     
@@ -473,21 +414,15 @@ class TextNodeTests: XCTestCase {
         
         let newText = ""
         
-        var undoClosure: UndoClosure? = nil
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
         
-        let textNode = TextNode(text: fullText) { anUndoClosure in
-            undoClosure = anUndoClosure
-        }
+        let textNode = TextNode(text: fullText, editContext: editContext)
         
         textNode.replaceCharacters(inRange: range, withString: newText, inheritStyle: false)
         XCTAssertEqual(textNode.text(), newText)
         
-        guard let theUndoClosure = undoClosure else {
-            XCTAssertNotNil(undoClosure)
-            return
-        }
-        
-        theUndoClosure()
+        undoManager.undo()
         XCTAssertEqual(textNode.text(), fullText)
     }
 }

--- a/AztecTests/Importer/HTMLToAttributedStringTests.swift
+++ b/AztecTests/Importer/HTMLToAttributedStringTests.swift
@@ -26,7 +26,7 @@ class HTMLToAttributedStringTests: XCTestCase {
         let tagNames = ["bold", "italic", "customTag", "div", "p", "a"]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
 
             let nodeText = "Hello"
             let html = "<\(tagName)>\(nodeText)</\(tagName)>"
@@ -70,7 +70,7 @@ class HTMLToAttributedStringTests: XCTestCase {
         let tagNames = ["bold", "italic", "customTag", "div", "p", "a"]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
 
             let firstText = "Hello "
             let secondText = "world"
@@ -123,7 +123,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
 
             let text = "Hello"
             let html = "<\(tagName.0)><\(tagName.1)>\(text)</\(tagName.1)></\(tagName.0)>"
@@ -181,7 +181,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
 
             let firstText = "Hello "
             let secondText = "world"
@@ -260,7 +260,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold", "italic")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor, registerUndo: { _ in })
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
 
             let firstText = "Hello "
             let secondText = "world"

--- a/AztecTests/Importer/InHTMLConverterTests.swift
+++ b/AztecTests/Importer/InHTMLConverterTests.swift
@@ -20,7 +20,7 @@ class InHTMLConverterTests: XCTestCase {
     }
 
     func testSimpleHTMLConversion() {
-        let parser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
+        let parser = Libxml2.In.HTMLConverter()
 
         let html = "<bold>Hello!</bold>"
 
@@ -49,7 +49,7 @@ class InHTMLConverterTests: XCTestCase {
     }
 
     func testComplexHTMLConversion() {
-        let parser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
+        let parser = Libxml2.In.HTMLConverter()
 
         let html = "<div styLe='a' nostyle peace='123'>Hello <b>World</b>!</div>"
 
@@ -101,7 +101,7 @@ class InHTMLConverterTests: XCTestCase {
     }
 
     func testNonASCIIConversion() {
-        let parser = Libxml2.In.HTMLConverter(registerUndo: { _ in })
+        let parser = Libxml2.In.HTMLConverter()
 
         let html = "Otro año más"
 

--- a/AztecTests/Importer/InNodeConverterTests.swift
+++ b/AztecTests/Importer/InNodeConverterTests.swift
@@ -31,7 +31,7 @@ class InNodeConverterTests: XCTestCase {
             return
         }
         
-        let outNode = Libxml2.In.NodeConverter(registerUndo: { _ in }).convert(node.pointee)
+        let outNode = Libxml2.In.NodeConverter().convert(node.pointee)
         xmlFreeNode(node)
 
         guard let elementNode = outNode as? ElementNode else {
@@ -56,7 +56,7 @@ class InNodeConverterTests: XCTestCase {
             return
         }
         
-        let converter = Libxml2.In.NodeConverter(registerUndo: { _ in })
+        let converter = Libxml2.In.NodeConverter()
         let outNode = converter.convert(node.pointee)
         xmlFreeNode(node)
 
@@ -84,7 +84,7 @@ class InNodeConverterTests: XCTestCase {
 
         xmlAddChild(parentNode, childNode)
 
-        let converter = Libxml2.In.NodeConverter(registerUndo: { _ in })
+        let converter = Libxml2.In.NodeConverter()
         let outParentNode = converter.convert(parentNode.pointee)
 
         xmlFreeNode(parentNode) // frees all children


### PR DESCRIPTION
<h3>Details</h3>

This PR introduces several small improvements to undo / redo.

Improvements:
- We're no longer passing around a closure, but an `EditContext` object which provides access to the undo manager.  This is better because we now have access, from almost anywhere, to the methods [`enableUndoRegistration()`](enableUndoRegistration) and [`disableUndoRegistration()`](https://developer.apple.com/reference/foundation/undomanager/1412239-disableundoregistration).
- I'm expecting the edit context will contain more state information eventually.  If it turns out it doesn't, we can reconsider the architecture.

<h3>Testing</h3>

**Test:**

- Make sure there are no big crashes caused by this PR by randomly testing the editor.
- Not all operations support undo operations, so testing in the editor may be tricky.  For now I suggest to just run the unit tests and take them as an indication that the implemented undo operations are working fine.
