### PR TITLE
Disable libxml2 formatting of HTML.

### DIFF
--- a/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
@@ -20,27 +20,27 @@ extension Libxml2.Out {
         /// - Returns: a String object representing the specified HTML data.
         ///
         func convert(_ rawNode: Node) -> String {
-            
-            guard let buffer = xmlBufferCreate() else {
+
+            guard let outputBuffer = xmlAllocOutputBuffer(nil) else {
                 fatalError("This should not ever happen. Prevent the code from going further to avoid possible data loss.")
             }
-            
+
             let xmlDocPtr = xmlNewDoc(nil)
-            
+
             defer {
                 xmlFreeDoc(xmlDocPtr)
-                xmlBufferFree(buffer)
+                xmlOutputBufferClose(outputBuffer)
             }
 
             let xmlNodePtr = Libxml2.Out.NodeConverter().convert(rawNode)
-            
+
             xmlDocSetRootElement(xmlDocPtr, xmlNodePtr)
-            htmlNodeDump(buffer, xmlDocPtr, xmlNodePtr)
-            
-            let htmlDumpString = String(cString: buffer.pointee.content)
+            htmlNodeDumpFormatOutput(outputBuffer, xmlDocPtr, xmlNodePtr, nil, 0)
+
+            let htmlDumpString = String(cString: xmlBufContent(outputBuffer.pointee.buffer))
 
             let finalString = htmlDumpString.replacingOccurrences(of: "<\(RootNode.name)>", with: "").replacingOccurrences(of: "</\(RootNode.name)>", with: "")
-            
+
             return finalString
         }
     }


### PR DESCRIPTION
<h3>Description:</h3>

Since libxml2 is behaving in a not-very-consistent way when formatting HTML, I've disabled its formatter in this PR.

We can work in an HTML beautifier later on, either by figuring out how the libxml2 beautifier works, or by implementing our own.

<h3>Testing:</h3>

Switch back and forth between visual and HTML in the editor demo with content, and make sure the HTML representation doesn't change or add newlines.

<h3>Related issues:</h3>

This PR is related to issue #239 