### PR TITLE
Standardize check for formatting

### DIFF
--- a/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
@@ -52,3 +52,9 @@ class StrikethroughFormatter: StandardAttributeFormatter {
     }
 }
 
+class LinkFormatter: StandardAttributeFormatter {
+    init() {
+        super.init(elementType: .a, attributeKey: NSLinkAttributeName, attributeValue: NSURL())
+    }
+}
+

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -256,7 +256,7 @@ open class TextView: UITextView {
 
 
     // MARK: - Getting format identifiers
-    
+
     private let formatterIdentifiersMap: [FormattingIdentifier: AttributeFormatter] = [
         .bold: BoldFormatter(),
         .italic: ItalicFormatter(),
@@ -569,17 +569,19 @@ open class TextView: UITextView {
             return false
         }
 
-        if formattingAtIndexContainsOrderedList(range.location) {
+        let identifiers = formatIdentifiersAtIndex(range.location)
+
+        if identifiers.contains(.orderedlist) {
             toggleOrderedList(range: range)
             return true
         }
 
-        if formattingAtIndexContainsUnorderedList(range.location) {
+        if identifiers.contains(.unorderedlist) {
             toggleUnorderedList(range: range)
             return true
         }
 
-        if formattingAtIndexContainsBlockquote(range.location) {
+        if identifiers.contains(.blockquote) {
             toggleBlockquote(range: range)
             return true
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -821,13 +821,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute spans the entire range.
     ///
     open func linkFormattingSpansRange(_ range: NSRange) -> Bool {
-        let index = maxIndex(range.location)
-        var effectiveRange = NSRange()
-        if storage.attribute(NSLinkAttributeName, at: index, effectiveRange: &effectiveRange) != nil {
-           return NSEqualRanges(range, NSIntersectionRange(range, effectiveRange))
-        }
-
-        return false
+        let formatter = LinkFormatter()
+        return formatter.present(in: storage, at: range)
     }
 
 
@@ -987,7 +982,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute exists at the specified index.
     ///
     open func formattingAtIndexContainsLink(_ index: Int) -> Bool {
-        return storage.attribute(NSLinkAttributeName, at: index, effectiveRange: nil) != nil
+        let formatter = LinkFormatter()
+        return formatter.present(in: storage, at: index)
     }
 
     
@@ -1035,7 +1031,7 @@ open class TextView: UITextView {
     /// Checks if the next character entered by the user will be in Bold, or not.
     ///
     open func typingAttributesContainsBold() -> Bool {
-        let formatter = BoldFormatter();
+        let formatter = BoldFormatter()
         return formatter.present(in: typingAttributes)
     }
 
@@ -1043,7 +1039,7 @@ open class TextView: UITextView {
     /// Checks if the next character entered by the user will be in Italic, or not.
     ///
     open func typingAttributesContainsItalic() -> Bool {
-        let formatter = ItalicFormatter();
+        let formatter = ItalicFormatter()
         return formatter.present(in: typingAttributes)
     }
 
@@ -1051,7 +1047,7 @@ open class TextView: UITextView {
     /// Checks if the next character that the user types will get Strikethrough Attribute, or not.
     ///
     open func typingAttributesContainsStrikethrough() -> Bool {
-        let formatter = StrikethroughFormatter();
+        let formatter = StrikethroughFormatter()
         return formatter.present(in: typingAttributes)
     }
 
@@ -1059,7 +1055,7 @@ open class TextView: UITextView {
     /// Checks if the next character that the user types will be underlined, or not.
     ///
     open func typingAttributesContainsUnderline() -> Bool {
-        let formatter = UnderlineFormatter();
+        let formatter = UnderlineFormatter()
         return formatter.present(in: typingAttributes)
     }
 
@@ -1067,7 +1063,7 @@ open class TextView: UITextView {
     /// Checks if the next character that the user types will be formatted as Blockquote, or not.
     ///
     open func typingAttributesContainsBlockquote() -> Bool {
-        let formatter = BlockquoteFormatter();
+        let formatter = BlockquoteFormatter()
         return formatter.present(in: typingAttributes)
     }
 
@@ -1075,7 +1071,7 @@ open class TextView: UITextView {
     /// Checks if the next character that the user types will be formatted as an Ordered List, or not.
     ///
     open func typingAttributesContainsOrderedList() -> Bool {
-        let formatter = TextListFormatter(style: .ordered);
+        let formatter = TextListFormatter(style: .ordered)
         return formatter.present(in: typingAttributes)
     }
 
@@ -1083,14 +1079,15 @@ open class TextView: UITextView {
     /// Checks if the next character that the user types will be formatted as an Unordered List, or not.
     ///
     open func typingAttributesContainsUnorderedList() -> Bool {
-        let formatter = TextListFormatter(style: .unordered);
+        let formatter = TextListFormatter(style: .unordered)
         return formatter.present(in: typingAttributes)
     }
 
     /// Checks if the next character that the user types will be part of a link anchor, or not.
     ///
     open func typingAttributesContainsLink() -> Bool {
-        return typingAttributes[NSLinkAttributeName] != nil
+        let formatter = LinkFormatter()
+        return formatter.present(in: typingAttributes)
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -930,51 +930,6 @@ open class TextView: UITextView {
         return max(0, index - 1)
     }
 
-
-    /// TextListFormatter was designed to be applied over a range of text. Whenever such range is
-    /// zero, we may have trouble determining where to apply the list. For that reason,
-    /// whenever the list range's length is zero, we'll attempt to infer the range of the line at
-    /// which the cursor is located.
-    ///
-    /// - Parameter range: The NSRange in which a TextList should be applied
-    ///
-    /// Returns: A corrected NSRange, if the original one had empty length.
-    ///
-    func rangeForTextList(_ range: NSRange) -> NSRange {
-        guard range.length == 0 else {
-            return range
-        }
-
-        return storage.rangeOfLine(atIndex: range.location) ?? range
-    }
-
-
-    /// Returns the expected Selected Range for a given TextList, with the specified Effective Range,
-    /// and the Applied Range.
-    ///
-    /// Note that "Effective Range" is the actual List Range (including Markers), whereas Applied Range is just
-    /// the range at which the list was originally inserted.
-    ///
-    /// - Parameters:
-    ///     - effectiveRange: The actual range occupied by the List. Includes the String Markers!
-    ///     - appliedRange: The (original) range at which the list was applied.
-    ///
-    /// - Returns: If the current selection's length is zero, we'll return the selectedRange with it's location
-    ///   updated to consider the left padding applied by the list. Otherwise, we'll return the List's 
-    ///   Effective range.
-    ///
-    func rangeForSelectedTextList(withEffectiveRange effectiveRange: NSRange, andAppliedRange appliedRange: NSRange) -> NSRange {
-        guard selectedRange.length == 0 else {
-            return effectiveRange
-        }
-
-        var newSelectedRange = selectedRange
-        newSelectedRange.location += effectiveRange.length - appliedRange.length
-
-        return newSelectedRange
-    }
-
-
     // MARK - Inspect at Index
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -940,7 +940,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute exists at the specified index.
     ///
     open func formattingAtIndexContainsBold(_ index: Int) -> Bool {
-        return storage.fontTrait(.traitBold, existsAtIndex: index)
+        let formatter = BoldFormatter()
+        return formatter.present(in: storage, at: index)
     }
 
 
@@ -951,7 +952,8 @@ open class TextView: UITextView {
     /// - Returns: True if the attribute exists at the specified index.
     ///
     open func formattingAtIndexContainsItalic(_ index: Int) -> Bool {
-        return storage.fontTrait(.traitItalic, existsAtIndex: index)
+        let formatter = ItalicFormatter()
+        return formatter.present(in: storage, at: index)
     }
 
 
@@ -1033,22 +1035,16 @@ open class TextView: UITextView {
     /// Checks if the next character entered by the user will be in Bold, or not.
     ///
     open func typingAttributesContainsBold() -> Bool {
-        guard let font = typingAttributes[NSFontAttributeName] as? UIFont else {
-            return false
-        }
-
-        return font.containsTraits(.traitBold)
+        let formatter = BoldFormatter();
+        return formatter.present(in: typingAttributes)
     }
 
 
     /// Checks if the next character entered by the user will be in Italic, or not.
     ///
     open func typingAttributesContainsItalic() -> Bool {
-        guard let font = typingAttributes[NSFontAttributeName] as? UIFont else {
-            return false
-        }
-
-        return font.containsTraits(.traitItalic)
+        let formatter = ItalicFormatter();
+        return formatter.present(in: typingAttributes)
     }
 
 
@@ -1071,24 +1067,24 @@ open class TextView: UITextView {
     /// Checks if the next character that the user types will be formatted as Blockquote, or not.
     ///
     open func typingAttributesContainsBlockquote() -> Bool {
-        let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle
-        return paragraphStyle?.blockquote != nil
+        let formatter = BlockquoteFormatter();
+        return formatter.present(in: typingAttributes)
     }
 
 
     /// Checks if the next character that the user types will be formatted as an Ordered List, or not.
     ///
     open func typingAttributesContainsOrderedList() -> Bool {
-        let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle
-        return paragraphStyle?.textList?.style == .ordered
+        let formatter = TextListFormatter(style: .ordered);
+        return formatter.present(in: typingAttributes)
     }
 
 
     /// Checks if the next character that the user types will be formatted as an Unordered List, or not.
     ///
     open func typingAttributesContainsUnorderedList() -> Bool {
-        let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle
-        return paragraphStyle?.textList?.style == .unordered
+        let formatter = TextListFormatter(style: .unordered);
+        return formatter.present(in: typingAttributes)
     }
 
     /// Checks if the next character that the user types will be part of a link anchor, or not.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -276,8 +276,7 @@ open class TextView: UITextView {
     ///
     open func formatIdentifiersSpanningRange(_ range: NSRange) -> [FormattingIdentifier] {
         guard storage.length != 0 else {
-            // FIXME: if empty string, check typingAttributes
-            return []
+            return formatIdentifiersForTypingAttributes()
         }
 
         if range.length == 0 {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -256,7 +256,17 @@ open class TextView: UITextView {
 
 
     // MARK: - Getting format identifiers
-
+    
+    private let formatterIdentifiersMap: [FormattingIdentifier: AttributeFormatter] = [
+        .bold: BoldFormatter(),
+        .italic: ItalicFormatter(),
+        .underline: UnderlineFormatter(),
+        .strikethrough: StrikethroughFormatter(),
+        .link: LinkFormatter(),
+        .orderedlist: TextListFormatter(style: .ordered),
+        .unorderedlist: TextListFormatter(style: .unordered),
+        .blockquote: BlockquoteFormatter()
+    ]
 
     /// Get a list of format identifiers spanning the specified range as a String array.
     ///
@@ -276,36 +286,10 @@ open class TextView: UITextView {
 
         var identifiers = [FormattingIdentifier]()
 
-        if boldFormattingSpansRange(range) {
-            identifiers.append(.bold)
-        }
-
-        if italicFormattingSpansRange(range) {
-            identifiers.append(.italic)
-        }
-
-        if underlineFormattingSpansRange(range) {
-            identifiers.append(.underline)
-        }
-
-        if strikethroughFormattingSpansRange(range) {
-            identifiers.append(.strikethrough)
-        }
-
-        if linkFormattingSpansRange(range) {
-            identifiers.append(.link)
-        }
-
-        if orderedListFormattingSpansRange(range) {
-            identifiers.append(.orderedlist)
-        }
-
-        if unorderedListFormattingSpansRange(range) {
-            identifiers.append(.unorderedlist)
-        }
-
-        if blockquoteFormattingSpansRange(range) {
-            identifiers.append(.blockquote)
+        for (key, formatter) in formatterIdentifiersMap {
+            if formatter.present(in: storage, at: range) {
+                identifiers.append(key)
+            }
         }
 
         return identifiers
@@ -326,36 +310,10 @@ open class TextView: UITextView {
         let index = adjustedIndex(index)
         var identifiers = [FormattingIdentifier]()
 
-        if formattingAtIndexContainsBold(index) {
-            identifiers.append(.bold)
-        }
-
-        if formattingAtIndexContainsItalic(index) {
-            identifiers.append(.italic)
-        }
-
-        if formattingAtIndexContainsUnderline(index) {
-            identifiers.append(.underline)
-        }
-
-        if formattingAtIndexContainsStrikethrough(index) {
-            identifiers.append(.strikethrough)
-        }
-
-        if formattingAtIndexContainsBlockquote(index) {
-            identifiers.append(.blockquote)
-        }
-
-        if formattingAtIndexContainsLink(index) {
-            identifiers.append(.link)
-        }
-
-        if formattingAtIndexContainsOrderedList(index) {
-            identifiers.append(.orderedlist)
-        }
-
-        if formattingAtIndexContainsUnorderedList(index) {
-            identifiers.append(.unorderedlist)
+        for (key, formatter) in formatterIdentifiersMap {
+            if formatter.present(in: storage, at: index) {
+                identifiers.append(key)
+            }
         }
 
         return identifiers
@@ -369,36 +327,10 @@ open class TextView: UITextView {
     open func formatIdentifiersForTypingAttributes() -> [FormattingIdentifier] {
         var identifiers = [FormattingIdentifier]()
 
-        if typingAttributesContainsBold() {
-            identifiers.append(.bold)
-        }
-
-        if typingAttributesContainsItalic() {
-            identifiers.append(.italic)
-        }
-
-        if typingAttributesContainsUnderline() {
-            identifiers.append(.underline)
-        }
-
-        if typingAttributesContainsStrikethrough() {
-            identifiers.append(.strikethrough)
-        }
-
-        if typingAttributesContainsBlockquote() {
-            identifiers.append(.blockquote)
-        }
-
-        if typingAttributesContainsOrderedList() {
-            identifiers.append(.orderedlist)
-        }
-
-        if typingAttributesContainsUnorderedList() {
-            identifiers.append(.unorderedlist)
-        }
-
-        if typingAttributesContainsLink() {
-            identifiers.append(.link)
+        for (key, formatter) in formatterIdentifiersMap {
+            if formatter.present(in: typingAttributes) {
+                identifiers.append(key)
+            }
         }
 
         return identifiers
@@ -746,11 +678,6 @@ open class TextView: UITextView {
         print("video")
     }
 
-
-    // MARK: - Inspectors
-    // MARK: - Inspect Within Range
-
-
     /// Returns the associated TextAttachment, at a given point, if any.
     ///
     /// - Parameter point: The point on screen to check for attachments.
@@ -766,89 +693,7 @@ open class TextView: UITextView {
         return textStorage.attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil) as? TextAttachment
     }
 
-
-    /// Check if the bold attribute spans the specified range.
-    ///
-    /// - Parameter range: The NSRange to inspect.
-    ///
-    /// - Returns: True if the attribute spans the entire range.
-    ///
-    open func boldFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = BoldFormatter()
-        return formatter.present(in: storage, at: range)
-    }
-
-
-    /// Check if the italic attribute spans the specified range.
-    ///
-    /// - Parameter range: The NSRange to inspect.
-    ///
-    /// - Returns: True if the attribute spans the entire range.
-    ///
-    open func italicFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = ItalicFormatter()
-        return formatter.present(in: storage, at: range)
-    }
-
-
-    /// Check if the underline attribute spans the specified range.
-    ///
-    /// - Parameter range: The NSRange to inspect.
-    ///
-    /// - Returns: True if the attribute spans the entire range.
-    ///
-    open func underlineFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = UnderlineFormatter()        
-        return formatter.present(in: storage, at: range)
-    }
-
-
-    /// Check if the strikethrough attribute spans the specified range.
-    ///
-    /// - Parameter range: The NSRange to inspect.
-    ///
-    /// - Returns: True if the attribute spans the entire range.
-    ///
-    open func strikethroughFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = StrikethroughFormatter()
-        return formatter.present(in: storage, at: range)
-    }
-
-    /// Check if the link attribute spans the specified range.
-    ///
-    /// - Parameter range: The NSRange to inspect.
-    ///
-    /// - Returns: True if the attribute spans the entire range.
-    ///
-    open func linkFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = LinkFormatter()
-        return formatter.present(in: storage, at: range)
-    }
-
-
-    /// Check if an ordered list spans the specified range.
-    ///
-    /// - Parameter range: The NSRange to inspect.
-    ///
-    /// - Returns: True if the attribute spans the entire range.
-    ///
-    open func orderedListFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = TextListFormatter(style: .ordered)
-        return formatter.present(in: storage, at: range)
-    }
-
-
-    /// Check if an unordered list spans the specified range.
-    ///
-    /// - Parameter range: The NSRange to inspect.
-    ///
-    /// - Returns: True if the attribute spans the entire range.
-    ///
-    open func unorderedListFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = TextListFormatter(style: .unordered)
-        return formatter.present(in: storage, at: range)
-    }
-
+    // MARK: - Links
 
     /// Returns an NSURL if the specified range as attached a link attribute
     ///
@@ -885,18 +730,6 @@ open class TextView: UITextView {
         return nil
     }
 
-    /// Check if the blockquote attribute spans the specified range.
-    ///
-    /// - Parameter range: The NSRange to inspect.
-    ///
-    /// - Returns: True if the attribute spans the entire range.
-    ///
-    open func blockquoteFormattingSpansRange(_ range: NSRange) -> Bool {
-        let formatter = BlockquoteFormatter()
-        return formatter.present(in: storage, at: range)
-    }
-
-
     /// The maximum index should never exceed the length of the text storage minus one,
     /// else we court out of index exceptions.
     ///
@@ -912,7 +745,6 @@ open class TextView: UITextView {
         return index
     }
 
-
     /// In most instances, the value of NSRange.location is off by one when compared to a character index.
     /// Call this method to get an adjusted character index from an NSRange.location.
     ///
@@ -924,172 +756,6 @@ open class TextView: UITextView {
         let index = maxIndex(index)
         return max(0, index - 1)
     }
-
-    // MARK - Inspect at Index
-
-
-    /// Check if the bold attribute exists at the specified index.
-    ///
-    /// - Parameter index: The character index to inspect.
-    ///
-    /// - Returns: True if the attribute exists at the specified index.
-    ///
-    open func formattingAtIndexContainsBold(_ index: Int) -> Bool {
-        let formatter = BoldFormatter()
-        return formatter.present(in: storage, at: index)
-    }
-
-
-    /// Check if the italic attribute exists at the specified index.
-    ///
-    /// - Parameter index: The character index to inspect.
-    ///
-    /// - Returns: True if the attribute exists at the specified index.
-    ///
-    open func formattingAtIndexContainsItalic(_ index: Int) -> Bool {
-        let formatter = ItalicFormatter()
-        return formatter.present(in: storage, at: index)
-    }
-
-
-    /// Check if the underline attribute exists at the specified index.
-    ///
-    /// - Parameter index: The character index to inspect.
-    ///
-    /// - Returns: True if the attribute exists at the specified index.
-    ///
-    open func formattingAtIndexContainsUnderline(_ index: Int) -> Bool {
-        let formatter = UnderlineFormatter()
-        return formatter.present(in: storage, at: index)
-    }
-
-
-    /// Check if the strikethrough attribute exists at the specified index.
-    ///
-    /// - Parameter index: The character index to inspect.
-    ///
-    /// - Returns: True if the attribute exists at the specified index.
-    ///
-    open func formattingAtIndexContainsStrikethrough(_ index: Int) -> Bool {
-        let formatter = StrikethroughFormatter()
-        return formatter.present(in: storage, at: index)
-    }
-
-    /// Check if the link attribute exists at the specified index.
-    ///
-    /// - Parameter index: The character index to inspect.
-    ///
-    /// - Returns: True if the attribute exists at the specified index.
-    ///
-    open func formattingAtIndexContainsLink(_ index: Int) -> Bool {
-        let formatter = LinkFormatter()
-        return formatter.present(in: storage, at: index)
-    }
-
-    
-    /// Check if the blockquote attribute exists at the specified index.
-    ///
-    /// - Parameter index: The character index to inspect.
-    ///
-    /// - Returns: True if the attribute exists at the specified index.
-    ///
-    open func formattingAtIndexContainsBlockquote(_ index: Int) -> Bool {
-        let formatter = BlockquoteFormatter()
-        return formatter.present(in: textStorage, at: index)
-    }
-
-
-    /// Check if an ordered list exists at the specified index.
-    ///
-    /// - Paramters:
-    ///     - index: The character index to inspect.
-    ///
-    /// - Returns: True if the attribute exists at the specified index.
-    ///
-    open func formattingAtIndexContainsOrderedList(_ index: Int) -> Bool {
-        let formatter = TextListFormatter(style: .ordered)
-        return formatter.present(in: textStorage, at: index)
-    }
-
-
-    /// Check if an unordered list exists at the specified index.
-    ///
-    /// - Paramters:
-    ///     - index: The character index to inspect.
-    ///
-    /// - Returns: True if the attribute exists at the specified index.
-    ///
-    open func formattingAtIndexContainsUnorderedList(_ index: Int) -> Bool {
-        let formatter = TextListFormatter(style: .unordered)
-        return formatter.present(in: textStorage, at: index)
-    }
-
-
-    // MARK: - Inspect Typing Attributes
-
-
-    /// Checks if the next character entered by the user will be in Bold, or not.
-    ///
-    open func typingAttributesContainsBold() -> Bool {
-        let formatter = BoldFormatter()
-        return formatter.present(in: typingAttributes)
-    }
-
-
-    /// Checks if the next character entered by the user will be in Italic, or not.
-    ///
-    open func typingAttributesContainsItalic() -> Bool {
-        let formatter = ItalicFormatter()
-        return formatter.present(in: typingAttributes)
-    }
-
-
-    /// Checks if the next character that the user types will get Strikethrough Attribute, or not.
-    ///
-    open func typingAttributesContainsStrikethrough() -> Bool {
-        let formatter = StrikethroughFormatter()
-        return formatter.present(in: typingAttributes)
-    }
-
-
-    /// Checks if the next character that the user types will be underlined, or not.
-    ///
-    open func typingAttributesContainsUnderline() -> Bool {
-        let formatter = UnderlineFormatter()
-        return formatter.present(in: typingAttributes)
-    }
-
-
-    /// Checks if the next character that the user types will be formatted as Blockquote, or not.
-    ///
-    open func typingAttributesContainsBlockquote() -> Bool {
-        let formatter = BlockquoteFormatter()
-        return formatter.present(in: typingAttributes)
-    }
-
-
-    /// Checks if the next character that the user types will be formatted as an Ordered List, or not.
-    ///
-    open func typingAttributesContainsOrderedList() -> Bool {
-        let formatter = TextListFormatter(style: .ordered)
-        return formatter.present(in: typingAttributes)
-    }
-
-
-    /// Checks if the next character that the user types will be formatted as an Unordered List, or not.
-    ///
-    open func typingAttributesContainsUnorderedList() -> Bool {
-        let formatter = TextListFormatter(style: .unordered)
-        return formatter.present(in: typingAttributes)
-    }
-
-    /// Checks if the next character that the user types will be part of a link anchor, or not.
-    ///
-    open func typingAttributesContainsLink() -> Bool {
-        let formatter = LinkFormatter()
-        return formatter.present(in: typingAttributes)
-    }
-
 
     // MARK: - Attachments
 

--- a/AztecTests/AztecVisualEditorTests.swift
+++ b/AztecTests/AztecVisualEditorTests.swift
@@ -112,60 +112,60 @@ class AztecVisualEditorTests: XCTestCase {
         let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
         let range = NSRange(location: 3, length: 3)
 
-        XCTAssert(editor.boldFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.bold))
 
         editor.toggleBold(range: range)
 
-        XCTAssert(!editor.boldFormattingSpansRange(range))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(range).contains(.bold))
 
         editor.toggleBold(range: range)
 
-        XCTAssert(editor.boldFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.bold))
     }
 
     func testToggleItalic() {
         let editor = editorConfiguredForTesting(withHTML: "foo<i>bar</i>baz")
         let range = NSRange(location: 3, length: 3)
 
-        XCTAssert(editor.italicFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.italic))
 
         editor.toggleItalic(range: range)
 
-        XCTAssert(!editor.italicFormattingSpansRange(range))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(range).contains(.italic))
 
         editor.toggleItalic(range: range)
 
-        XCTAssert(editor.italicFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.italic))
     }
 
     func testToggleUnderline() {
         let editor = editorConfiguredForTesting(withHTML: "foo<u>bar</u>baz")
         let range = NSRange(location: 3, length: 3)
 
-        XCTAssert(editor.underlineFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.underline))
 
         editor.toggleUnderline(range: range)
 
-        XCTAssert(!editor.underlineFormattingSpansRange(range))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(range).contains(.underline))
 
         editor.toggleUnderline(range: range)
 
-        XCTAssert(editor.underlineFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.underline))
     }
 
     func testToggleStrike() {
         let editor = editorConfiguredForTesting(withHTML: "foo<strike>bar</strike>baz")
         let range = NSRange(location: 3, length: 3)
 
-        XCTAssert(editor.strikethroughFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.strikethrough))
 
         editor.toggleStrikethrough(range: range)
 
-        XCTAssert(!editor.strikethroughFormattingSpansRange(range))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(range).contains(.strikethrough))
 
         editor.toggleStrikethrough(range: range)
 
-        XCTAssert(editor.strikethroughFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.strikethrough))
     }
 
     func testToggleBlockquote() {
@@ -175,13 +175,13 @@ class AztecVisualEditorTests: XCTestCase {
 
         editor.toggleBlockquote(range: range)
 
-        XCTAssert(editor.formattingAtIndexContainsBlockquote(1))
-        XCTAssert(editor.blockquoteFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersAtIndex(1).contains(.blockquote))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.blockquote))
 
         editor.toggleBlockquote(range: range)
 
-        XCTAssert(!editor.formattingAtIndexContainsBlockquote(1))
-        XCTAssert(!editor.blockquoteFormattingSpansRange(range))
+        XCTAssert(!editor.formatIdentifiersAtIndex(1).contains(.blockquote))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(range).contains(.blockquote))
     }
 
     func testToggleOrderedList() {
@@ -191,13 +191,13 @@ class AztecVisualEditorTests: XCTestCase {
 
         editor.toggleOrderedList(range: range)
 
-        XCTAssert(editor.formattingAtIndexContainsOrderedList(0))
-        XCTAssert(editor.orderedListFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersAtIndex(0).contains(.orderedlist))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.orderedlist))
 
         editor.toggleOrderedList(range: range)
 
-        XCTAssert(!editor.formattingAtIndexContainsOrderedList(0))
-        XCTAssert(!editor.orderedListFormattingSpansRange(range))
+        XCTAssert(!editor.formatIdentifiersAtIndex(0).contains(.orderedlist))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(range).contains(.orderedlist))
     }
 
     func testToggleUnorderedList() {
@@ -207,59 +207,63 @@ class AztecVisualEditorTests: XCTestCase {
 
         editor.toggleUnorderedList(range: range)
 
-        XCTAssert(editor.formattingAtIndexContainsUnorderedList(0))
-        XCTAssert(editor.unorderedListFormattingSpansRange(range))
+        XCTAssert(editor.formatIdentifiersAtIndex(0).contains(.unorderedlist))
+        XCTAssert(editor.formatIdentifiersSpanningRange(range).contains(.unorderedlist))
 
         editor.toggleOrderedList(range: range)
 
-        XCTAssert(!editor.formattingAtIndexContainsUnorderedList(0))
-        XCTAssert(!editor.unorderedListFormattingSpansRange(range))
+        XCTAssert(!editor.formatIdentifiersAtIndex(0).contains(.unorderedlist))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(range).contains(.unorderedlist))
     }
 
     // MARK: - Test Attributes Exist
 
+    func check(editor: TextView, range:NSRange, forIndentifier identifier: FormattingIdentifier) -> Bool {
+        return editor.formatIdentifiersSpanningRange(range).contains(identifier)
+    }
+
     func testBoldSpansRange() {
         let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
 
-        XCTAssert(editor.boldFormattingSpansRange(NSRange(location: 3, length: 3)))
-        XCTAssert(editor.boldFormattingSpansRange(NSRange(location: 3, length: 2)))
-        XCTAssert(editor.boldFormattingSpansRange(NSRange(location: 3, length: 1)))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.bold))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.bold))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.bold))
 
