### PR TITLE
Improves readability, fixes a bug.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1546,10 +1546,17 @@ extension Libxml2 {
                 //
                 return
             }
-            
+
             let firstChild = childNodesAndRanges[0].child
             let firstChildIntersection = childNodesAndRanges[0].intersection
-            
+
+            if childNodesAndRanges.count == 1,
+                let elementNode = firstChild as? ElementNode {
+
+                elementNode.forceWrapChildren(intersectingRange: firstChildIntersection, inElement: elementDescriptor)
+                return
+            }
+
             if let firstEditableChild = firstChild as? EditableNode, !NSEqualRanges(firstChild.range(), firstChildIntersection) {
                 firstEditableChild.split(forRange: firstChildIntersection)
             }
@@ -1580,18 +1587,18 @@ extension Libxml2 {
         /// - Returns: the newly created `ElementNode`.
         ///
         @discardableResult
-        func wrap(children newChildren: [Node], inElement elementDescriptor: ElementNodeDescriptor) -> ElementNode {
+        func wrap(children selectedChildren: [Node], inElement elementDescriptor: ElementNodeDescriptor) -> ElementNode {
 
-            guard newChildren.count > 0 else {
+            guard selectedChildren.count > 0 else {
                 assertionFailure("Avoid calling this method with no nodes.")
                 return ElementNode(descriptor: elementDescriptor, editContext: editContext)
             }
 
-            guard let firstNodeIndex = children.index(of: newChildren[0]) else {
+            guard let firstNodeIndex = children.index(of: selectedChildren[0]) else {
                 fatalError("A node's parent should contain the node. Review the child/parent updating logic.")
             }
             
-            guard let lastNodeIndex = children.index(of: newChildren[newChildren.count - 1]) else {
+            guard let lastNodeIndex = children.index(of: selectedChildren[selectedChildren.count - 1]) else {
                 fatalError("A node's parent should contain the node. Review the child/parent updating logic.")
             }
             
@@ -1609,7 +1616,7 @@ extension Libxml2 {
             let rightSibling = pushUp(siblingOrDescendantAtRightSideOf: lastNodeIndex, evaluatedBy: evaluation, bailIf: bailEvaluation)
             let leftSibling = pushUp(siblingOrDescendantAtLeftSideOf: firstNodeIndex, evaluatedBy: evaluation, bailIf: bailEvaluation)
 
-            var childrenToWrap = newChildren
+            var childrenToWrap = selectedChildren
             var result: ElementNode?
             
             if let sibling = rightSibling {

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -831,7 +831,7 @@ class ElementNodeTests: XCTestCase {
     /// HTML String: <div><em>Hello </em>there!</div>
     /// Wrap range: (0...6)
     ///
-    /// The result should be: <div><em><b>Hello </b></em>there!</div>
+    /// The result should be: <div><b><em>Hello </em></b>there!</div>
     ///
     func testWrapChildrenInNewBNode1() {
 
@@ -851,21 +851,21 @@ class ElementNodeTests: XCTestCase {
 
         XCTAssertEqual(div.children.count, 2)
         XCTAssertEqual(div.children[1], textNode2)
-        
-        guard let newBoldNode = div.children[0] as? ElementNode, newBoldNode.name == boldElementType.rawValue else {
-                XCTFail("Expected a bold node here.")
-                return
-        }
-        
-        XCTAssertEqual(newBoldNode.children.count, 1)
 
-        guard let newEmNode = newBoldNode.children[0] as? ElementNode, newEmNode.name == em.name else {
+        guard let newEmNode = div.children[0] as? ElementNode, newEmNode.name == em.name else {
             XCTFail("Expected an em node here.")
             return
         }
 
         XCTAssertEqual(newEmNode.children.count, 1)
-        XCTAssertEqual(newEmNode.children[0], textNode1)
+        
+        guard let newBoldNode = newEmNode.children[0] as? ElementNode, newBoldNode.name == boldElementType.rawValue else {
+                XCTFail("Expected a bold node here.")
+                return
+        }
+        
+        XCTAssertEqual(newBoldNode.children.count, 1)
+        XCTAssertEqual(newBoldNode.children[0], textNode1)
     }
 
 


### PR DESCRIPTION
<h3>Description</h3>

Fixes a problem that was causing HTML to become excessively fragmented when applying styles.

Fixes #242.

<h3>Testing:</h3>

**Test 1:**

1. Run an empty editor.
2. Apply any two styles simultaneously and type: 123
3. Switch to HTML mode and make sure there's almost no HTML fragmentation.

**Test 2:**

1. Run the empty editor
2. Apply styles and write anything you want, randomly.
3. Switch to HTML mode and make sure the HTML has little if any fragmentation.

PS: for all tests keep in mind HTML node fragmentation can still exist in Aztec.  This PR only reduces some very noticeable fragmentation issues we were having.