### PR TITLE
Undo support for removing child nodes.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -766,6 +766,7 @@ extension Libxml2 {
                 return
             }
 
+            registerUndoForRemove(child)
             children.remove(at: index)
 
             if updateParent {
@@ -1531,6 +1532,24 @@ extension Libxml2 {
                 newNode.parent = self
                 
                 return newNode
+            }
+        }
+        
+        // MARK: - Undo Support
+        
+        private func registerUndoForRemove(_ child: Node) {
+            
+            guard let editContext = editContext else {
+                return
+            }
+            
+            guard let index = children.index(of: child) else {
+                assertionFailure("The specified node is not one of this node's children.")
+                return
+            }
+            
+            editContext.undoManager.registerUndo(withTarget: self) { [weak self] target in
+                self?.children.insert(child, at: index)
             }
         }
     }

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -782,17 +782,9 @@ extension Libxml2 {
         ///             If not specified, the parent is updated.
         ///
         func remove(_ children: [Node], updateParent: Bool = true) {
-
-            self.children = self.children.filter({ child -> Bool in
-
-                let removeChild = children.contains(child)
-
-                if removeChild && updateParent {
-                    child.parent = nil
-                }
-
-                return !removeChild
-            })
+            for child in children {
+                remove(child, updateParent: updateParent)
+            }
         }
 
         /// Retrieves all child nodes positioned after a specified location.
@@ -1186,7 +1178,6 @@ extension Libxml2 {
                 let newElement = ElementNode(name: name, attributes: attributes, children: postNodes, editContext: editContext)
                 
                 parent.insert(newElement, at: nodeIndex + 1)
-                remove(postNodes, updateParent: false)
             }
         }
 
@@ -1216,7 +1207,6 @@ extension Libxml2 {
                 let newElement = ElementNode(name: name, attributes: attributes, children: postNodes, editContext: editContext)
 
                 parent.insert(newElement, at: nodeIndex + 1)
-                remove(postNodes, updateParent: false)
             }
 
             let preNodes = splitChildren(before: range.location)
@@ -1225,7 +1215,6 @@ extension Libxml2 {
                 let newElement = ElementNode(name: name, attributes: attributes, children: preNodes, editContext: editContext)
 
                 parent.insert(newElement, at: nodeIndex)
-                remove(preNodes, updateParent: false)
             }
         }
 

--- a/Aztec/Classes/Libxml2/DOM/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Node.swift
@@ -150,10 +150,7 @@ extension Libxml2 {
         /// Removes this node from its parent, if it has one.
         ///
         func removeFromParent() {
-            if let theParent = parent {
-                theParent.remove(self)
-                parent = nil
-            }
+            parent?.remove(self)
         }
         
         /// Wraps this node in a new node with the specified name.  Also takes care of updating

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1670,4 +1670,57 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(textNode1.parent, paragraph)
         XCTAssertEqual(boldNode.parent, paragraph)
     }
+    
+    
+    /// Test that removing a children can be undone perfectly.
+    ///
+    /// Input:
+    /// - HTML: `<p>Hello <b>world!</b><em>How are you?</em></p>`
+    /// - Children to remove: the bold and em tags
+    ///
+    /// Expected results:
+    /// - After undoing the operation, the whole DOM shoud be back to normal.
+    ///
+    func testUndoRemoveChildren() {
+        
+        let undoManager = UndoManager()
+        let editContext = EditContext(undoManager: undoManager)
+        
+        undoManager.disableUndoRegistration()
+        
+        let textNode1 = TextNode(text: "Hello ", editContext: editContext)
+        let textNode2 = TextNode(text: "world!", editContext: editContext)
+        let textNode3 = TextNode(text: "How are you?", editContext: editContext)
+        let boldNode = ElementNode(name: StandardElementType.b.rawValue, attributes: [], children: [textNode2], editContext: editContext)
+        let emNode = ElementNode(name: StandardElementType.em.rawValue, attributes: [], children: [textNode3], editContext: editContext)
+        let paragraph = ElementNode(name: StandardElementType.p.rawValue, attributes: [], children: [textNode1, boldNode, emNode], editContext: editContext)
+        
+        undoManager.enableUndoRegistration()
+        
+        XCTAssertEqual(paragraph.children.count, 3)
+        XCTAssertEqual(paragraph.children[0], textNode1)
+        XCTAssertEqual(paragraph.children[1], boldNode)
+        XCTAssertEqual(paragraph.children[2], emNode)
+        XCTAssertEqual(textNode1.parent, paragraph)
+        XCTAssertEqual(boldNode.parent, paragraph)
+        XCTAssertEqual(emNode.parent, paragraph)
+        
+        paragraph.remove([boldNode, emNode])
+        
+        XCTAssertEqual(paragraph.children.count, 1)
+        XCTAssertEqual(paragraph.children[0], textNode1)
+        XCTAssertEqual(textNode1.parent, paragraph)
+        XCTAssertNil(boldNode.parent)
+        XCTAssertNil(emNode.parent)
+        
+        undoManager.undo()
+        
+        XCTAssertEqual(paragraph.children.count, 3)
+        XCTAssertEqual(paragraph.children[0], textNode1)
+        XCTAssertEqual(paragraph.children[1], boldNode)
+        XCTAssertEqual(paragraph.children[2], emNode)
+        XCTAssertEqual(textNode1.parent, paragraph)
+        XCTAssertEqual(boldNode.parent, paragraph)
+        XCTAssertEqual(emNode.parent, paragraph)
+    }
 }


### PR DESCRIPTION
Adds support for undoing child removal.

**How to test:**

Unfortunately testing this straight in the editor is prone to errors.  So the best way to make sure this works as expected is to review the provided unit test and make sure the logic is correct.