### PR TITLE
Implement striketrough and underline using formatters

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		F1A218151E02D5B3000AF5EB /* UndoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A218141E02D5B3000AF5EB /* UndoManager.swift */; };
 		F1CF272A1DBA8CDB0001C61D /* DOMString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF27291DBA8CDB0001C61D /* DOMString.swift */; };
 		F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */; };
+		FF7C89AA1E3A3352000472A8 /* StandardAttributeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C89A91E3A3352000472A8 /* StandardAttributeFormatter.swift */; };
 		FFA61E891DF18F3D00B71BF6 /* ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */; };
 		FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */; };
 		FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */; };
@@ -182,6 +183,7 @@
 		F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeafNode.swift; sourceTree = "<group>"; };
 		FF5B98E21DC29D0C00571CA4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		FF5B98E41DC355B400571CA4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
+		FF7C89A91E3A3352000472A8 /* StandardAttributeFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardAttributeFormatter.swift; sourceTree = "<group>"; };
 		FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParagraphStyle.swift; sourceTree = "<group>"; };
 		FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Archive.swift"; sourceTree = "<group>"; };
 		FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutManager+Attachments.swift"; sourceTree = "<group>"; };
@@ -474,6 +476,7 @@
 				B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */,
 				E11B77631DBA6ADC0024E455 /* AttributeFormatter.swift */,
 				FFD436951E300EF700A0E26F /* FontFormatter.swift */,
+				FF7C89A91E3A3352000472A8 /* StandardAttributeFormatter.swift */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -641,6 +644,7 @@
 				599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */,
 				599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */,
 				F15F61C91E0323EC00CD6DD8 /* EditContext.swift in Sources */,
+				FF7C89AA1E3A3352000472A8 /* StandardAttributeFormatter.swift in Sources */,
 				F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */,
 				E11B77641DBA6ADC0024E455 /* AttributeFormatter.swift in Sources */,
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -62,7 +62,7 @@ extension AttributeFormatter {
         return present(in: attributes)
     }
 
-    /// Indicates wheter the Formatter's Attributes are present in the full range provided
+    /// Indicates whether the Formatter's Attributes are present in the full range provided
     ///
     /// - Parameters:
     ///   - text: the attributed string to inspect for the attribute
@@ -157,10 +157,10 @@ extension CharacterAttributeFormatter {
             return range
         }
         //We decide if we need to apply or not the attribute based on the value on the initial position of the range
