### PR TITLE
Formatters: Updating Newline Handling

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -640,8 +640,7 @@ open class TextView: UITextView {
             return
         }
 
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
-        selectedRange = newSelectedRange ?? selectedRange
+        toggleBlockquote(range: range)
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -699,7 +699,7 @@ open class TextView: UITextView {
     /// This method was meant as a workaround for Issue #144.
     ///
     func forceRedrawCursorIfNeeded(afterEditing text: String) {
-        guard text == "\n" else {
+        guard text == StringConstants.newline else {
             return
         }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -137,7 +137,9 @@ open class TextView: UITextView {
         // text insertion to happen. Thus, we won't call super.insertText.
         // But because we don't call the super we need to refresh the attributes ourselfs, and callback to the delegate.
         if removeParagraphAttributesIfNeeded(insertedText: text, at: selectedRange) {
-            typingAttributes = textStorage.attributes(at: selectedRange.location, effectiveRange: nil)
+            if (self.textStorage.length > 0) {
+                typingAttributes = textStorage.attributes(at: min(selectedRange.location, textStorage.length-1), effectiveRange: nil)
+            }
             self.delegate?.textViewDidChangeSelection?(self)
             return
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -614,7 +614,20 @@ open class TextView: UITextView {
         toggleBlockquote(range: range)
     }
 
+
+    /// Indicates whether ParagraphStyles should be removed, when inserting the specified string, at a given location,
+    /// or not. Note that we should remove Paragraph Styles whenever:
     ///
+    /// -   The previous string contains just a newline
+    /// -   The next string is a newline (or we're at the end of the text storage)
+    /// -   We're at the beginning of a new line
+    /// -   The user just typed a new line
+    ///
+    /// - Parameters:
+    ///     - insertedText: String that was just inserted
+    ///     - at: Location in which the string was just inserted
+    ///
+    /// - Returns: True if we should remove the paragraph attributes. False otherwise!
     ///
     private func shouldRemoveParagraphAttributes(insertedText text: String, at location: Int) -> Bool {
         guard text == StringConstants.newline else {
@@ -636,6 +649,7 @@ open class TextView: UITextView {
 
         return beforeString == StringConstants.newline && afterString == StringConstants.newline && storage.isStartOfNewLine(atLocation: location)
     }
+
 
     /// This helper will proceed to remove the Paragraph attributes, in a given string, at the specified range,
     /// if needed (please, check `shouldRemoveParagraphAttributes` to learn the conditions that would trigger this!).

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1111,7 +1111,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute exists at the specified index.
     ///
     open func formattingAtIndexContainsOrderedList(_ index: Int) -> Bool {
-        return storage.textListAttribute(atIndex: index)?.style == .ordered
+        let formatter = TextListFormatter(style: .ordered)
+        return formatter.present(in: textStorage, at: index)
     }
 
 
@@ -1123,7 +1124,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute exists at the specified index.
     ///
     open func formattingAtIndexContainsUnorderedList(_ index: Int) -> Bool {
-        return storage.textListAttribute(atIndex: index)?.style == .unordered
+        let formatter = TextListFormatter(style: .unordered)
+        return formatter.present(in: textStorage, at: index)
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -572,26 +572,16 @@ open class TextView: UITextView {
     ///
     private func refreshListAfterDeletion(of deletedText: NSAttributedString, at range: NSRange) {
         guard let textList = deletedText.textListAttribute(atIndex: 0),
-              deletedText.string == "\n" || range.location == 0 else {
+              deletedText.string == StringConstants.newline && range.location == 0 else {
             return
         }
 
-        if (range.location == 0) {
-            remove(list: textList, at: range)
+        switch textList.style {
+        case .ordered:
+            toggleOrderedList(range: range)
+        case .unordered:
+            toggleUnorderedList(range: range)
         }
-    }
-
-
-    /// Removes the TextList of the specified format, at a given range.
-    ///
-    /// - Parameters:
-    ///     - list: The list to be removed.
-    ///     - range: Range of the list to be removed.
-    ///
-    fileprivate func remove(list: TextList, at range: NSRange) {
-        let formatter = TextListFormatter(style: list.style, placeholderAttributes: typingAttributes)
-        let newSelectedRange = formatter.toggle(in: textStorage, at: range)
-        selectedRange = newSelectedRange ?? selectedRange
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -542,6 +542,9 @@ open class TextView: UITextView {
             return
         }
 
+        // Proceed to remove the list
+        // TODO: We should have explicit methods to Remove a TextList format, rather than just calling Toggle
+        //
         switch textList.style {
         case .ordered:
             toggleOrderedList(range: range)
@@ -605,6 +608,9 @@ open class TextView: UITextView {
             return
         }
 
+        // Remove the Blockquote.
+        // TODO: We should have explicit methods to Remove a Blockquote format, rather than just calling Toggle
+        //
         toggleBlockquote(range: range)
     }
 
@@ -631,7 +637,14 @@ open class TextView: UITextView {
         return beforeString == StringConstants.newline && afterString == StringConstants.newline && storage.isStartOfNewLine(atLocation: location)
     }
 
+    /// This helper will proceed to remove the Paragraph attributes, in a given string, at the specified range,
+    /// if needed (please, check `shouldRemoveParagraphAttributes` to learn the conditions that would trigger this!).
     ///
+    /// - Parameters:
+    ///     - insertedText: String that just got inserted.
+    ///     - at: Range in which the string was inserted.
+    ///
+    /// - Returns: True if ParagraphAttributes were removed. False otherwise!
     ///
     func removeParagraphAttributesIfNeeded(insertedText text: String, at range: NSRange) -> Bool {
         guard shouldRemoveParagraphAttributes(insertedText: text, at: range.location) else {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -134,9 +134,11 @@ open class TextView: UITextView {
     open override func insertText(_ text: String) {
         // Note:
         // Whenever the entered text causes the Paragraph Attributes to be removed, we should prevent the actual
-        // text insertion to happen. Thus, we won't call super.insertText, capicci?
-        //
+        // text insertion to happen. Thus, we won't call super.insertText.
+        // But because we don't call the super we need to refresh the attributes ourselfs, and callback to the delegate.
         if removeParagraphAttributesIfNeeded(insertedText: text, at: selectedRange) {
+            typingAttributes = textStorage.attributes(at: selectedRange.location, effectiveRange: nil)
+            self.delegate?.textViewDidChangeSelection?(self)
             return
         }
 


### PR DESCRIPTION
### Details:
In this PR we're updating the mechanism that handles `newline's` (as they are typed by the user!).

Closes #206 
Closes #207 

### Scenario: Extra New Line
1. Launch the Empty Editor Demo
2. Press the `Blockquote` / `List` format bar action
3. Press **Return** twice
4. Verify that the Blockquote / List gets closed. 

Note that there's no new line below the cursor. (#207 should be fixed!).

### Scenario: Extra New Item
1. Launch the Empty Editor Demo
2. Hit the **Numbered List** Format Bar Action
3. Hit **Return** times *four*
4. Again, press the **Numbered List** action

Verify that a single new item shows up, and that there's no extra new items below the cursor (#206 should be fixed!).

--

Needs Review: @SergioEstevao @diegoreymendez 
Gentlemen, i know you're gonna be refactoring how newlines are being handled. If possible, i'd super appreciate if you took a look at this PR.

Not sure if it's gonna be useful, or not, just wanna make sure it does not get lost.

Feel free to delete the branch / discard if needed.

Thanks in advance!
**Hug hug**