-        XCTAssert(!editor.boldFormattingSpansRange(NSRange(location: 2, length: 3)))
-        XCTAssert(!editor.boldFormattingSpansRange(NSRange(location: 4, length: 3)))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.bold))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.bold))
     }
 
     func testItalicSpansRange() {
         let editor = editorConfiguredForTesting(withHTML: "foo<i>bar</i>baz")
 
-        XCTAssert(editor.italicFormattingSpansRange(NSRange(location: 3, length: 3)))
-        XCTAssert(editor.italicFormattingSpansRange(NSRange(location: 3, length: 2)))
-        XCTAssert(editor.italicFormattingSpansRange(NSRange(location: 3, length: 1)))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.italic))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.italic))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.italic))
 
-        XCTAssert(!editor.italicFormattingSpansRange(NSRange(location: 2, length: 3)))
-        XCTAssert(!editor.italicFormattingSpansRange(NSRange(location: 4, length: 3)))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.italic))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.italic))
     }
 
     func testUnderlineSpansRange() {
         let editor = editorConfiguredForTesting(withHTML: "foo<u>bar</u>baz")
 
-        XCTAssert(editor.underlineFormattingSpansRange(NSRange(location: 3, length: 3)))
-        XCTAssert(editor.underlineFormattingSpansRange(NSRange(location: 3, length: 2)))
-        XCTAssert(editor.underlineFormattingSpansRange(NSRange(location: 3, length: 1)))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.underline))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.underline))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.underline))
 
