### PR TITLE
Add option to remove attachment trough code.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -359,6 +359,21 @@ open class TextStorage: NSTextStorage {
         dom.updateImage(spanning: rangesForAttachment, url: url, size: size, alignment: alignment)
     }
 
+    /// Removes the attachments that match the attachament identifier provided from the storage
+    ///
+    /// - Parameter attachmentID: the unique id of the attachment
+    ///
+    open func remove(attachmentID: String) {
+        enumerateAttachmentsOfType(TextAttachment.self) { (attachment, range, stop) in
+            if attachment.identifier == attachmentID {
+                self.replaceCharacters(in: range, with: NSAttributedString(string: ""))
+                stop.pointee = true
+            }
+        }
+    }
+
+    // MARK: - Toggle Attributes
+
     fileprivate func toggleAttribute(_ attributeName: String, value: AnyObject, range: NSRange) {
 
         var effectiveRange = NSRange()

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -686,6 +686,14 @@ open class TextView: UITextView {
         return storage.attachment(withId: id)
     }
 
+    /// Removes the attachments that match the attachament identifier provided from the storage
+    ///
+    /// - Parameter attachmentID: the unique id of the attachment
+    ///
+    open func remove(attachmentID: String) {
+        storage.remove(attachmentID: attachmentID)
+    }
+
 
     /// Inserts a Video attachment at the specified index
     ///

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -112,4 +112,16 @@ class TextStorageTests: XCTestCase
             return UIImage()
         }
     }
+
+    func testRemovalOfAttachment() {
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+
+        let attachment = storage.insertImage(sourceURL: URL(string:"test://")!, atPosition: 0, placeHolderImage: UIImage())
+
+        storage.remove(attachmentID: attachment.identifier)
+
+        XCTAssertTrue(mockDelegate.deletedAttachmendIDCalledWithString == attachment.identifier)
+    }
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -664,7 +664,40 @@ private extension EditorDemoController
         let font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.caption1)
         return [NSParagraphStyleAttributeName:paragraphStyle, NSFontAttributeName:font]
     }
-    
+
+    func displayActions(forAttachment attachment: TextAttachment, position: CGPoint) {
+        let mediaID = attachment.identifier
+        let title: String = NSLocalizedString("Media Options", comment: "Title for action sheet with media options.")
+        let message: String? = nil
+        let alertController = UIAlertController(title: title, message:message, preferredStyle: .actionSheet)
+        let dismissAction = UIAlertAction(title: NSLocalizedString("Dismiss", comment: "User action to dismiss media options."),
+                                          style: .cancel,
+                                          handler: { (action) in
+        })
+        alertController.addAction(dismissAction)
+
+        let removeAction = UIAlertAction(title: NSLocalizedString("Remove Media", comment: "User action to remove media."),
+                                         style: .destructive,
+                                         handler: { (action) in
+                                            self.richTextView.remove(attachmentID: mediaID)
+        })
+        alertController.addAction(removeAction)
+
+        let detailsAction = UIAlertAction(title:NSLocalizedString("Media Details", comment: "User action to remove media."),
+                                          style: .destructive,
+                                          handler: { (action) in
+                                            self.displayDetailsForAttachment(attachment, position: position)
+        })
+        alertController.addAction(detailsAction)
+
+        alertController.title = title
+        alertController.message = message
+        alertController.popoverPresentationController?.sourceView = richTextView
+        alertController.popoverPresentationController?.sourceRect = CGRect(origin: richTextView.center, size: CGSize(width: 1, height: 1))
+        alertController.popoverPresentationController?.permittedArrowDirections = .up
+        present(alertController, animated:true, completion: nil)
+    }
+
     func displayDetailsForAttachment(_ attachment: TextAttachment, position:CGPoint) {
         let detailsViewController = AttachmentDetailsViewController.controller()
         detailsViewController.attachment = attachment
@@ -697,6 +730,6 @@ extension EditorDemoController: UIGestureRecognizerDelegate
             return
         }
 
-        displayDetailsForAttachment(attachment, position:locationInTextView)
+        displayActions(forAttachment: attachment, position:locationInTextView)
     }
 }


### PR DESCRIPTION
This PR add methods to allow removal attachment trough direct method calls.

How to test:

 - Open the editor demo
 - Tap on an existing image
 - On the Action Sheet tap on the Remove Media option
 - Check if media is removed.
 - Try the same after inserting a media directly
 - Check on the html if image was removed.