### PR TITLE
Implement bold italic with formatters

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */; };
 		FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */; };
 		FFD436961E300EF800A0E26F /* FontFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD436951E300EF700A0E26F /* FontFormatter.swift */; };
+		FFD436981E3180A500A0E26F /* FontFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD436971E3180A500A0E26F /* FontFormatterTests.swift */; };
 		FFF585CF1DB6398E00299B93 /* StandardElementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF585CE1DB6398E00299B93 /* StandardElementType.swift */; };
 /* End PBXBuildFile section */
 
@@ -185,6 +186,7 @@
 		FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Archive.swift"; sourceTree = "<group>"; };
 		FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutManager+Attachments.swift"; sourceTree = "<group>"; };
 		FFD436951E300EF700A0E26F /* FontFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontFormatter.swift; sourceTree = "<group>"; };
+		FFD436971E3180A500A0E26F /* FontFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontFormatterTests.swift; sourceTree = "<group>"; };
 		FFF585CE1DB6398E00299B93 /* StandardElementType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardElementType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -481,6 +483,7 @@
 			children = (
 				B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */,
 				E11B775F1DBA14B40024E455 /* BlockquoteFormatterTests.swift */,
+				FFD436971E3180A500A0E26F /* FontFormatterTests.swift */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -699,6 +702,7 @@
 				599F25941D8BDCFC002871D6 /* TextStorageTests.swift in Sources */,
 				59FEA0741D8BDFA700D138DF /* ElementNodeTests.swift in Sources */,
 				B5BC4FF21DA2D17000614582 /* NSAttributedStringListsTests.swift in Sources */,
+				FFD436981E3180A500A0E26F /* FontFormatterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		FFA61E891DF18F3D00B71BF6 /* ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */; };
 		FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */; };
 		FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */; };
+		FFD436961E300EF800A0E26F /* FontFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD436951E300EF700A0E26F /* FontFormatter.swift */; };
 		FFF585CF1DB6398E00299B93 /* StandardElementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF585CE1DB6398E00299B93 /* StandardElementType.swift */; };
 /* End PBXBuildFile section */
 
@@ -183,6 +184,7 @@
 		FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParagraphStyle.swift; sourceTree = "<group>"; };
 		FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Archive.swift"; sourceTree = "<group>"; };
 		FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutManager+Attachments.swift"; sourceTree = "<group>"; };
+		FFD436951E300EF700A0E26F /* FontFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontFormatter.swift; sourceTree = "<group>"; };
 		FFF585CE1DB6398E00299B93 /* StandardElementType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardElementType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -469,6 +471,7 @@
 				E1C163A41DB6056B00E66A83 /* BlockquoteFormatter.swift */,
 				B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */,
 				E11B77631DBA6ADC0024E455 /* AttributeFormatter.swift */,
+				FFD436951E300EF700A0E26F /* FontFormatter.swift */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				F15C9B881DD58D8B00833C39 /* ElementNodeDescriptor.swift in Sources */,
 				599F254C1D8BC9A1002871D6 /* UITextView+Helpers.swift in Sources */,
 				FFA61E891DF18F3D00B71BF6 /* ParagraphStyle.swift in Sources */,
