### PR TITLE
Check for space on start of the text when doing sanitise.

### DIFF
--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -145,10 +145,9 @@ extension Libxml2.In {
         private func sanitize(_ text: String) -> String {
 
             let hasAnEndingSpace = text.hasSuffix(String(.space))
-            let hasAnStartingSpace = text.hasPrefix(String(.space))
+            let hasAStartingSpace = text.hasPrefix(String(.space))
 
-            let characterSet = CharacterSet(charactersIn: "\(String(.space))")
-            let trimmedText = text.trimmingCharacters(in: characterSet)
+            let trimmedText = text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             var singleSpaceText = trimmedText
             let doubleSpace = "  "
             let singleSpace = " "
@@ -159,7 +158,7 @@ extension Libxml2.In {
 
             let noBreaksText = singleSpaceText.replacingOccurrences(of: String(.newline), with: "")
             let endingSpace = noBreaksText.characters.count > 0 && hasAnEndingSpace ? String(.space) : ""
-            let startingSpace = noBreaksText.characters.count > 0 && hasAnStartingSpace ? String(.space) : ""
+            let startingSpace = noBreaksText.characters.count > 0 && hasAStartingSpace ? String(.space) : ""
             return "\(startingSpace)\(noBreaksText)\(endingSpace)"
         }
     }

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -144,7 +144,8 @@ extension Libxml2.In {
 
         private func sanitize(_ text: String) -> String {
 
-            let hasAnEndingSpace = text[text.index(before: text.endIndex)] == Character(.space)
+            let hasAnEndingSpace = text.hasSuffix(String(.space))
+            let hasAnStartingSpace = text.hasPrefix(String(.space))
 
             let characterSet = CharacterSet(charactersIn: "\(String(.space))")
             let trimmedText = text.trimmingCharacters(in: characterSet)
@@ -158,8 +159,8 @@ extension Libxml2.In {
 
             let noBreaksText = singleSpaceText.replacingOccurrences(of: String(.newline), with: "")
             let endingSpace = noBreaksText.characters.count > 0 && hasAnEndingSpace ? String(.space) : ""
-
-            return "\(noBreaksText)\(endingSpace)"
+            let startingSpace = noBreaksText.characters.count > 0 && hasAnStartingSpace ? String(.space) : ""
+            return "\(startingSpace)\(noBreaksText)\(endingSpace)"
         }
     }
 }


### PR DESCRIPTION
This PR adds checks for empty space on the start of text block.

How to text:

Insert this text on the source code view:
```It has <strong>bold text</strong> and <em>italic text</em> and <del>strikethrough text</del> and <span style="text-decoration: underline;">underlined text</span>.```

Then switch to visual mode and see if the space between bold and italic and strikethrough text are all correct.