### PR TITLE
FormatBar: Marking Formatter as weak

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -5,7 +5,7 @@ import UIKit
 open class FormatBar: UIToolbar
 {
 
-    open var formatter: FormatBarDelegate?
+    open weak var formatter: FormatBarDelegate?
 
 
     override open var items: [UIBarButtonItem]? {


### PR DESCRIPTION
### Details:
This (brief!) PR simply marks the Format Bar's delegate as **weak**, in order to patch a retain cycle that's affecting WPiOS.

Needs Review: @diegoreymendez 
Thanks in advance!
