### PR TITLE
Add property to see if formatter can be applied to empty range.

### DIFF
--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -53,6 +53,8 @@ protocol AttributeFormatter {
     func present(in attributes: [String: Any]) -> Bool
 
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange
+
+    func worksInEmtpyRange() -> Bool
 }
 
 
@@ -183,6 +185,10 @@ extension CharacterAttributeFormatter {
 
         return range
     }
+
+    func worksInEmtpyRange() -> Bool {
+        return false
+    }
 }
 
 
@@ -230,5 +236,9 @@ extension ParagraphAttributeFormatter {
         }
 
         return newSelectedRange
+    }
+
+    func worksInEmtpyRange() -> Bool {
+        return true
     }
 }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -225,6 +225,9 @@ open class TextStorage: NSTextStorage {
     // MARK: - Styles: Toggling
     @discardableResult func toggle(formatter: AttributeFormatter, at range: NSRange) -> NSRange? {
         let applicationRange = formatter.applicationRange(for: range, in: self)
+        if applicationRange.length == 0, !formatter.worksInEmtpyRange() {
+            return applicationRange
+        }
         let newSelectedRange = formatter.toggle(in: self, at: applicationRange)
         if !formatter.present(in: self, at: applicationRange.location) {
             dom.remove(element:formatter.elementType, at: applicationRange)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -408,7 +408,7 @@ open class TextView: UITextView {
     // MARK: - Formatting
 
     func toggle(formatter: AttributeFormatter, atRange range: NSRange) {
-        let newSelectedRange = storage.toggle(formatter: formatter, at: range)
+        let newSelectedRange = storage.toggle(formatter: formatter, at: range)         
         selectedRange = newSelectedRange ?? selectedRange
         if selectedRange.length == 0 {
             typingAttributes = formatter.toggle(in: typingAttributes)


### PR DESCRIPTION
This fix a crash when trying to apply one of the character attributes (bold, italic, ...) to an empty string.
The fix consist on adding back a test for the application range but with using an extra check to see if the formatter allows it. Paragraph Formatters normally allow it because they will add an empty/invisile string.

How to test:
 - Start the demo app using the empty option
 - Immediately apply one of the character attributes (bold, italic, ..) and see if the app doesn't crash
 - Do the same but now with paragraph attributes (blockquote, lists) and see if the app doesn't crash and the attributes are applied (marker on lists, background on block quotes)