### PR TITLE
More tag

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */; };
 		F1CF272A1DBA8CDB0001C61D /* DOMString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF27291DBA8CDB0001C61D /* DOMString.swift */; };
 		F1E47FB91D9BFBD3006B46E2 /* LeafNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E47FB81D9BFBD3006B46E2 /* LeafNode.swift */; };
+		FF7A1C4F1E560A1F00C4C7C8 /* MoreAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7A1C4E1E560A1F00C4C7C8 /* MoreAttachment.swift */; };
 		FF7C89A81E3A2B7C000472A8 /* Blockquote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C89A71E3A2B7C000472A8 /* Blockquote.swift */; };
 		FF7C89AC1E3A47F1000472A8 /* StandardAttributeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C89AB1E3A47F1000472A8 /* StandardAttributeFormatter.swift */; };
 		FF7C89B01E3BC52F000472A8 /* NSAttributedString+FontTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C89AF1E3BC52F000472A8 /* NSAttributedString+FontTraits.swift */; };
@@ -205,6 +206,7 @@
 		FF5B98E41DC355B400571CA4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		FF7A1C481E51EFB600C4C7C8 /* WordPress-Aztec-iOS.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "WordPress-Aztec-iOS.podspec"; sourceTree = "<group>"; };
 		FF7A1C4A1E51F05700C4C7C8 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		FF7A1C4E1E560A1F00C4C7C8 /* MoreAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreAttachment.swift; sourceTree = "<group>"; };
 		FF7C89A71E3A2B7C000472A8 /* Blockquote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Blockquote.swift; sourceTree = "<group>"; };
 		FF7C89AB1E3A47F1000472A8 /* StandardAttributeFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardAttributeFormatter.swift; sourceTree = "<group>"; };
 		FF7C89AF1E3BC52F000472A8 /* NSAttributedString+FontTraits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+FontTraits.swift"; sourceTree = "<group>"; };
@@ -428,6 +430,7 @@
 			isa = PBXGroup;
 			children = (
 				599F25301D8BC9A1002871D6 /* TextAttachment.swift */,
+				FF7A1C4E1E560A1F00C4C7C8 /* MoreAttachment.swift */,
 				B5BC4FF51DA2D76600614582 /* TextList.swift */,
 				599F25311D8BC9A1002871D6 /* TextStorage.swift */,
 				599F25321D8BC9A1002871D6 /* TextView.swift */,
@@ -706,6 +709,7 @@
 				599F254A1D8BC9A1002871D6 /* NSAttributedString+Attachments.swift in Sources */,
 				B5B96DAB1E01B2F300791315 /* UIPasteboard+Helpers.swift in Sources */,
 				F17D64AE1E4230A400D09FED /* VisualOnlyAttribute.swift in Sources */,
+				FF7A1C4F1E560A1F00C4C7C8 /* MoreAttachment.swift in Sources */,
 				F15C9B881DD58D8B00833C39 /* ElementNodeDescriptor.swift in Sources */,
 				FF7C89A81E3A2B7C000472A8 /* Blockquote.swift in Sources */,
 				599F254C1D8BC9A1002871D6 /* UITextView+Helpers.swift in Sources */,

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -26,6 +26,10 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         self.defaultFontDescriptor = defaultFontDescriptor
     }
 
+    private lazy var defaultAttributes: [String: Any] = {
+        let defaultFont = UIFont(descriptor: self.defaultFontDescriptor, size: self.defaultFontDescriptor.pointSize)
+        return [NSFontAttributeName: defaultFont]
+    }()
     // MARK: - Conversion
 
     /// Main conversion method.
@@ -36,10 +40,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     func convert(_ node: Node) -> NSAttributedString {
-
-        let defaultFont = UIFont(descriptor: defaultFontDescriptor, size: defaultFontDescriptor.pointSize)
-
-        return convert(node, inheritingAttributes: [NSFontAttributeName: defaultFont])
+        return convert(node, inheritingAttributes: defaultAttributes)
     }
 
     /// Recursive conversion method.  Useful for maintaining the font style of parent nodes when
