### PR TITLE
Fixing Insert Link Crash

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -700,36 +700,47 @@ open class TextView: UITextView {
     ///
     /// - Parameter range: The NSRange to inspect
     ///
-    /// - Returns: the NSURL if available
+    /// - Returns: The NSURL if available
     ///
     open func linkURL(forRange range: NSRange) -> URL? {
         let index = maxIndex(range.location)
         var effectiveRange = NSRange()
-        if let attr = storage.attribute(NSLinkAttributeName, at: index, effectiveRange: &effectiveRange) {
-            if let url = attr as? URL {
-                return url
-            } else if let urlString = attr as? String {
-                return URL(string:urlString)
-            }
+        guard index > storage.length,
+            let attr = storage.attribute(NSLinkAttributeName, at: index, effectiveRange: &effectiveRange)
+            else {
+                return nil
         }
+
+        if let url = attr as? URL {
+            return url
+        }
+
+        if let urlString = attr as? String {
+            return URL(string:urlString)
+        }
+
         return nil
     }
 
 
-    /// Returns the entire range covered by the link to be found in the (potentially partial) specified range.
+    /// Returns the Link Attribute's Full Range, intersecting the specified range.
     ///
     /// - Parameter range: The NSRange to inspect
     ///
-    /// - Returns: The full Range required by the link.
+    /// - Returns: The full Link's Range.
     ///
     open func linkFullRange(forRange range: NSRange) -> NSRange? {
         let index = maxIndex(range.location)
         var effectiveRange = NSRange()
-        if storage.attribute(NSLinkAttributeName, at: index, effectiveRange: &effectiveRange) != nil {
-            return effectiveRange
+        guard index > storage.length,
+            storage.attribute(NSLinkAttributeName, at: index, effectiveRange: &effectiveRange) != nil
+            else {
+                return nil
         }
-        return nil
+
+        return effectiveRange
     }
+
 
     /// The maximum index should never exceed the length of the text storage minus one,
     /// else we court out of index exceptions.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -705,7 +705,7 @@ open class TextView: UITextView {
     open func linkURL(forRange range: NSRange) -> URL? {
         let index = maxIndex(range.location)
         var effectiveRange = NSRange()
-        guard index > storage.length,
+        guard index < storage.length,
             let attr = storage.attribute(NSLinkAttributeName, at: index, effectiveRange: &effectiveRange)
             else {
                 return nil
@@ -732,7 +732,7 @@ open class TextView: UITextView {
     open func linkFullRange(forRange range: NSRange) -> NSRange? {
         let index = maxIndex(range.location)
         var effectiveRange = NSRange()
-        guard index > storage.length,
+        guard index < storage.length,
             storage.attribute(NSLinkAttributeName, at: index, effectiveRange: &effectiveRange) != nil
             else {
                 return nil

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -751,7 +751,7 @@ open class TextView: UITextView {
     ///
     func maxIndex(_ index: Int) -> Int {
         if index >= storage.length {
-            return storage.length - 1
+            return max(storage.length - 1, 0)
         }
 
         return index


### PR DESCRIPTION
### Testing:
1. Launch the Aztec Empty Editor
2. Hit the **Insert Link** button
3. Verify that the app doesn't crash anymore
4. Run the Unit Tests and verify that nothing breaks

Needs Review: @SergioEstevao 
Thanks in advance!!
