### PR TITLE
Fixes keyboard style removal for underline and strikethrough.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -428,11 +428,15 @@ open class TextStorage: NSTextStorage {
     ///     - newFont: the new font object.
     ///
     private func processStrikethroughDifferences(in range: NSRange, betweenOriginal originalStyle: NSNumber?, andNew newStyle: NSNumber?) {
+
+        let sourceStyle = originalStyle ?? 0
+        let targetStyle = newStyle ?? 0
+
         // At some point we'll support different styles.  For now we only check if ANY style is
         // set.
         //
-        let addStyle = originalStyle == nil && newStyle != nil
-        let removeStyle = originalStyle != nil && newStyle == nil
+        let addStyle = sourceStyle == 0 && targetStyle == 1
+        let removeStyle = sourceStyle == 1 && targetStyle == 0
 
         if addStyle {
             dom.applyStrikethrough(spanning: range)
@@ -450,11 +454,15 @@ open class TextStorage: NSTextStorage {
     ///     - newFont: the new font object.
     ///
     private func processUnderlineDifferences(in range: NSRange, betweenOriginal originalStyle: NSNumber?, andNew newStyle: NSNumber?) {
+
+        let sourceStyle = originalStyle ?? 0
+        let targetStyle = newStyle ?? 0
+
         // At some point we'll support different styles.  For now we only check if ANY style is
         // set.
         //
-        let addStyle = originalStyle == nil && newStyle != nil
-        let removeStyle = originalStyle != nil && newStyle == nil
+        let addStyle = sourceStyle == 0 && targetStyle == 1
+        let removeStyle = sourceStyle == 1 && targetStyle == 0
 
         if addStyle {
             dom.applyUnderline(spanning: range)


### PR DESCRIPTION
<h3>Description:</h3>

This PR fixes the removal of underline and strikethrough using the keyboard.

Fixes #254.

<h3>Testing:</h3>

**Test 1:**
1. Run the unit tests.

**Test 2:**
1. Apply and remove the style for any range of text using CMD + U.

Note: There's still no keyboard shortcut for strikethrough, but the change is the same as in the underline style.