### PR TITLE
Fixes editing around the more tag.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -478,7 +478,11 @@ open class TextStorage: NSTextStorage {
             return true
         }
 
-        return attribute(VisualOnlyAttributeName, at: caretPosition - 1, effectiveRange: nil) == nil
+        let rawIndex = caretPosition - 1
+        let index = textStore.string.index(textStore.string.startIndex, offsetBy: rawIndex)
+
+        return string.characters[index] != Character(.newline)
+            && attribute(VisualOnlyAttributeName, at: rawIndex, effectiveRange: nil) == nil
     }
 
     private func map(visualLocation: Int) -> Int {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -473,16 +473,37 @@ open class TextStorage: NSTextStorage {
 
     // MARK: - Range Mapping: Visual vs HTML
 
+    private func canAppendToNodeRepresentedByCharacter(atIndex index: Int) -> Bool {
+        return !hasNewLine(atIndex: index)
+            && !hasMoreAttachment(atIndex: index)
+            && !hasVisualOnlyElement(atIndex: index)
+    }
+
     private func doesPreferLeftNode(atCaretPosition caretPosition: Int) -> Bool {
         guard caretPosition != 0 else {
             return true
         }
 
-        let rawIndex = caretPosition - 1
-        let index = textStore.string.index(textStore.string.startIndex, offsetBy: rawIndex)
+        return canAppendToNodeRepresentedByCharacter(atIndex: caretPosition - 1)
+    }
 
-        return string.characters[index] != Character(.newline)
-            && attribute(VisualOnlyAttributeName, at: rawIndex, effectiveRange: nil) == nil
+    private func hasMoreAttachment(atIndex index: Int) -> Bool {
+        guard let attachment = attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil),
+            attachment is MoreAttachment else {
+            return false
+        }
+
+        return true
+    }
+
+    private func hasNewLine(atIndex index: Int) -> Bool {
+        let swiftStringIndex = textStore.string.index(textStore.string.startIndex, offsetBy: index)
+
+        return string.characters[swiftStringIndex] == Character(.newline)
+    }
+
+    private func hasVisualOnlyElement(atIndex index: Int) -> Bool {
+        return attribute(VisualOnlyAttributeName, at: index, effectiveRange: nil) != nil
     }
 
     private func map(visualLocation: Int) -> Int {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -475,7 +475,8 @@ open class TextStorage: NSTextStorage {
 
     private func canAppendToNodeRepresentedByCharacter(atIndex index: Int) -> Bool {
         return !hasNewLine(atIndex: index)
-            && !hasMoreAttachment(atIndex: index)
+            && !hasHorizontalLine(atIndex: index)
+            && !hasMoreMarker(atIndex: index)
             && !hasVisualOnlyElement(atIndex: index)
     }
 
@@ -487,7 +488,16 @@ open class TextStorage: NSTextStorage {
         return canAppendToNodeRepresentedByCharacter(atIndex: caretPosition - 1)
     }
 
-    private func hasMoreAttachment(atIndex index: Int) -> Bool {
+    private func hasHorizontalLine(atIndex index: Int) -> Bool {
+        guard let attachment = attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil),
+            attachment is LineAttachment else {
+                return false
+        }
+
+        return true
+    }
+
+    private func hasMoreMarker(atIndex index: Int) -> Bool {
         guard let attachment = attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil),
             attachment is MoreAttachment else {
             return false

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1058,8 +1058,8 @@ class ElementNodeTests: XCTestCase {
     /// Range: (5...0)
     ///
     /// Expected results:
-    ///     - should find 1 matching child node (the first bold node)
-    ///     - the range should be unchanged
+    ///     - should find 2 matching child nodes
+    ///     - the ranges should be at the end of the first node, and the beginning of the second
     ///
     func testChildNodesIntersectingRange3() {
 
@@ -1076,51 +1076,17 @@ class ElementNodeTests: XCTestCase {
         let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2])
         let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2])
 
-        let childrenAndRanges = paragraph.childNodes(intersectingRange: range, preferLeftNode: true)
+        let childrenAndRanges = paragraph.childNodes(intersectingRange: range)
 
-        guard childrenAndRanges.count == 1 else {
+        guard childrenAndRanges.count == 2 else {
             XCTFail("Expected 1 child.")
             return
         }
 
         XCTAssertEqual(childrenAndRanges[0].child, bold1)
+        XCTAssertEqual(childrenAndRanges[1].child, bold2)
         XCTAssert(NSEqualRanges(childrenAndRanges[0].intersection, range))
-    }
-
-    /// Tests `childNodes(intersectingRange:)` with a zero-length range.
-    ///
-    /// Input HTML: <p><b>Hello</b><b>Hello again!</b></p>
-    /// Prefer left node: false
-    /// Range: (5...0)
-    ///
-    /// Expected results:
-    ///     - should find 1 matching child node (the second bold node)
-    ///     - the range should be unchanged
-    ///
-    func testChildNodesIntersectingRange4() {
-
-        let textNode1 = TextNode(text: "Hello")
-        let textNode2 = TextNode(text: "Hello again!")
-
-        let rangeLocation = 5
-        XCTAssert(rangeLocation == textNode1.length(),
-                  "For this text we need to make sure the range location is inside the test node.")
-
-        let range = NSRange(location: rangeLocation, length: 0)
-
-        let bold1 = ElementNode(name: "b", attributes: [], children: [textNode1])
-        let bold2 = ElementNode(name: "b", attributes: [], children: [textNode2])
-        let paragraph = ElementNode(name: "p", attributes: [], children: [bold1, bold2])
-
-        let childrenAndRanges = paragraph.childNodes(intersectingRange: range, preferLeftNode: false)
-
-        guard childrenAndRanges.count == 1 else {
-            XCTFail("Expected 1 child.")
-            return
-        }
-
-        XCTAssertEqual(childrenAndRanges[0].child, bold2)
-        XCTAssert(NSEqualRanges(childrenAndRanges[0].intersection, NSRange(location: 0, length: 0)))
+        XCTAssert(NSEqualRanges(childrenAndRanges[1].intersection, NSRange(location: 0, length: 0)))
     }
     
     /// Tests `insert(string: String, at index: Int)`.

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1079,7 +1079,7 @@ class ElementNodeTests: XCTestCase {
         let childrenAndRanges = paragraph.childNodes(intersectingRange: range)
 
         guard childrenAndRanges.count == 2 else {
-            XCTFail("Expected 1 child.")
+            XCTFail("Expected 2 children.")
             return
         }
 


### PR DESCRIPTION
<h3>Description:</h3>

Fixes the DOM synchronization when editing text around the "more" tag.

Fixes #293.

<h3>Testing:</h3>

1. Run the app.
2. Place the cursor right before of after the "more" tag.
3. Insert text.
4. Switch to HTML and back.
5. Make sure everything's ok (styles can be slightly off but that's unrelated).