@@ -97,6 +98,13 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
+        if node.comment == "more" {
+            var attributes = inheritedAttributes;
+            let moreAttachment = MoreAttachment()
+            moreAttachment.message = NSAttributedString(string: NSLocalizedString("MORE", comment:"Text for the center of the   more divider"), attributes: defaultAttributes)
+            attributes[NSAttachmentAttributeName] = moreAttachment
+            return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
+        }
         return NSAttributedString(string: node.text(), attributes: inheritedAttributes)
     }
 

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -101,7 +101,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         if node.comment == "more" {
             var attributes = inheritedAttributes;
             let moreAttachment = MoreAttachment()
-            moreAttachment.message = NSAttributedString(string: NSLocalizedString("MORE", comment:"Text for the center of the   more divider"), attributes: defaultAttributes)
+            moreAttachment.message = NSAttributedString(string: NSLocalizedString("MORE", comment: "Text for the center of the   more divider"), attributes: defaultAttributes)
             attributes[NSAttachmentAttributeName] = moreAttachment
             return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
         }

--- a/Aztec/Classes/TextKit/MoreAttachment.swift
+++ b/Aztec/Classes/TextKit/MoreAttachment.swift
@@ -44,7 +44,7 @@ open class MoreAttachment: NSTextAttachment
         colorMessage.addAttribute(NSForegroundColorAttributeName, value: color, range: message.rangeOfEntireString)
         let textRect = colorMessage.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
         let textPosition = CGPoint(x: ((size.width - textRect.width) / 2), y: ((size.height - textRect.height) / 2) )
-        colorMessage.draw(in: CGRect(origin: textPosition , size: CGSize(width:size.width, height:textRect.size.height)))
+        colorMessage.draw(in: CGRect(origin: textPosition , size: CGSize(width: size.width, height: textRect.size.height)))
 
         let path = UIBezierPath()
 
@@ -52,12 +52,12 @@ open class MoreAttachment: NSTextAttachment
         let  dashes: [ CGFloat ] = [ dashWidth, dashWidth ]
         path.setLineDash(dashes, count: dashes.count, phase: 0.0)
         path.lineWidth = 2.0
+        let centerY = round(size.height / 2.0)
+        path.move(to: CGPoint(x:0, y: centerY))
+        path.addLine(to: CGPoint(x: ((size.width - textRect.width) / 2) - dashWidth, y: centerY))
 
-        path.move(to: CGPoint(x:0, y:bounds.height / 2))
-        path.addLine(to: CGPoint(x: ((size.width - textRect.width) / 2) - dashWidth, y: bounds.height / 2))
-
-        path.move(to: CGPoint(x:((size.width + textRect.width) / 2) + dashWidth, y:bounds.height / 2))
-        path.addLine(to: CGPoint(x: size.width, y: bounds.height / 2))
+        path.move(to: CGPoint(x:((size.width + textRect.width) / 2) + dashWidth, y: centerY))
+        path.addLine(to: CGPoint(x: size.width, y: centerY))
 
         color.setStroke()
         path.stroke()
@@ -67,10 +67,6 @@ open class MoreAttachment: NSTextAttachment
         return result;
     }
 
-    /// Returns the "Onscreen Character Size" of the attachment range. When we're in Alignment.None,
-    /// the attachment will be 'Inline', and thus, we'll return the actual Associated View Size.
-    /// Otherwise, we'll always take the whole container's width.
-    ///
     override open func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
 
         let padding = textContainer?.lineFragmentPadding ?? 0
@@ -78,9 +74,5 @@ open class MoreAttachment: NSTextAttachment
         let height:CGFloat = 44.0
 
         return CGRect(origin: CGPoint.zero, size: CGSize(width: width, height: height))
-    }
-
-    fileprivate func invalidateLayout(inTextContainer textContainer: NSTextContainer?) {
-        textContainer?.layoutManager?.invalidateLayoutForAttachment(self)
     }
 }