-        XCTAssert(!editor.underlineFormattingSpansRange(NSRange(location: 2, length: 3)))
-        XCTAssert(!editor.underlineFormattingSpansRange(NSRange(location: 4, length: 3)))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.underline))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.underline))
     }
 
     func testStrikethroughSpansRange() {
         let editor = editorConfiguredForTesting(withHTML: "foo<strike>bar</strike>baz")
 
-        XCTAssert(editor.strikethroughFormattingSpansRange(NSRange(location: 3, length: 3)))
-        XCTAssert(editor.strikethroughFormattingSpansRange(NSRange(location: 3, length: 2)))
-        XCTAssert(editor.strikethroughFormattingSpansRange(NSRange(location: 3, length: 1)))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.strikethrough))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.strikethrough))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.strikethrough))
 
-        XCTAssert(!editor.strikethroughFormattingSpansRange(NSRange(location: 2, length: 3)))
-        XCTAssert(!editor.strikethroughFormattingSpansRange(NSRange(location: 4, length: 3)))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.strikethrough))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.strikethrough))
     }
 
     func testBlockquoteSpansRange() {
@@ -269,68 +273,68 @@ class AztecVisualEditorTests: XCTestCase {
 
         editor.toggleBlockquote(range: range)
 
-        XCTAssert(editor.blockquoteFormattingSpansRange(NSRange(location: 0, length: length)))
-        XCTAssert(!editor.blockquoteFormattingSpansRange(NSRange(location: 0, length: length + 1)))
-        XCTAssert(!editor.blockquoteFormattingSpansRange(NSRange(location: 1, length: length)))
+        XCTAssert(editor.formatIdentifiersSpanningRange(NSRange(location: 0, length: length)).contains(.blockquote))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 0, length: length + 1)).contains(.blockquote))
+        XCTAssert(!editor.formatIdentifiersSpanningRange(NSRange(location: 1, length: length)).contains(.blockquote))
     }
 
     func testBoldAtIndex() {
         let editor = editorConfiguredForTesting(withHTML: "foo<b>bar</b>baz")
 
-        XCTAssert(editor.formattingAtIndexContainsBold(3))
-        XCTAssert(editor.formattingAtIndexContainsBold(4))
-        XCTAssert(editor.formattingAtIndexContainsBold(5))
+        XCTAssert(editor.formatIdentifiersAtIndex(4).contains(.bold))
+        XCTAssert(editor.formatIdentifiersAtIndex(5).contains(.bold))
+        XCTAssert(editor.formatIdentifiersAtIndex(6).contains(.bold))
 
-        XCTAssert(!editor.formattingAtIndexContainsBold(2))
-        XCTAssert(!editor.formattingAtIndexContainsBold(6))
+        XCTAssert(!editor.formatIdentifiersAtIndex(2).contains(.bold))
+        XCTAssert(!editor.formatIdentifiersAtIndex(7).contains(.bold))
     }
 
     func testItalicAtIndex() {
         let editor = editorConfiguredForTesting(withHTML: "foo<i>bar</i>baz")
 
-        XCTAssert(editor.formattingAtIndexContainsItalic(3))
-        XCTAssert(editor.formattingAtIndexContainsItalic(4))
-        XCTAssert(editor.formattingAtIndexContainsItalic(5))
+        XCTAssert(editor.formatIdentifiersAtIndex(4).contains(.italic))
+        XCTAssert(editor.formatIdentifiersAtIndex(5).contains(.italic))
+        XCTAssert(editor.formatIdentifiersAtIndex(6).contains(.italic))
 
-        XCTAssert(!editor.formattingAtIndexContainsItalic(2))
-        XCTAssert(!editor.formattingAtIndexContainsItalic(6))
+        XCTAssert(!editor.formatIdentifiersAtIndex(2).contains(.italic))
+        XCTAssert(!editor.formatIdentifiersAtIndex(7).contains(.italic))
     }
 
     func testUnderlineAtIndex() {
         let editor = editorConfiguredForTesting(withHTML: "foo<u>bar</u>baz")
 
-        XCTAssert(editor.formattingAtIndexContainsUnderline(3))
-        XCTAssert(editor.formattingAtIndexContainsUnderline(4))
-        XCTAssert(editor.formattingAtIndexContainsUnderline(5))
+        XCTAssert(editor.formatIdentifiersAtIndex(4).contains(.underline))
+        XCTAssert(editor.formatIdentifiersAtIndex(5).contains(.underline))
+        XCTAssert(editor.formatIdentifiersAtIndex(6).contains(.underline))
 
-        XCTAssert(!editor.formattingAtIndexContainsUnderline(2))
-        XCTAssert(!editor.formattingAtIndexContainsUnderline(6))
+        XCTAssert(!editor.formatIdentifiersAtIndex(2).contains(.underline))
+        XCTAssert(!editor.formatIdentifiersAtIndex(7).contains(.underline))
     }
 
     func testStrikethroughAtIndex() {
         let editor = editorConfiguredForTesting(withHTML: "foo<strike>bar</strike>baz")
 
-        XCTAssert(editor.formattingAtIndexContainsStrikethrough(3))
-        XCTAssert(editor.formattingAtIndexContainsStrikethrough(4))
-        XCTAssert(editor.formattingAtIndexContainsStrikethrough(5))
+        XCTAssert(editor.formatIdentifiersAtIndex(4).contains(.strikethrough))
+        XCTAssert(editor.formatIdentifiersAtIndex(5).contains(.strikethrough))
+        XCTAssert(editor.formatIdentifiersAtIndex(6).contains(.strikethrough))
 
-        XCTAssert(!editor.formattingAtIndexContainsStrikethrough(2))
-        XCTAssert(!editor.formattingAtIndexContainsStrikethrough(6))
+        XCTAssert(!editor.formatIdentifiersAtIndex(2).contains(.strikethrough))
+        XCTAssert(!editor.formatIdentifiersAtIndex(7).contains(.strikethrough))
     }
 
     func testBlockquoteAtIndex() {
         let editor = editorConfiguredWithParagraphs()
         let range = NSRange(location: 0, length: 1)
 
-        XCTAssert(!editor.formattingAtIndexContainsBlockquote(1))
+        XCTAssert(!editor.formatIdentifiersAtIndex(1).contains(.blockquote))
 
         editor.toggleBlockquote(range: range)
 
-        XCTAssert(editor.formattingAtIndexContainsBlockquote(1))
+        XCTAssert(editor.formatIdentifiersAtIndex(1).contains(.blockquote))
 
         editor.toggleBlockquote(range: range)
 
-        XCTAssert(!editor.formattingAtIndexContainsBlockquote(1))
+        XCTAssert(!editor.formatIdentifiersAtIndex(1).contains(.blockquote))
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Instead of using multiple methods to check for formatters active, this PR switch the approach to use a data driven approach where the mapping of formatters and typing attributes is done using a dictionary.

How to test:
 - Start the demo app
 - Navigate around and see if the toolbar is updated correctly.
 - Apply style to new ranges and location and see if the toolbar updates correctly.