### PR TITLE
Apply the typing attributes to the image range.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -664,6 +664,7 @@ open class TextView: UITextView {
     open func insertImage(sourceURL url: URL, atPosition position: Int, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> TextAttachment {
         let attachment = storage.insertImage(sourceURL: url, atPosition: position, placeHolderImage: placeHolderImage ?? defaultMissingImage, identifier: identifier)
         let length = NSAttributedString(attachment:NSTextAttachment()).length
+        textStorage.addAttributes(typingAttributes, range: NSMakeRange(position, length))
         selectedRange = NSMakeRange(position+length, 0)
         return attachment
     }


### PR DESCRIPTION
This PR fix the issue that after inserting an image to the AztecTextView the style are not followed up after the image.

How to Test:

- On the editor
- Insert the image on a location where styling exists, like bold or italic.
- See if the style continues after the image.