### PR TITLE
Fixes a crashing bug when combining styles.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -919,7 +919,7 @@ extension Libxml2 {
         ///
         /// The result is that the order of the receiver and its parent node will be inverted.
         ///
-        func pushUp() {
+        func pushUp(left: Bool) {
             guard let parent = parent, let grandParent = parent.parent else {
                 // This is actually an error scenario, as this method should not be called on
                 // nodes that don't have a parent and a grandparent.
@@ -942,7 +942,9 @@ extension Libxml2 {
             let parentDescriptor = ElementNodeDescriptor(name: parent.name, attributes: parent.attributes)
             wrap(children: children, inElement: parentDescriptor)
 
-            grandParent.insert(self, at: parentIndex)
+            let indexOffset = left ? 0 : 1
+
+            grandParent.insert(self, at: parentIndex + indexOffset)
 
             if originalParent.children.count == 0 {
                 originalParent.removeFromParent()
@@ -1008,8 +1010,13 @@ extension Libxml2 {
                 return nil
             }
 
-            while element.parent != nil && element.parent != self {
-                element.pushUp()
+            guard let finalParent = parent else {
+                assertionFailure("Cannot call this method on a node that doesn't have a parent.")
+                return nil
+            }
+
+            while element.parent != nil && element.parent != finalParent {
+                element.pushUp(left: true)
             }
             
             return node
@@ -1074,8 +1081,13 @@ extension Libxml2 {
                 return nil
             }
 
-            while element.parent != nil && element.parent != self {
-                element.pushUp()
+            guard let finalParent = parent else {
+                assertionFailure("Cannot call this method on a node that doesn't have a parent.")
+                return nil
+            }
+
+            while element.parent != nil && element.parent != finalParent {
+                element.pushUp(left: false)
             }
 
             return node

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -163,7 +163,7 @@ open class TextStorage: NSTextStorage {
             
             finalString.addAttribute(NSAttachmentAttributeName, value: replacementAttachment, range: range)
         }
-        
+
         return finalString
     }
 
@@ -216,11 +216,11 @@ open class TextStorage: NSTextStorage {
 
     override open func setAttributes(_ attrs: [String : Any]?, range: NSRange) {
         beginEditing()
+
         textStore.setAttributes(attrs, range: range)
         edited(.editedAttributes, range: range, changeInLength: 0)
         
-        if let domRange = map(visualRange: range),
-            mustUpdateDOM() {
+        if let domRange = map(visualRange: range), mustUpdateDOM() {
             dom.setAttributes(attrs, range: domRange)
         }
         

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -139,7 +139,7 @@ open class TextView: UITextView {
 
 
     // MARK: - Intersect keyboard operations
-/*
+
     open override func insertText(_ text: String) {
         // Note:
         // Whenever the entered text causes the Paragraph Attributes to be removed, we should prevent the actual
@@ -155,7 +155,7 @@ open class TextView: UITextView {
 
         super.insertText(text)
         ensureCursorRedraw(afterEditing: text)
-    }*/
+    }
 
     open override func deleteBackward() {
         var deletionRange = selectedRange

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -139,7 +139,7 @@ open class TextView: UITextView {
 
 
     // MARK: - Intersect keyboard operations
-
+/*
     open override func insertText(_ text: String) {
         // Note:
         // Whenever the entered text causes the Paragraph Attributes to be removed, we should prevent the actual
@@ -155,7 +155,7 @@ open class TextView: UITextView {
 
         super.insertText(text)
         ensureCursorRedraw(afterEditing: text)
-    }
+    }*/
 
     open override func deleteBackward() {
         var deletionRange = selectedRange

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1535,7 +1535,7 @@ class ElementNodeTests: XCTestCase {
         
         let result = strike.pushUp(leftSideDescendantEvaluatedBy: { node -> Bool in
             return node.name == "b"
-            })
+        })
         
         XCTAssertEqual(paragraph.children.count, 2)
         
@@ -1589,7 +1589,7 @@ class ElementNodeTests: XCTestCase {
     ///
     /// Push the node named "b" up to the level of the "strike" node.
     ///
-    /// Input HTML: `<p><strike>Hello <b>there!</b><strike></p>`
+    /// Input HTML: `<p><strike>Hello <b>there!</b></strike></p>`
     /// - Evaluation criteria: node.name == "b"
     ///
     /// Expected results:


### PR DESCRIPTION
<h3>Description:</h3>

This PR fixes a crashing bug that was triggered under certain conditions, when applying combined styles in a text run.

I also took the chance to eliminate some code redundancy and to improve readability.

Fixes #240.

<h3>Testing:</h3>

**Test 1:**

Run the unit tests.

**Test 2:**

This test is taken from issue #240 .

- Launch the empty editor
- Type <strong>a<em>a<strike>a</strike></em></strong> (first is bold, second adds italic, third adds strikethrough)
- Swith to HTML Mode.
- Ensure the app doesn't crash (styles can be oddly organized, though).