### PR TITLE
Updates the format bar with keyboard commands.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -36,6 +36,15 @@ public protocol TextViewMediaDelegate: class {
         urlForImage image: UIImage) -> URL
 }
 
+public protocol TextViewFormattingDelegate: class {
+
+    /// Called a text view command toggled a style.
+    ///
+    /// If you have a format bar, you should probably update it here.
+    ///
+    func textViewCommandToggledAStyle()
+}
+
 open class TextView: UITextView {
 
     typealias ElementNode = Libxml2.ElementNode
@@ -46,7 +55,11 @@ open class TextView: UITextView {
     /// The media delegate takes care of providing remote media when requested by the `TextView`.
     /// If this is not set, all remove images will be left blank.
     ///
-    open weak var mediaDelegate: TextViewMediaDelegate? = nil
+    open weak var mediaDelegate: TextViewMediaDelegate?
+
+    // MARK: - Properties: Formatting
+
+    open weak var formattingDelegate: TextViewFormattingDelegate?
 
     // MARK: - Properties: GUI Defaults
 
@@ -344,6 +357,22 @@ open class TextView: UITextView {
         return identifiers
     }
 
+    // MARK: - UIResponderStandardEditActions
+
+    open override func toggleBoldface(_ sender: Any?) {
+        super.toggleBoldface(sender)
+        formattingDelegate?.textViewCommandToggledAStyle()
+    }
+
+    open override func toggleItalics(_ sender: Any?) {
+        super.toggleItalics(sender)
+        formattingDelegate?.textViewCommandToggledAStyle()
+    }
+
+    open override func toggleUnderline(_ sender: Any?) {
+        super.toggleUnderline(sender)
+        formattingDelegate?.textViewCommandToggledAStyle()
+    }
 
     // MARK: - Formatting
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -17,6 +17,7 @@ class EditorDemoController: UIViewController {
 
         textView.accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
         textView.delegate = self
+        textView.formattingDelegate = self
         textView.mediaDelegate = self
         textView.font = defaultContentFont
 
@@ -269,21 +270,24 @@ class EditorDemoController: UIViewController {
     }
 }
 
-extension EditorDemoController : UITextViewDelegate
-{
+extension EditorDemoController : UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
-        updateFormatBar()        
+        updateFormatBar()
+    }
+}
+
+extension EditorDemoController : Aztec.TextViewFormattingDelegate {
+    func textViewCommandToggledAStyle() {
+        updateFormatBar()
     }
 }
 
 
-extension EditorDemoController : UITextFieldDelegate
-{
+extension EditorDemoController : UITextFieldDelegate {
 
 }
 
-extension EditorDemoController
-{
+extension EditorDemoController {
     enum EditionMode {
         case richText
         case html
@@ -319,8 +323,7 @@ extension EditorDemoController
 }
 
 
-extension EditorDemoController : Aztec.FormatBarDelegate
-{
+extension EditorDemoController : Aztec.FormatBarDelegate {
     func handleActionForIdentifier(_ identifier: FormattingIdentifier) {
         switch identifier {
         case .bold:
@@ -576,12 +579,11 @@ extension EditorDemoController: TextViewMediaDelegate
     }
 }
 
-
 extension EditorDemoController: UINavigationControllerDelegate
 {
-
 }
 
+// MARK: - UIImagePickerControllerDelegate
 
 extension EditorDemoController: UIImagePickerControllerDelegate
 {
@@ -598,6 +600,7 @@ extension EditorDemoController: UIImagePickerControllerDelegate
     }
 }
 
+// MARK: - Misc
 
 private extension EditorDemoController
 {
@@ -680,6 +683,7 @@ private extension EditorDemoController
     }
 }
 
+// MARK: - UIGestureRecognizerDelegate
 
 extension EditorDemoController: UIGestureRecognizerDelegate
 {


### PR DESCRIPTION
<h3>Description</h3>

Updates the tooblar properly when CMD+i, CMD+b, CMD+u are pressed, even if there's no selection.

Fixes #244.

<h3>Testing:</h3>

**Test 1:**

1. Open the empty editor.
2. Without typing anything press CMD + b.
3. Make sure the toolbar is updated properly.

**Further tests:**

Try the same as test 1 with CMD + i and CMD + u.
Also try the same as test 1 in the editor with sample content.

