### PR TITLE
Refactor HTML parsing to NSAttributedString to use formatters.

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -157,19 +157,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         var attributes = inheritedAttributes
 
-        // Since a default font is requested by this class, there's no way this attribute should
-        // ever be unset.
-        //
-        precondition(inheritedAttributes[NSFontAttributeName] is UIFont)
-        let baseFont = inheritedAttributes[NSFontAttributeName] as! UIFont
-        let baseFontDescriptor = baseFont.fontDescriptor
-        let descriptor = fontDescriptor(forNode: node, withBaseFontDescriptor: baseFontDescriptor)
-
-        if descriptor != baseFontDescriptor {
-            attributes[NSFontAttributeName] = UIFont(descriptor: descriptor, size: descriptor.pointSize)
-        }
-
-        if isLink(node) {
+        if node.isNodeType(.a) {
             let linkURL: String
 
             if let attributeIndex = node.attributes.index(where: { $0.name == HTMLLinkAttribute.Href.rawValue }),
@@ -185,20 +173,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             attributes[NSLinkAttributeName] = linkURL as AnyObject?
         }
 
-        if isStrikedThrough(node) {
-            attributes[NSStrikethroughStyleAttributeName] = NSUnderlineStyle.styleSingle.rawValue as AnyObject?
-        }
-
-        if isUnderlined(node) {
-            attributes[NSUnderlineStyleAttributeName] = NSUnderlineStyle.styleSingle.rawValue as AnyObject?
-        }
-
-        if isBlockquote(node) {
-            let formatter = BlockquoteFormatter()
-            attributes = formatter.apply(to: attributes)
-        }
-
-        if isImage(node) {
+        if node.isNodeType(.img) {
             let url: URL?
 
             if let urlString = node.valueForStringAttribute(named: "src") {
@@ -223,76 +198,22 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             attributes[NSAttachmentAttributeName] = attachment
         }
 
-        if node.isNodeType(.ol) {
-            let formatter = TextListFormatter(style: .ordered)
-            attributes = formatter.apply(to: attributes)
-        }
-
-        if node.isNodeType(.ul) {
-            let formatter = TextListFormatter(style: .unordered)
-            attributes = formatter.apply(to: attributes)
+        for (key, formatter) in elementToFormattersMap {
+            if node.isNodeType(key) {
+                attributes = formatter.apply(to: attributes);
+            }
         }
 
         return attributes
     }
 
-    // MARK: - Font
-
-    fileprivate func fontDescriptor(forNode node: ElementNode, withBaseFontDescriptor fontDescriptor: UIFontDescriptor) -> UIFontDescriptor {
-        let traits = symbolicTraits(forNode: node, withBaseSymbolicTraits: fontDescriptor.symbolicTraits)
-
-        return fontDescriptor.withSymbolicTraits(traits)!
-    }
-
-    /// Gets a list of symbolic traits representing the specified node.
-    ///
-    /// - Parameters:
-    ///     - node: the node to get the traits from.
-    ///
-    /// - Returns: the requested symbolic traits.
-    ///
-    fileprivate func symbolicTraits(forNode node: ElementNode, withBaseSymbolicTraits baseTraits: UIFontDescriptorSymbolicTraits) -> UIFontDescriptorSymbolicTraits {
-
-        var traits = baseTraits
-
-        if isBold(node) {
-            traits.insert(.traitBold)
-        }
-
-        if isItalic(node) {
-            traits.insert(.traitItalic)
-        }
-
-        return traits
-    }
-
-    // MARK: - Node Style Checks
-
-    fileprivate func isLink(_ node: ElementNode) -> Bool {
-        return node.name == StandardElementType.a.rawValue
-    }
-
-    fileprivate func isBold(_ node: ElementNode) -> Bool {
-        return StandardElementType.b.equivalentNames.contains(node.name)
-    }
-
-    fileprivate func isItalic(_ node: ElementNode) -> Bool {
-        return StandardElementType.i.equivalentNames.contains(node.name)
-    }
-
-    fileprivate func isStrikedThrough(_ node: ElementNode) -> Bool {
-        return StandardElementType.s.equivalentNames.contains(node.name)
-    }
-
-    fileprivate func isUnderlined(_ node: ElementNode) -> Bool {
-        return node.name == StandardElementType.u.rawValue
-    }
-
-    fileprivate func isBlockquote(_ node: ElementNode) -> Bool {
-        return node.name == StandardElementType.blockquote.rawValue
-    }
-
-    fileprivate func isImage(_ node: ElementNode) -> Bool {
-        return node.name == StandardElementType.img.rawValue
-    }    
+    public let elementToFormattersMap: [StandardElementType: AttributeFormatter] = [
+        .ol: TextListFormatter(style: .ordered),
+        .ul: TextListFormatter(style: .unordered),
+        .blockquote: BlockquoteFormatter(),
+        .strong: BoldFormatter(),
+        .em: ItalicFormatter(),
+        .u: UnderlineFormatter(),
+        .del: StrikethroughFormatter()
+    ]
 }

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -157,6 +157,8 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         var attributes = inheritedAttributes
 
+        var attributeValue: Any?
+
         if node.isNodeType(.a) {
             let linkURL: String
 
@@ -170,7 +172,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
                 linkURL = ""
             }
 
-            attributes[NSLinkAttributeName] = linkURL as AnyObject?
+            attributeValue = linkURL
         }
 
         if node.isNodeType(.img) {
@@ -195,11 +197,15 @@ class HMTLNodeToNSAttributedString: SafeConverter {
                     }
                 }
             }
-            attributes[NSAttachmentAttributeName] = attachment
+            attributeValue = attachment
         }
 
         for (key, formatter) in elementToFormattersMap {
             if node.isNodeType(key) {
+                if let standardValueFormatter = formatter as? StandardAttributeFormatter,
+                    let value = attributeValue {
+                    standardValueFormatter.attributeValue = value
+                }
                 attributes = formatter.apply(to: attributes);
             }
         }
@@ -214,6 +220,8 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         .strong: BoldFormatter(),
         .em: ItalicFormatter(),
         .u: UnderlineFormatter(),
-        .del: StrikethroughFormatter()
+        .del: StrikethroughFormatter(),
+        .a: LinkFormatter(),
+        .img: ImageFormatter()
     ]
 }

--- a/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
@@ -8,7 +8,7 @@ class StandardAttributeFormatter: CharacterAttributeFormatter {
 
     let attributeKey: String
 
-    let attributeValue: Any
+    var attributeValue: Any
 
     init(elementType: Libxml2.StandardElementType, attributeKey: String, attributeValue: Any) {
         self.elementType = elementType
@@ -54,7 +54,13 @@ class StrikethroughFormatter: StandardAttributeFormatter {
 
 class LinkFormatter: StandardAttributeFormatter {
     init() {
-        super.init(elementType: .a, attributeKey: NSLinkAttributeName, attributeValue: NSURL())
+        super.init(elementType: .a, attributeKey: NSLinkAttributeName, attributeValue: NSURL(string:"")!)
+    }
+}
+
+class ImageFormatter: StandardAttributeFormatter {
+    init() {
+        super.init(elementType: .img, attributeKey: NSAttachmentAttributeName, attributeValue: TextAttachment(identifier: NSUUID().uuidString))
     }
 }
 


### PR DESCRIPTION
This PR refactor the HTML parsing code to use formatters for all the HTML elements.

How to test:
 - Run the demo app
 - Check that all the HTML was correctly parsed to the Visual mode
 - Run the unit tests.