### PR TITLE
Fix some issues around attachment

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -192,7 +192,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
                 url = nil
             }
 
-            let attachment = TextAttachment(url: url)
+            let attachment = TextAttachment(identifier: UUID().uuidString, url: url)
 
             if let elementClass = node.valueForStringAttribute(named: "class") {
                 let classAttributes = elementClass.components(separatedBy: " ")

--- a/Aztec/Classes/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/TextKit/TextAttachment.swift
@@ -73,7 +73,7 @@ open class TextAttachment: NSTextAttachment
     ///
     /// - returns: self, initilized with the identifier a with kind = .MissingImage
     ///
-    required public init(identifier: String = UUID().uuidString, url: URL? = nil) {
+    required public init(identifier: String, url: URL? = nil) {
         self.identifier = identifier
         self.url = url
         

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -278,10 +278,10 @@ open class TextStorage: NSTextStorage {
     /// - parameter position: the position to insert the image
     /// - parameter placeHolderImage: an image to display while the image from sourceURL is being prepared
     ///
-    /// - returns: the identifier of the image
+    /// - returns: the attachment object that was created and inserted on the text
     ///
-    func insertImage(sourceURL url: URL, atPosition position:Int, placeHolderImage: UIImage) -> String {
-        let attachment = TextAttachment()
+    func insertImage(sourceURL url: URL, atPosition position:Int, placeHolderImage: UIImage, identifier: String = UUID().uuidString) -> TextAttachment {
+        let attachment = TextAttachment(identifier: identifier)
         attachment.imageProvider = self
         attachment.url = url
         attachment.image = placeHolderImage
@@ -291,7 +291,7 @@ open class TextStorage: NSTextStorage {
         let attachmentString = NSAttributedString(attachment: attachment)
         replaceCharacters(in: insertionRange, with: attachmentString)
 
-        return attachment.identifier
+        return attachment
     }
 
     // MARK: - Attachments

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -21,7 +21,16 @@ public protocol TextViewMediaDelegate: class {
         imageAtUrl imageURL: URL,
         onSuccess success: @escaping (UIImage) -> Void,
         onFailure failure: @escaping (Void) -> Void) -> UIImage
-    
+
+    /// Called when an image is about to be added to the storage as an attachment (copy/paste), so that the
+    /// delegate can specify an URL where that image is available.
+    ///
+    /// - Parameters:
+    ///     - textView: The textView that is requesting the image.
+    ///     - image: The image that was added to the storage.
+    ///
+    /// - Returns: the requested `NSURL` where the image is stored.
+    ///
     func textView(
         _ textView: TextView,
         urlForImage image: UIImage) -> URL
@@ -650,13 +659,13 @@ open class TextView: UITextView {
     ///     - sourceURL: The url of the image to be inserted.
     ///     - position: The character index at which to insert the image.
     ///
-    /// - Returns: an id of the attachment that can be used for further calls
+    /// - Returns: the attachment object that can be used for further calls
     ///
-    open func insertImage(sourceURL url: URL, atPosition position: Int, placeHolderImage: UIImage?) -> String {
-        let imageId = storage.insertImage(sourceURL: url, atPosition: position, placeHolderImage: placeHolderImage ?? defaultMissingImage)
+    open func insertImage(sourceURL url: URL, atPosition position: Int, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> TextAttachment {
+        let attachment = storage.insertImage(sourceURL: url, atPosition: position, placeHolderImage: placeHolderImage ?? defaultMissingImage, identifier: identifier)
         let length = NSAttributedString(attachment:NSTextAttachment()).length
         selectedRange = NSMakeRange(position+length, 0)
-        return imageId
+        return attachment
     }
 
 
@@ -779,9 +788,9 @@ open class TextView: UITextView {
     /// - parameter url:        the attachment url
     ///
     open func update(attachment: TextAttachment,
-                                  alignment: TextAttachment.Alignment,
-                                  size: TextAttachment.Size,
-                                  url: URL) {
+                     alignment: TextAttachment.Alignment,
+                     size: TextAttachment.Size,
+                     url: URL) {
         storage.update(attachment: attachment, alignment: alignment, size: size, url: url)
         layoutManager.invalidateLayoutForAttachment(attachment)
     }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -622,8 +622,9 @@ private extension EditorDemoController
         let index = richTextView.positionForCursor()
         let fileURL = saveToDisk(image: image)
         
-        let imageId = richTextView.insertImage(sourceURL: fileURL, atPosition: index, placeHolderImage: image)
-        let progress = Progress(parent: nil, userInfo: ["imageID": imageId])
+        let attachment = richTextView.insertImage(sourceURL: fileURL, atPosition: index, placeHolderImage: image)
+        let imageID = attachment.identifier
+        let progress = Progress(parent: nil, userInfo: ["imageID": imageID])
         progress.totalUnitCount = 100
         
         Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(EditorDemoController.timerFireMethod(_:)), userInfo: progress, repeats: true)
@@ -631,11 +632,11 @@ private extension EditorDemoController
 
     @objc func timerFireMethod(_ timer: Timer) {
         guard let progress = timer.userInfo as? Progress,
-            let imageId = progress.userInfo[ProgressUserInfoKey("imageID")] as? String else {
+            let imageId = progress.userInfo[ProgressUserInfoKey("imageID")] as? String
+        else {
                 
             return
-        }
-        
+        }        
         progress.completedUnitCount += 1
         if let attachment = richTextView.attachment(withId: imageId) {            
             richTextView.update(attachment: attachment, progress: progress.fractionCompleted, progressColor: UIColor.blue)


### PR DESCRIPTION
This PR make the definition of the attachment id explicit in order to make it easier to interact and to fix a bug in Swift where the init() method of the base object was being called instead of the Swift init.

It also change a the interface of insertImage to return the attachment object instead of the ID. This is to avoid callbacks to return the attachment.

How to test:

 - Launch the demo app
 - Check if images are loaded
 - Check if images that are inserted load ok.