### PR TITLE
Copy/Paste link from pasteboard to link editor if available.

### DIFF
--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -3,7 +3,7 @@ import Aztec
 import Gridicons
 import Photos
 import UIKit
-
+import MobileCoreServices
 
 class EditorDemoController: UIViewController {
     static let margin = CGFloat(20)
@@ -402,7 +402,14 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     func showLinkDialog(forURL url: URL?, title: String?, range: NSRange) {
 
         let isInsertingNewLink = (url == nil)
-        // TODO: grab link from pasteboard if available
+        var urlToUse = url
+
+        if isInsertingNewLink {
+            let pasteboard = UIPasteboard.general
+            if let pastedURL = pasteboard.value(forPasteboardType:String(kUTTypeURL)) as? URL {
+                urlToUse = pastedURL
+            }
+        }
 
         let insertButtonTitle = isInsertingNewLink ? NSLocalizedString("Insert Link", comment:"Label action for inserting a link on the editor") : NSLocalizedString("Update Link", comment:"Label action for updating a link on the editor")
         let removeButtonTitle = NSLocalizedString("Remove Link", comment:"Label action for removing a link from the editor");
@@ -416,7 +423,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
             textField.clearButtonMode = UITextFieldViewMode.always;
             textField.placeholder = NSLocalizedString("URL", comment:"URL text field placeholder");
 
-            textField.text = url?.absoluteString
+            textField.text = urlToUse?.absoluteString
 
             textField.addTarget(self,
                 action:#selector(EditorDemoController.alertTextFieldDidChange),


### PR DESCRIPTION
Fixes #250 

How to test:

- Open Safari and open a site
- Tap on share icon on Safary and select the option Copy
- Jump to the Aztec demo app
- tap on the link button in a area where a link doesn't exist
- check that the link URL is pre-filled with the link copied from Safari