### PR TITLE
Add possibility to add an overlay icon on top of attachments.

### DIFF
--- a/Aztec/Classes/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/TextKit/TextAttachment.swift
@@ -67,6 +67,25 @@ open class TextAttachment: NSTextAttachment
         }
     }
 
+    /// An image to display overlaid on top of the image has an action icon.
+    ///
+    open var overlayImage: UIImage? {
+        willSet {
+            if newValue != overlayImage {
+                glyphImage = nil
+            }
+        }
+    }
+
+
+    /// Clears all overlay information that is applied to the attachment
+    ///
+    open func clearAllOverlays() {
+        progress = nil
+        message = nil
+        overlayImage = nil
+    }
+
     fileprivate var glyphImage: UIImage?
 
     var imageProvider: TextAttachmentImageProvider?
@@ -222,9 +241,19 @@ open class TextAttachment: NSTextAttachment
             path.stroke()
         }
 
+        var imagePadding: CGFloat = 0
+        if let overlayImage = overlayImage {
+            UIColor.white.set()
+            let center = CGPoint(x: origin.x + (size.width / 2.0), y: origin.y + (size.height / 2.0))
+            let path = UIBezierPath(arcCenter: center, radius: overlayImage.size.width * 2.0/3.0, startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
+            path.stroke()
+            overlayImage.draw(at: CGPoint(x: center.x - (overlayImage.size.width / 2.0), y: center.y - (overlayImage.size.height / 2.0)))
+            imagePadding += overlayImage.size.width * (2.0/3.0) * 2;
+        }
+
         if let message = message {
             let textRect = message.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
-            let textPosition = CGPoint(x: origin.x, y: origin.y + ((size.height-textRect.size.height) / 2) )
+            let textPosition = CGPoint(x: origin.x, y: origin.y + (size.height / 2 ) + imagePadding - (textRect.height / 2) )
             message.draw(in: CGRect(origin: textPosition , size: CGSize(width:size.width, height:textRect.size.height)))
         }
 

--- a/Aztec/Classes/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/TextKit/TextAttachment.swift
@@ -244,11 +244,11 @@ open class TextAttachment: NSTextAttachment
         var imagePadding: CGFloat = 0
         if let overlayImage = overlayImage {
             UIColor.white.set()
-            let center = CGPoint(x: origin.x + (size.width / 2.0), y: origin.y + (size.height / 2.0))
-            let path = UIBezierPath(arcCenter: center, radius: overlayImage.size.width * 2.0/3.0, startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
+            let center = CGPoint(x: round(origin.x + (size.width / 2.0)), y: round(origin.y + (size.height / 2.0)))
+            let path = UIBezierPath(arcCenter: center, radius: round(overlayImage.size.width * 2.0/3.0), startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
             path.stroke()
-            overlayImage.draw(at: CGPoint(x: center.x - (overlayImage.size.width / 2.0), y: center.y - (overlayImage.size.height / 2.0)))
-            imagePadding += overlayImage.size.width * (2.0/3.0) * 2;
+            overlayImage.draw(at: CGPoint(x: round(center.x - (overlayImage.size.width / 2.0)), y: round(center.y - (overlayImage.size.height / 2.0))))
+            imagePadding += round(overlayImage.size.width * (2.0/3.0) * 2);
         }
 
         if let message = message {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -657,6 +657,7 @@ private extension EditorDemoController
                 timer.invalidate()
                 let message = NSAttributedString(string: "Upload failed!", attributes: mediaMessageAttributes)
                 attachment.message = message
+                attachment.overlayImage = Gridicon.iconOfType(.refresh)
             }
             if progress.fractionCompleted >= 1 {
                 timer.invalidate()
@@ -691,7 +692,7 @@ private extension EditorDemoController
                                           handler: { (action) in
                                             if attachment == self.currentSelectedAttachment {
                                                 self.currentSelectedAttachment = nil
-                                                attachment.message = nil
+                                                attachment.clearAllOverlays()
                                                 self.richTextView.refreshLayoutFor(attachment: attachment)
                                             }
         })
@@ -753,6 +754,7 @@ extension EditorDemoController: UIGestureRecognizerDelegate
             // if we have an attachment marked lets unmark it
             if let selectedAttachment = currentSelectedAttachment {
                 selectedAttachment.message = nil
+                selectedAttachment.clearAllOverlays()
                 richTextView.refreshLayoutFor(attachment: selectedAttachment)
                 currentSelectedAttachment = nil
             }
@@ -772,6 +774,7 @@ extension EditorDemoController: UIGestureRecognizerDelegate
             // and mark the newly tapped attachment
             let message = NSLocalizedString("Tap to edit", comment: "Options to show when tapping on a image on the post/page editor.")
             attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)
+            attachment.overlayImage = Gridicon.iconOfType(.pencil).withRenderingMode(.alwaysTemplate)
             richTextView.refreshLayoutFor(attachment: attachment)
             currentSelectedAttachment = attachment
         }


### PR DESCRIPTION
How to test:

 - Start the demo app
 - Scroll to an image or insert one
 - tap on it and see if the new Pencil icon shows correctly
 - Tap out and see if it goes away