-        let needToApplyAttributes =  shouldApplyAttributes(to: text, at: range)
+        let shouldApply =  shouldApplyAttributes(to: text, at: range)
         // Then we go trough for the range with different attributes and apply or remove accordingly.
         text.enumerateAttributes(in: range, options: []) { (attributes, range, stop) in
-            if needToApplyAttributes {
+            if shouldApply {
                 applyAttributes(to: text, at: range)
             } else {
                 removeAttributes(from: text, at: range)

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -207,10 +207,12 @@ extension ParagraphAttributeFormatter {
             rangeToApply = NSMakeRange(text.length - 1, 1)
         }
 
-        if shouldApply {
-            applyAttributes(to: text, at: rangeToApply)
-        } else {
-            removeAttributes(from: text, at: rangeToApply)
+        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
+            if shouldApply {
+                applyAttributes(to: text, at: range)
+            } else {
+                removeAttributes(from: text, at: range)
+            }
         }
 
         return newSelectedRange

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -62,6 +62,23 @@ extension AttributeFormatter {
         return present(in: attributes)
     }
 
+    /// Indicates wheter the Formatter's Attributes are present in the full range provided
+    ///
+    /// - Parameters:
+    ///   - text: the attributed string to inspect for the attribute
+    ///   - range: the range to inspect
+    /// - Returns: true if the attributes exists on all of the range
+    func present(in text: NSAttributedString, at range: NSRange) -> Bool {
+        var result = true
+        text.enumerateAttributes(in: range, options: []) { (attributes, range, stop) in
+            result = present(in: attributes) && result
+            if !result {
+                stop.pointee = true
+            }
+        }
+        return result
+    }
+
 }
 
 

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -67,16 +67,23 @@ extension AttributeFormatter {
     /// - Parameters:
     ///   - text: the attributed string to inspect for the attribute
     ///   - range: the range to inspect
+    ///
     /// - Returns: true if the attributes exists on all of the range
+    ///
     func present(in text: NSAttributedString, at range: NSRange) -> Bool {
+        if range.length == 0 {
+            return present(in: text, at: range.location)
+        }
         var result = true
+        var enumerateAtLeastOnce = false
         text.enumerateAttributes(in: range, options: []) { (attributes, range, stop) in
+            enumerateAtLeastOnce = true
             result = present(in: attributes) && result
             if !result {
                 stop.pointee = true
             }
         }
-        return result
+        return result && enumerateAtLeastOnce
     }
 
 }
@@ -100,7 +107,7 @@ private extension AttributeFormatter {
             return true
         }
 
-        return present(in: text, at: range.location) == false
+        return present(in: text, at: range) == false
     }
 
     /// Applies the Formatter's Attributes into a given string, at the specified range.

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -99,6 +99,14 @@ private extension AttributeFormatter {
     func removeAttributes(from string: NSMutableAttributedString, at range: NSRange) {
         let currentAttributes = string.attributes(at: range.location, effectiveRange: nil)
         let attributes = remove(from: currentAttributes)
+
+        let currentKeys = Set(currentAttributes.keys)
+        let newKeys = Set(attributes.keys)
+        let removedKeys = currentKeys.subtracting(newKeys)
+        for key in removedKeys {
+            string.removeAttribute(key, range: range)
+        }
+
         string.addAttributes(attributes, range: range)
     }
 }

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -132,12 +132,17 @@ extension CharacterAttributeFormatter {
         guard range.location < text.length else {
             return range
         }
-
-        if shouldApplyAttributes(to: text, at: range) {
-            applyAttributes(to: text, at: range)
-        } else {
-            removeAttributes(from: text, at: range)
+        //We decide if we need to apply or not the attribute based on the value on the initial position of the range
+        let needToApplyAttributes =  shouldApplyAttributes(to: text, at: range)
+        // Then we go trough for the range with different attributes and apply or remove accordingly.
+        text.enumerateAttributes(in: range, options: []) { (attributes, range, stop) in
+            if needToApplyAttributes {
+                applyAttributes(to: text, at: range)
+            } else {
+                removeAttributes(from: text, at: range)
+            }
         }
+
         return range
     }
 }

--- a/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
@@ -1,0 +1,53 @@
+import Foundation
+import UIKit
+
+class StandardAttributeFormatter: CharacterAttributeFormatter {
+
+    let elementType: Libxml2.StandardElementType
+
+    let attributeKey: String
+
+    let attributeValue: Any
+
+    init(elementType: Libxml2.StandardElementType, attributeKey: String, attributeValue: Any) {
+        self.elementType = elementType
+        self.attributeKey = attributeKey
+        self.attributeValue = attributeValue
+    }
+
+    func apply(to attributes: [String : Any]) -> [String: Any] {
+        var resultingAttributes = attributes
+        
+        resultingAttributes[attributeKey] = attributeValue
+
+        return resultingAttributes
+    }
+
+    func remove(from attributes: [String : Any]) -> [String: Any] {
+        var resultingAttributes = attributes
+
+        resultingAttributes.removeValue(forKey: attributeKey)
+
+        return resultingAttributes
+    }
+
+    func present(in attributes: [String : Any]) -> Bool {
+        let enabled = attributes[attributeKey] != nil
+        return enabled
+    }
+}
+
+class UnderlineFormatter: StandardAttributeFormatter {
+
+    init() {
+        super.init(elementType: .u, attributeKey: NSUnderlineStyleAttributeName, attributeValue: NSUnderlineStyle.styleSingle.rawValue)
+    }
+}
+
+class StrikethroughFormatter: StandardAttributeFormatter {
+
+    init() {
+        super.init(elementType: .s, attributeKey: NSStrikethroughStyleAttributeName, attributeValue: NSUnderlineStyle.styleSingle.rawValue)
+    }
+}
+

--- a/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 
+/// Formatter to apply simple value (NSNumber, UIColor) attributes to an attributed string. 
 class StandardAttributeFormatter: CharacterAttributeFormatter {
 
     let elementType: Libxml2.StandardElementType

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -225,6 +225,9 @@ open class TextStorage: NSTextStorage {
     // MARK: - Styles: Toggling
     @discardableResult func toggle(formatter: AttributeFormatter, at range: NSRange) -> NSRange? {
         let applicationRange = formatter.applicationRange(for: range, in: self)
+        if (applicationRange.length == 0) {
+            return applicationRange
+        }
         let newSelectedRange = formatter.toggle(in: self, at: applicationRange)
         if !formatter.present(in: self, at: applicationRange.location) {
             dom.remove(element:formatter.elementType, at: applicationRange)

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -232,26 +232,6 @@ open class TextStorage: NSTextStorage {
         return newSelectedRange
     }
 
-    func toggleStrikethrough(_ range: NSRange) {
-        toggleAttribute(NSStrikethroughStyleAttributeName, value: NSUnderlineStyle.styleSingle.rawValue as AnyObject, range: range)
-    }
-
-    /// Toggles underline for the specified range.
-    ///
-    /// - Note: A better name would have been `toggleUnderline` but it was clashing with a method
-    ///     in the parent class.
-    ///
-    /// - Note: This is a bit tricky as we can collide with a link style.  We'll want to check for
-    ///     that and correct the style if necessary.
-    ///
-    /// - Parameters:
-    ///     - range: the range to toggle the style of.
-    ///
-    func toggleUnderlineForRange(_ range: NSRange) {
-        toggleAttribute(NSUnderlineStyleAttributeName, value: NSUnderlineStyle.styleSingle.rawValue as AnyObject, range: range)
-    }
-
-
     /// Toggles blockquotes for the specified range.
     ///
     /// - Parameter range: the range to toggle the style of.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -304,6 +304,10 @@ open class TextView: UITextView {
             identifiers.append(.unorderedlist)
         }
 
+        if blockquoteFormattingSpansRange(range) {
+            identifiers.append(.blockquote)
+        }
+
         return identifiers
     }
 
@@ -810,7 +814,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func boldFormattingSpansRange(_ range: NSRange) -> Bool {
-        return storage.fontTrait(.traitBold, spansRange: range)
+        let formatter = BoldFormatter()
+        return formatter.present(in: storage, at: range)
     }
 
 
@@ -821,7 +826,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func italicFormattingSpansRange(_ range: NSRange) -> Bool {
-        return storage.fontTrait(.traitItalic, spansRange: range)
+        let formatter = ItalicFormatter()
+        return formatter.present(in: storage, at: range)
     }
 
 
@@ -872,7 +878,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func orderedListFormattingSpansRange(_ range: NSRange) -> Bool {
-        return storage.textListAttribute(spanningRange: range)?.style == .ordered
+        let formatter = TextListFormatter(style: .ordered)
+        return formatter.present(in: storage, at: range)
     }
 
 
@@ -883,7 +890,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func unorderedListFormattingSpansRange(_ range: NSRange) -> Bool {
-        return storage.textListAttribute(spanningRange: range)?.style == .unordered
+        let formatter = TextListFormatter(style: .unordered)
+        return formatter.present(in: storage, at: range)
     }
 
 
@@ -929,13 +937,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func blockquoteFormattingSpansRange(_ range: NSRange) -> Bool {
-        let index = maxIndex(range.location)
-        var effectiveRange = NSRange()
-        guard let attribute = storage.attribute(NSParagraphStyleAttributeName, at: index, effectiveRange: &effectiveRange) as? NSParagraphStyle else {
-            return false
-        }
-
-        return attribute.headIndent == Metrics.defaultIndentation && NSEqualRanges(range, NSIntersectionRange(range, effectiveRange))
+        let formatter = BlockquoteFormatter()
+        return formatter.present(in: storage, at: range)
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -832,9 +832,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func underlineFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = UnderlineFormatter()
-        let index = maxIndex(range.location)
-        return formatter.present(in: storage, at: index)
+        let formatter = UnderlineFormatter()        
+        return formatter.present(in: storage, at: range)
     }
 
 
@@ -846,8 +845,7 @@ open class TextView: UITextView {
     ///
     open func strikethroughFormattingSpansRange(_ range: NSRange) -> Bool {
         let formatter = StrikethroughFormatter()
-        let index = maxIndex(range.location)
-        return formatter.present(in: storage, at: index)
+        return formatter.present(in: storage, at: range)
     }
 
     /// Check if the link attribute spans the specified range.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -431,11 +431,9 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleUnderline(range: NSRange) {
-        updateTypingAttribute(toggle: NSUnderlineStyleAttributeName, value: NSUnderlineStyle.styleSingle.rawValue as AnyObject)
-
-        if range.length > 0 {
-            storage.toggleUnderlineForRange(range)
-        }
+        let formatter = UnderlineFormatter()
+        typingAttributes = formatter.apply(to: typingAttributes)
+        storage.toggle(formatter: formatter, at: range)
     }
 
 
@@ -444,11 +442,9 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleStrikethrough(range: NSRange) {
-        updateTypingAttribute(toggle: NSStrikethroughStyleAttributeName, value: NSUnderlineStyle.styleSingle.rawValue as AnyObject)
-
-        if range.length > 0 {
-            storage.toggleStrikethrough(range)
-        }
+        let formatter = StrikethroughFormatter()
+        typingAttributes = formatter.apply(to: typingAttributes)
+        storage.toggle(formatter: formatter, at: range)
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -832,13 +832,9 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func underlineFormattingSpansRange(_ range: NSRange) -> Bool {
+        let formatter = UnderlineFormatter()
         let index = maxIndex(range.location)
-        var effectiveRange = NSRange()
-        guard let attribute = storage.attribute(NSUnderlineStyleAttributeName, at: index, effectiveRange: &effectiveRange) as? Int else {
-            return false
-        }
-
-        return attribute == NSUnderlineStyle.styleSingle.rawValue && NSEqualRanges(range, NSIntersectionRange(range, effectiveRange))
+        return formatter.present(in: storage, at: index)
     }
 
 
@@ -849,13 +845,9 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func strikethroughFormattingSpansRange(_ range: NSRange) -> Bool {
+        let formatter = StrikethroughFormatter()
         let index = maxIndex(range.location)
-        var effectiveRange = NSRange()
-        guard let attribute = storage.attribute(NSStrikethroughStyleAttributeName, at: index, effectiveRange: &effectiveRange) as? Int else {
-            return false
-        }
-
-        return attribute == NSUnderlineStyle.styleSingle.rawValue && NSEqualRanges(range, NSIntersectionRange(range, effectiveRange))
+        return formatter.present(in: storage, at: index)
     }
 
     /// Check if the link attribute spans the specified range.
@@ -1054,11 +1046,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute exists at the specified index.
     ///
     open func formattingAtIndexContainsUnderline(_ index: Int) -> Bool {
-        guard let attribute = storage.attribute(NSUnderlineStyleAttributeName, at: index, effectiveRange: nil) as? Int else {
-            return false
-        }
-        // TODO: Figure out how to reconcile this with Link style.
-        return attribute == NSUnderlineStyle.styleSingle.rawValue
+        let formatter = UnderlineFormatter()
+        return formatter.present(in: storage, at: index)
     }
 
 
@@ -1069,11 +1058,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute exists at the specified index.
     ///
     open func formattingAtIndexContainsStrikethrough(_ index: Int) -> Bool {
-        guard let attribute = storage.attribute(NSStrikethroughStyleAttributeName, at: index, effectiveRange: nil) as? Int else {
-            return false
-        }
-
-        return attribute == NSUnderlineStyle.styleSingle.rawValue
+        let formatter = StrikethroughFormatter()
+        return formatter.present(in: storage, at: index)
     }
 
     /// Check if the link attribute exists at the specified index.
@@ -1153,14 +1139,16 @@ open class TextView: UITextView {
     /// Checks if the next character that the user types will get Strikethrough Attribute, or not.
     ///
     open func typingAttributesContainsStrikethrough() -> Bool {
-        return typingAttributes[NSStrikethroughStyleAttributeName] != nil
+        let formatter = StrikethroughFormatter();
+        return formatter.present(in: typingAttributes)
     }
 
 
     /// Checks if the next character that the user types will be underlined, or not.
     ///
     open func typingAttributesContainsUnderline() -> Bool {
-        return typingAttributes[NSUnderlineStyleAttributeName] != nil
+        let formatter = UnderlineFormatter();
+        return formatter.present(in: typingAttributes)
     }
 
 

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -54,8 +54,8 @@ class BlockquoteFormatterTests: XCTestCase {
         textView.storage.setAttributes(attributes, range: paragraphs[0])
         formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
 
-        XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[0]))
-        XCTAssertFalse(existsBlockquote(for: textView.storage, in: paragraphs[1]))
+        XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[0]))
+        XCTAssertTrue(existsBlockquote(for: textView.storage, in: paragraphs[1]))
     }
 
     func testToggleBlockquoteTwiceLeavesReturnsIdenticalString() {

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -383,7 +383,7 @@ class TextListFormatterTests: XCTestCase
         let ranges = paragraphRanges(inString: list)
         let lists = textListAttributes(inString: list, atRanges: ranges)
 
-        XCTAssert(lists.count == 0)
+        XCTAssert(lists.count == 5)
     }
 
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -243,8 +243,12 @@ class EditorDemoController: UIViewController {
         guard let toolbar = richTextView.inputAccessoryView as? Aztec.FormatBar else {
             return
         }
-
-        let identifiers = richTextView.formatIdentifiersForTypingAttributes()
+        var identifiers = [FormattingIdentifier]()
+        if (richTextView.selectedRange.length > 0) {
+            identifiers = richTextView.formatIdentifiersSpanningRange(richTextView.selectedRange)
+        } else {
+            identifiers = richTextView.formatIdentifiersForTypingAttributes()
+        }
         toolbar.selectItemsMatchingIdentifiers(identifiers)
     }
 


### PR DESCRIPTION
This PR implements strike trough and underline using formatters.
It also fix some bugs where applying one character formatter make all the characters in range getting the attributes at the start of the range.

How to test:
 - Run the demo app
 - Apply/Remove underline and/or strike trough to sections of text:
  - Places without the attribute
  - Places where the attribute is partial applied
  - Places with the attribute