--- a/Aztec/Classes/TextKit/MoreAttachment.swift
+++ b/Aztec/Classes/TextKit/MoreAttachment.swift
@@ -1,0 +1,86 @@
+import Foundation
+import UIKit
+
+/// Custom text attachment.
+///
+open class MoreAttachment: NSTextAttachment
+{
+    fileprivate var glyphImage: UIImage?
+
+    /// The color to use when drawing progress indicators
+    ///
+    open var color: UIColor = UIColor.gray
+
+    /// A message to display overlaid on top of the image
+    ///
+    open var message: NSAttributedString = NSAttributedString(string: "MORE") {
+        willSet {
+            if newValue != message {
+                glyphImage = nil
+            }
+        }
+    }
+
+    // MARK: - NSTextAttachmentContainer
+
+    override open func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
+
+        if let cachedImage = glyphImage, imageBounds.size.equalTo(cachedImage.size) {
+            return cachedImage
+        }
+
+        glyphImage = glyph(forBounds: imageBounds)
+
+        return glyphImage
+    }
+
+    fileprivate func glyph(forBounds bounds: CGRect) -> UIImage? {
+
+        let size = bounds.size
+
+        UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
+
+        let colorMessage = NSMutableAttributedString(attributedString: message)
+        colorMessage.addAttribute(NSForegroundColorAttributeName, value: color, range: message.rangeOfEntireString)
+        let textRect = colorMessage.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
+        let textPosition = CGPoint(x: ((size.width - textRect.width) / 2), y: ((size.height - textRect.height) / 2) )
+        colorMessage.draw(in: CGRect(origin: textPosition , size: CGSize(width:size.width, height:textRect.size.height)))
+
+        let path = UIBezierPath()
+
+        let dashWidth: CGFloat = 8.0
+        let  dashes: [ CGFloat ] = [ dashWidth, dashWidth ]
+        path.setLineDash(dashes, count: dashes.count, phase: 0.0)
+        path.lineWidth = 2.0
+
+        path.move(to: CGPoint(x:0, y:bounds.height / 2))
+        path.addLine(to: CGPoint(x: ((size.width - textRect.width) / 2) - dashWidth, y: bounds.height / 2))
+
+        path.move(to: CGPoint(x:((size.width + textRect.width) / 2) + dashWidth, y:bounds.height / 2))
+        path.addLine(to: CGPoint(x: size.width, y: bounds.height / 2))
+
+        color.setStroke()
+        path.stroke()
+
+        let result = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return result;
+    }
+
+    /// Returns the "Onscreen Character Size" of the attachment range. When we're in Alignment.None,
+    /// the attachment will be 'Inline', and thus, we'll return the actual Associated View Size.
+    /// Otherwise, we'll always take the whole container's width.
+    ///
+    override open func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+
+        let padding = textContainer?.lineFragmentPadding ?? 0
+        let width = lineFrag.width - padding * 2
+        let height:CGFloat = 44.0
+
+        return CGRect(origin: CGPoint.zero, size: CGSize(width: width, height: height))
+    }
+
+    fileprivate func invalidateLayout(inTextContainer textContainer: NSTextContainer?) {
+        textContainer?.layoutManager?.invalidateLayoutForAttachment(self)
+    }
+}

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -1,7 +1,6 @@
 <p>
 I'm a test post.
 </p>
-<!--more-->
 <p>
     this is some text
     that is spread out

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -1,6 +1,7 @@
 <p>
 I'm a test post.
 </p>
+<!--more-->
 <p>
     this is some text
     that is spread out


### PR DESCRIPTION
Fixes #275 

This PR implements the visualisation of the more tag using a custom attachment.

Notes: 
  - this still doesn't provide a way to insert more tag in the visual editor, it only parses them from HTML.
  - the more tag needs to be exactly like this: ```<!--more-->```. This is case sensitive and space sensitive like Calypso.

How to test:
 - Run the demo app
 - Check that in the sample content the more tag is presented correctly
 - Remove it on the visual mode and check if it updates the DOM
 - Add more tags
