### PR TITLE
Add callback to storage notify when attachments are removed.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -34,6 +34,14 @@ public protocol TextViewMediaDelegate: class {
     func textView(
         _ textView: TextView,
         urlForImage image: UIImage) -> URL
+
+
+    /// Called when a attachment is removed from the storage.
+    ///
+    /// - Parameters:
+    ///   - textView: The textView where the attachment was removed.
+    ///   - attachmentID: The attachment identifier of the media removed.
+    func textView(_ textView: TextView, deletedAttachmentWithID attachmentID: String);
 }
 
 open class TextView: UITextView {
@@ -850,5 +858,9 @@ extension TextView: TextStorageAttachmentsDelegate {
         }
         
         return mediaDelegate.textView(self, urlForImage: image)
+    }
+
+    func storage(_ storage: TextStorage, deletedAttachmentWithID attachmentID: String) {
+        mediaDelegate?.textView(self, deletedAttachmentWithID: attachmentID)
     }
 }

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -79,4 +79,37 @@ class TextStorageTests: XCTestCase
         // Confirm the trait was restored
         XCTAssert(storage.fontTrait(.traitBold, spansRange: range))
     }
+
+    func testDelegateCallbackWhenAttachmentRemoved() {
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+
+        let attachment = storage.insertImage(sourceURL: URL(string:"test://")!, atPosition: 0, placeHolderImage: UIImage())
+
+        storage.replaceCharacters(in: NSRange(location: 0, length: 1) , with: NSAttributedString(string:""))
+
+        XCTAssertTrue(mockDelegate.deletedAttachmendIDCalledWithString == attachment.identifier)
+    }
+
+    class MockAttachmentsDelegate: TextStorageAttachmentsDelegate {
+
+        var deletedAttachmendIDCalledWithString: String?
+
+        func storage(_ storage: TextStorage, deletedAttachmentWithID attachmentID: String) {
+            deletedAttachmendIDCalledWithString = attachmentID
+        }
+
+        func storage(_ storage: TextStorage, urlForImage image: UIImage) -> URL {
+            return URL(string:"test://")!
+        }
+
+        func storage(_ storage: TextStorage, missingImageForAttachment: TextAttachment) -> UIImage {
+            return UIImage()
+        }
+
+        func storage(_ storage: TextStorage, attachment: TextAttachment, imageForURL url: URL, onSuccess success: @escaping (UIImage) -> (), onFailure failure: @escaping () -> ()) -> UIImage {
+            return UIImage()
+        }
+    }
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -574,6 +574,10 @@ extension EditorDemoController: TextViewMediaDelegate
         
         return saveToDisk(image: image)
     }
+
+    func textView(_ textView: TextView, deletedAttachmentWithID attachmentID: String) {
+        print("Attachment \(attachmentID) removed.\n")
+    }
 }
 
 


### PR DESCRIPTION
This PR adds new callback to the TextView and TextStorage attachments delegates in order to report that attachments are removed.

This is to allow things like cancelation of attachment upload to server.

How to test:
 - Start the demo app
 - Insert an image on the post
 - Remove the image using the delete on the keyboard.
 - check if a callback message is printed on the console saying: "Attachment XXXX removed."