+				FFD436961E300EF800A0E26F /* FontFormatter.swift in Sources */,
 				599F25451D8BC9A1002871D6 /* Libxml2.swift in Sources */,
 				B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */,
 				599F25391D8BC9A1002871D6 /* InHTMLConverter.swift in Sources */,

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -9,6 +9,7 @@ import UIKit
 ///
 protocol AttributeFormatter {
 
+    var elementType: Libxml2.StandardElementType { get }
     /// Attributes to be used the Content Placeholder, when / if needed.
     ///
     var placeholderAttributes: [String: Any]? { get }
@@ -21,7 +22,7 @@ protocol AttributeFormatter {
     ///     - text: Text that should be formatted.
     ///     - range: Segment of text which format should be toggled.
     ///
-    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange?
+    @discardableResult func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange?
 
     /// Checks if the attribute is present in a given Attributed String at the specified index.
     ///
@@ -110,6 +111,8 @@ protocol CharacterAttributeFormatter: AttributeFormatter {
 
 extension CharacterAttributeFormatter {
 
+    var placeholderAttributes: [String : Any]? { return nil }
+
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
         return range
     }
@@ -117,9 +120,9 @@ extension CharacterAttributeFormatter {
     /// Toggles the Attribute Format, into a given string, at the specified range.
     ///
     @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange) {
+    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {
         guard range.location < text.length else {
-            return
+            return range
         }
 
         if shouldApplyAttributes(to: text, at: range) {
@@ -127,6 +130,7 @@ extension CharacterAttributeFormatter {
         } else {
             removeAttributes(from: text, at: range)
         }
+        return range
     }
 }
 

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -44,7 +44,7 @@ protocol AttributeFormatter {
 
     /// Checks if the attribute is present in a dictionary of attributes.
     ///
-    func present(in attributes: [String: AnyObject]) -> Bool
+    func present(in attributes: [String: Any]) -> Bool
 
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange
 }
@@ -58,7 +58,7 @@ extension AttributeFormatter {
     ///
     func present(in text: NSAttributedString, at index: Int) -> Bool {
         let safeIndex = max(min(index, text.length - 1), 0)
-        let attributes = text.attributes(at: safeIndex, effectiveRange: nil) as [String : AnyObject]
+        let attributes = text.attributes(at: safeIndex, effectiveRange: nil)
         return present(in: attributes)
     }
 

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -63,7 +63,7 @@ struct BlockquoteFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [String : AnyObject]) -> Bool {
+    func present(in attributes: [String : Any]) -> Bool {
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle {
             return paragraphStyle.blockquote != nil
         }

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -20,6 +20,9 @@ class Blockquote: NSObject, NSCoding {
 }
 
 struct BlockquoteFormatter: ParagraphAttributeFormatter {
+
+    let elementType: Libxml2.StandardElementType = .blockquote 
+
     let placeholderAttributes: [String : Any]?
 
     init(placeholderAttributes: [String : Any]? = nil) {

--- a/Aztec/Classes/Formatters/FontFormatter.swift
+++ b/Aztec/Classes/Formatters/FontFormatter.swift
@@ -1,0 +1,62 @@
+import Foundation
+import UIKit
+
+class FontFormatter: CharacterAttributeFormatter {
+
+    let elementType: Libxml2.StandardElementType
+    
+    let traits: UIFontDescriptorSymbolicTraits
+
+    init(elementType: Libxml2.StandardElementType, traits: UIFontDescriptorSymbolicTraits) {
+        self.elementType = elementType
+        self.traits = traits
+
+    }
+
+    func apply(to attributes: [String : Any]) -> [String: Any] {
+
+        var resultingAttributes = attributes
+        guard let font = attributes[NSFontAttributeName] as? UIFont else {
+            return attributes
+        }
+        let newFont = font.modifyTraits(traits, enable: true)
+        resultingAttributes[NSFontAttributeName] = newFont
+        
+        return resultingAttributes
+    }
+
+    func remove(from attributes:[String: Any]) -> [String: Any] {
+        var resultingAttributes = attributes
+        guard let font = attributes[NSFontAttributeName] as? UIFont else {
+            return attributes
+        }
+
+        let newFont = font.modifyTraits(traits, enable: false)
+        resultingAttributes[NSFontAttributeName] = newFont
+
+        return resultingAttributes
+    }
+
+    func present(in attributes: [String : AnyObject]) -> Bool {
+        guard let font = attributes[NSFontAttributeName] as? UIFont else {
+            return false
+        }
+        let enabled = font.containsTraits(traits)
+        return enabled
+    }
+}
+
+class BoldFormatter: FontFormatter {
+
+    init() {
+        super.init(elementType: .b, traits: .traitBold)
+    }
+}
+
+class ItalicFormatter: FontFormatter {
+
+    init() {
+        super.init(elementType: .i, traits: .traitItalic)
+    }
+}
+

--- a/Aztec/Classes/Formatters/FontFormatter.swift
+++ b/Aztec/Classes/Formatters/FontFormatter.swift
@@ -37,7 +37,7 @@ class FontFormatter: CharacterAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [String : AnyObject]) -> Bool {
+    func present(in attributes: [String : Any]) -> Bool {
         guard let font = attributes[NSFontAttributeName] as? UIFont else {
             return false
         }

--- a/Aztec/Classes/Formatters/FontFormatter.swift
+++ b/Aztec/Classes/Formatters/FontFormatter.swift
@@ -25,7 +25,7 @@ class FontFormatter: CharacterAttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(from attributes:[String: Any]) -> [String: Any] {
+    func remove(from attributes: [String : Any]) -> [String: Any] {
         var resultingAttributes = attributes
         guard let font = attributes[NSFontAttributeName] as? UIFont else {
             return attributes

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct TextListFormatter: ParagraphAttributeFormatter {
 
+    let elementType: Libxml2.StandardElementType = .li
     let listStyle: TextList.Style
     let placeholderAttributes: [String : Any]?
 

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -43,7 +43,7 @@ struct TextListFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [String : AnyObject]) -> Bool {
+    func present(in attributes: [String : Any]) -> Bool {
         guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
               let textList = paragraphStyle.textList else {
             return false

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -515,6 +515,12 @@ extension Libxml2 {
 
         // MARK: Remove Styles
 
+        func remove(element: StandardElementType, at range: NSRange){
+            performAsyncUndoable { [weak self] in
+                self?.removeSynchronously(element: element, at: range)
+            }
+        }
+
         /// Disables bold from the specified range.
         ///
         /// - Parameters:
@@ -572,7 +578,10 @@ extension Libxml2 {
         }
         
         // MARK: - Remove Styles: Synchronously
-        
+        private func removeSynchronously(element: StandardElementType, at range: NSRange) {
+            rootNode.unwrap(range: range, fromElementsNamed: element.equivalentNames)
+        }
+
         private func removeBoldSynchronously(spanning range: NSRange) {
             rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.b.equivalentNames)
         }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -223,33 +223,13 @@ open class TextStorage: NSTextStorage {
     }
     
     // MARK: - Styles: Toggling
-
-    func toggleBold(_ range: NSRange) {
-
-        let enable = !fontTrait(.traitBold, spansRange: range)
-        
-        /// We should be calculating what attributes to remove in `TextStorage.setAttributes()`
-        /// but since that may take a while to implement, we need this workaround until it's ready.
-        ///
-        if !enable {
-            dom.removeBold(spanning: range)
+    @discardableResult func toggle(formatter: AttributeFormatter, at range: NSRange) -> NSRange? {
+        let applicationRange = formatter.applicationRange(for: range, in: self)
+        let newSelectedRange = formatter.toggle(in: self, at: applicationRange)
+        if !formatter.present(in: self, at: applicationRange.location) {
+            dom.remove(element:formatter.elementType, at: applicationRange)
         }
-
-        modifyTraits(.traitBold, range: range, enable: enable)
-    }
-
-    func toggleItalic(_ range: NSRange) {
-
-        let enable = !fontTrait(.traitItalic, spansRange: range)
-
-        /// We should be calculating what attributes to remove in `TextStorage.setAttributes()`
-        /// but since that may take a while to implement, we need this workaround until it's ready.
-        ///
-        if !enable {
-            dom.removeItalic(spanning: range)
-        }
-        
-        modifyTraits(.traitItalic, range: range, enable: enable)
+        return newSelectedRange
     }
 
     func toggleStrikethrough(_ range: NSRange) {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -409,11 +409,9 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleBold(range: NSRange) {
-        updateTypingFont(toggle: .traitBold)
-
-        if range.length > 0 {
-            storage.toggleBold(range)
-        }
+        let formatter = BoldFormatter()
+        typingAttributes = formatter.apply(to: typingAttributes)
+        storage.toggle(formatter: formatter, at: range)
     }
 
 
@@ -422,11 +420,9 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleItalic(range: NSRange) {
-        updateTypingFont(toggle: .traitItalic)
-
-        if range.length > 0 {
-            storage.toggleItalic(range)
-        }
+        let formatter = ItalicFormatter()
+        typingAttributes = formatter.apply(to: typingAttributes)
+        storage.toggle(formatter: formatter, at: range)
     }
 
 

--- a/AztecTests/Formatters/FontFormatterTests.swift
+++ b/AztecTests/Formatters/FontFormatterTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import Aztec
+
+
+// MARK: - FontFormatter Tests
+//
+class FontFormatterTests: XCTestCase
+{
+    let boldFormatter = BoldFormatter()
+    let italicFormatter = ItalicFormatter()
+
+    func testApplyAttribute() {
+        var attributes: [String : Any] = [NSFontAttributeName: UIFont.systemFont(ofSize: UIFont.systemFontSize)]
+        var font: UIFont?
+        //test adding a non-existent testApplyAttribute
+        attributes = boldFormatter.apply(to: attributes)
+        //this should add a new attribute to it
+        font = attributes[NSFontAttributeName] as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertTrue(font!.containsTraits(.traitBold))
+
+        //test addding a existent attribute
+        attributes = boldFormatter.apply(to: attributes)
+        // this shouldn't change anything in the attributes
+        font = attributes[NSFontAttributeName] as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertTrue(font!.containsTraits(.traitBold))
+
+    }
+
+    func testRemoveAttributes() {
+        var attributes: [String : Any] = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)]
+        var font: UIFont?
+
+        //test removing a existent attribute
+        attributes = boldFormatter.remove(from: attributes)
+        font = attributes[NSFontAttributeName] as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertFalse(font!.containsTraits(.traitBold))
+
+        attributes = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)]
+        //test removing a non-existent testApplyAttribute
+        attributes = italicFormatter.remove(from: attributes)
+        font = attributes[NSFontAttributeName] as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertTrue(font!.containsTraits(.traitBold))
+    }
+
+    func testPresentAttributes() {
+        var attributes: [String : Any] = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)]
+        //test when attribute is present
+        XCTAssertTrue(boldFormatter.present(in: attributes))
+        //test when attributes is not present
+        XCTAssertFalse(italicFormatter.present(in: attributes))
+        // apply attribute and check again
+        attributes = italicFormatter.apply(to: attributes)
+        XCTAssertTrue(italicFormatter.present(in: attributes))
+    }
+}


### PR DESCRIPTION
This PR changes the way we apply bold and italic to the storage, by using CharacterFormatters instead of specific code in the TextView and TextStorage classes.

How to test:

- Apply bold and/or italic to sections of test and see if everything works ok.
 - Check if the HTML is updated correctly also.

