### PR TITLE
Fixes a crashing bug.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1137,6 +1137,13 @@ extension Libxml2 {
 
             guard blockLevelElementsAndIntersections.count != 0 else {
                 if location == 0 {
+                    // It's not great having to set empty text and then append text to it.  The reason
+                    // we're doing it here is that if the text contains line-breaks, they will only
+                    // be processed as BR tags if the text is set after construction.
+                    //
+                    // This code can be improved but this "hack" will allow us to postpone the necessary
+                    // code restructuration.
+                    //
                     let textNode = TextNode(text: "", editContext: editContext)
                     append(textNode)
                     textNode.append(string)

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1134,9 +1134,17 @@ extension Libxml2 {
         func insert(_ string: String, atLocation location: Int) {
 
             let blockLevelElementsAndIntersections = lowestBlockLevelElements(intersectingRange: NSRange(location: location, length: 0))
-            
-            guard blockLevelElementsAndIntersections.count > 0 else {
-                fatalError("We should have exactly one block-level element here.")
+
+            guard blockLevelElementsAndIntersections.count != 0 else {
+                if location == 0 {
+                    let textNode = TextNode(text: "", editContext: editContext)
+                    append(textNode)
+                    textNode.append(string)
+                } else {
+                    fatalError("If there are no child nodes, the insert location has to be zero.")
+                }
+
+                return
             }
 
             let element = blockLevelElementsAndIntersections[0].element


### PR DESCRIPTION
**Description:**

Fixes a problem that was causing the editor to crash after inserting an image, removing it, and typing some text.

Fixes #236.

**How to verify:**

1. Launch the empty editor demo.
2. Insert an image.
3. Remove it.
4. Type anything.  The demo should not crash.

**Known issues:**

After following the testing steps, the font is smaller for some reason.  I'm planning to fix this separately since it may be related to other issues I'm dealing with.