### PR TITLE
Blockquotes changes update DOM

### DIFF
--- a/Aztec/Classes/Extensions/NSRange+Helpers.swift
+++ b/Aztec/Classes/Extensions/NSRange+Helpers.swift
@@ -5,6 +5,17 @@ import Foundation
 //
 extension NSRange
 {
+    /// Checks if the receiver contains the specified range.
+    ///
+    /// - Parameters:
+    ///     - range: the range that the receiver may or may not contain.
+    ///
+    /// - Returns: `true` if the receiver contains the specified range, `false` otherwise.
+    ///
+    func contains(range: NSRange) -> Bool {
+        return intersect(withRange: range) == range
+    }
+    
     /// Returns the intersection between the receiver and the specified range.
     ///
     /// - Important: the main difference with NSIntersectionRange is that this method considers any contact (even a

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1436,7 +1436,7 @@ extension Libxml2 {
         ///
         fileprivate func forceWrapChildren(intersectingRange targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
             
-            assert(range().intersect(withRange: targetRange) == targetRange)
+            assert(range().contains(range: targetRange))
             
             let childNodesAndRanges = childNodes(intersectingRange: targetRange)
             

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1435,9 +1435,18 @@ extension Libxml2 {
         ///     - elementDescriptor: the descriptor for the element to wrap the range in.
         ///
         fileprivate func forceWrapChildren(intersectingRange targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
-                
+            
+            assert(range().intersect(withRange: targetRange) == targetRange)
+            
             let childNodesAndRanges = childNodes(intersectingRange: targetRange)
-            assert(childNodesAndRanges.count > 0)
+            
+            guard childNodesAndRanges.count > 0 else {
+                // It's possible the range may not intersect any child node, if this node is adding
+                // any special characters for formatting purposes in visual mode.  For instance some
+                // nodes add a `\n` character at their end.
+                //
+                return
+            }
             
             let firstChild = childNodesAndRanges[0].child
             let firstChildIntersection = childNodesAndRanges[0].intersection

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -283,6 +283,8 @@ extension Libxml2 {
                     applyStyle(strikethroughValue: value, to: range)
                 case NSUnderlineStyleAttributeName:
                     applyStyle(underlineValue: value, to: range)
+                case NSParagraphStyleAttributeName:
+                    applyStyle(paragraphStyle: value, to:range)
                 default:
                     break
                 }
@@ -471,6 +473,20 @@ extension Libxml2 {
             default:
                 // We don't support anything more than single-line underline for now
                 break
+            }
+        }
+
+        fileprivate func applyStyle(paragraphStyle value: Any, to range: NSRange) {
+            guard let paragraphStyle = value as? ParagraphStyle else {
+                // if the value is not a Aztec ParagraphStyle we ignore it
+                return
+            }
+            applyStyle(paragraphStyle: paragraphStyle, to: range)
+        }
+
+        fileprivate func applyStyle(paragraphStyle: ParagraphStyle, to range: NSRange) {
+            if paragraphStyle.blockquote != nil {
+                applyElement(.blockquote, spanning: range)
             }
         }
         

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -559,6 +559,17 @@ extension Libxml2 {
                 self?.removeUnderlineSynchronously(spanning: range)
             }
         }
+
+        /// Disables blockquote from the specified range.
+        ///
+        /// - Parameters:
+        ///     - range: the range to remove the style from.
+        ///
+        func removeBlockquote(spanning range: NSRange) {
+            performAsyncUndoable { [weak self] in
+                self?.removeBlockquoteSynchronously(spanning: range)
+            }
+        }
         
         // MARK: - Remove Styles: Synchronously
         
@@ -576,6 +587,10 @@ extension Libxml2 {
         
         private func removeUnderlineSynchronously(spanning range: NSRange) {
             rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.u.equivalentNames)
+        }
+
+        private func removeBlockquoteSynchronously(spanning range: NSRange) {
+            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.blockquote.equivalentNames)
         }
         
         // Apply Styles

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -271,6 +271,21 @@ open class TextStorage: NSTextStorage {
         toggleAttribute(NSUnderlineStyleAttributeName, value: NSUnderlineStyle.styleSingle.rawValue as AnyObject, range: range)
     }
 
+
+    /// Toggles blockquotes for the specified range.
+    ///
+    /// - Parameter range: the range to toggle the style of.
+    /// - Returns: the range that was applied to.
+    func toggleBlockquote(_ range: NSRange) -> NSRange? {
+        let formatter = BlockquoteFormatter()
+        let applicationRange = formatter.applicationRange(for: range, in: self)
+        let newSelectedRange = formatter.toggle(in: self, at: range)
+        if !formatter.present(in: self, at: range.location) {
+            dom.removeBlockquote(spanning: applicationRange)
+        }
+        return newSelectedRange
+    }
+
     func setLink(_ url: URL, forRange range: NSRange) {
         var effectiveRange = range
         if attribute(NSLinkAttributeName, at: range.location, effectiveRange: &effectiveRange) != nil {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -628,9 +628,8 @@ open class TextView: UITextView {
     /// - Parameters:
     ///     - range: The NSRange to edit.
     ///
-    open func toggleBlockquote(range: NSRange) {
-        let formatter = BlockquoteFormatter()
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
+    open func toggleBlockquote(range: NSRange) {        
+        let newSelectedRange = storage.toggleBlockquote(range)
         selectedRange = newSelectedRange ?? selectedRange
         forceRedrawCursorAfterDelay()
     }


### PR DESCRIPTION
Changes made to block quotes update the DOM structure.

@diegoreymendez this is a first stab on updating the DOM when applying block quotes, this is still not final but I would like to have some feedback from you of the changes I made.

My main questions are:

 - Should we move the formatters inside the TextStorage class instead of having on the view.
 - I'm not very happy with the way we are removing elements from the DOM, you have some comments around about using TextStorage.setAttributes: 
     

> We should be calculating what attributes to remove in 
>     `TextStorage.setAttributes()` but since that may take a while to implement, we need this workaround until it's ready.

What was your idea there?
