### PR TITLE
Issue/media attachment improvements

### DIFF
--- a/Aztec/Classes/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/TextKit/TextAttachment.swift
@@ -209,7 +209,7 @@ open class TextAttachment: NSTextAttachment
             box.addLine(to: CGPoint(x: origin.x, y: origin.y + size.height))
             box.addLine(to: CGPoint(x: origin.x, y: origin.y))
             box.lineWidth = 2.0
-            UIColor(white: 1, alpha: 0.75).setFill()
+            UIColor(white: 0.3, alpha: 0.6).setFill()
             box.fill()
         }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -717,6 +717,20 @@ open class TextView: UITextView {
         return textStorage.attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil) as? TextAttachment
     }
 
+    /// Move the selected range to the nearest character of the point specified in the textView
+    ///
+    /// - Parameter point: the position to move the selection to.
+    ///
+    open func moveSelectionToPoint(_ point: CGPoint) {
+        let index = layoutManager.characterIndex(for: point, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
+        guard index < textStorage.length else {
+            return
+        }
+
+        selectedRange = NSRange(location: index + 1, length: 0)
+        forceRedrawCursorAfterDelay()
+    }
+
     // MARK: - Links
 
     /// Returns an NSURL if the specified range as attached a link attribute

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -706,8 +706,8 @@ private extension EditorDemoController
         alertController.title = title
         alertController.message = message
         alertController.popoverPresentationController?.sourceView = richTextView
-        alertController.popoverPresentationController?.sourceRect = CGRect(origin: richTextView.center, size: CGSize(width: 1, height: 1))
-        alertController.popoverPresentationController?.permittedArrowDirections = .up
+        alertController.popoverPresentationController?.sourceRect = CGRect(origin: position, size: CGSize(width: 1, height: 1))
+        alertController.popoverPresentationController?.permittedArrowDirections = .any
         present(alertController, animated:true, completion: nil)
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -686,6 +686,11 @@ private extension EditorDemoController
         let dismissAction = UIAlertAction(title: NSLocalizedString("Dismiss", comment: "User action to dismiss media options."),
                                           style: .cancel,
                                           handler: { (action) in
+                                            if attachment == self.currentSelectedAttachment {
+                                                self.currentSelectedAttachment = nil
+                                                attachment.message = nil
+                                                self.richTextView.refreshLayoutFor(attachment: attachment)
+                                            }
         })
         alertController.addAction(dismissAction)
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -751,8 +751,7 @@ extension EditorDemoController: UIGestureRecognizerDelegate
             return
         }
         // move the selection to the position of the attachment
-        let index = richTextView.layoutManager.characterIndex(for: locationInTextView, in: richTextView.textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
-        richTextView.selectedRange = NSRange(location: index, length: 0)
+        richTextView.moveSelectionToPoint(locationInTextView)
         if attachment == currentSelectedAttachment {
             //if it's the same attachment has before let's display the options
             displayActions(forAttachment: attachment, position: locationInTextView)


### PR DESCRIPTION
This PR improved the interaction with media by replacing the long press gesture for a double tap on image. First tap makes the image go to selection mode and second tap on it shows the related options.

How to test:
 - Start demo app
 - Tap on a image ( see if image get an overlay saying tap to edit)
 - Tap on the image ( see if image displays the action sheet)
 - Tap outside the image to see if overlay goes away.

