### PR TITLE
Fix attachment html attributes set

### DIFF
--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -719,7 +719,7 @@ extension Libxml2 {
                     if let currentAttributes = element.valueForStringAttribute(named: "class") {
                         components = currentAttributes.components(separatedBy: CharacterSet.whitespaces)
                         components = components.filter({ (value) -> Bool in
-                            return !(value.lowercased().hasPrefix("size-") || value.lowercased().hasPrefix("align"))
+                            return TextAttachment.Alignment.fromHTML(string: value.lowercased()) == nil && TextAttachment.Size.fromHTML(string: value.lowercased()) == nil
                         })
 
                     }

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -715,7 +715,17 @@ extension Libxml2 {
                 let element = self.rootNode.lowestElementNodeWrapping(range)
                 
                 if element.name == StandardElementType.img.rawValue {
-                    let classAttributes = alignment.htmlString() + " " + size.htmlString()
+                    var components = [String]()
+                    if let currentAttributes = element.valueForStringAttribute(named: "class") {
+                        components = currentAttributes.components(separatedBy: CharacterSet.whitespaces)
+                        components = components.filter({ (value) -> Bool in
+                            return !(value.lowercased().hasPrefix("size-") || value.lowercased().hasPrefix("align"))
+                        })
+
+                    }
+                    components.append(alignment.htmlString())
+                    components.append(size.htmlString())
+                    let classAttributes = components.joined(separator: " ")
                     element.updateAttribute(named: "class", value: classAttributes)
                     
                     if element.name == StandardElementType.img.rawValue {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -394,8 +394,12 @@ open class TextStorage: NSTextStorage {
         attachment.size = size
         attachment.url = url
         let rangesForAttachment = ranges(forAttachment:attachment)
+
+        let domRanges = rangesForAttachment.map { range -> NSRange in
+            map(visualRange: range)
+        }
         
-        dom.updateImage(spanning: rangesForAttachment, url: url, size: size, alignment: alignment)
+        dom.updateImage(spanning: domRanges, url: url, size: size, alignment: alignment)
     }
 
     /// Removes the attachments that match the attachament identifier provided from the storage


### PR DESCRIPTION
Fixes #121 

How to test:

 - Start the demo app
 - Tap on the image and change its attributes
 - Switch to HTML mode
 - Go to the img check if the attributes where applied
 - On the class attribute add some extra random attributes
 - Go to visual mode
 - Change the image attributes again using the details view
 - Go back to html and check if the changes are there and your custom attributes are still there.

