### PR TITLE
Trigger textviewDidChange on programmatically content changes

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -170,7 +170,8 @@ open class TextView: UITextView {
             if (self.textStorage.length > 0) {
                 typingAttributes = textStorage.attributes(at: min(selectedRange.location, textStorage.length-1), effectiveRange: nil)
             }
-            self.delegate?.textViewDidChangeSelection?(self)
+            delegate?.textViewDidChangeSelection?(self)
+            delegate?.textViewDidChange?(self)
             return
         }
 
@@ -198,6 +199,7 @@ open class TextView: UITextView {
         refreshListAfterDeletion(of: deletedString, at: deletionRange)
         refreshBlockquoteAfterDeletion(of: deletedString, at: deletionRange)
         ensureCursorRedraw(afterEditing: deletedString.string)
+        delegate?.textViewDidChange?(self)
     }
 
     // MARK: - UIView Overrides
@@ -364,6 +366,7 @@ open class TextView: UITextView {
             let location = max(0,min(selectedRange.location, textStorage.length-1))
             typingAttributes = textStorage.attributes(at: location, effectiveRange: nil)
         }
+        delegate?.textViewDidChange?(self)
     }
 
     /// Adds or removes a bold style from the specified range.
@@ -643,6 +646,7 @@ open class TextView: UITextView {
         let insertionRange = NSMakeRange(index, length)
         storage.replaceCharacters(in: range, with: title)
         storage.setLink(url, forRange: insertionRange)
+        delegate?.textViewDidChange?(self)
     }
 
 
@@ -652,6 +656,7 @@ open class TextView: UITextView {
     ///
     open func removeLink(inRange range: NSRange) {
         storage.removeLink(inRange: range)
+        delegate?.textViewDidChange?(self)
     }
 
 
@@ -671,6 +676,7 @@ open class TextView: UITextView {
         let length = NSAttributedString(attachment:NSTextAttachment()).length
         textStorage.addAttributes(typingAttributes, range: NSMakeRange(position, length))
         selectedRange = NSMakeRange(position+length, 0)
+        delegate?.textViewDidChange?(self)
         return attachment
     }
 
@@ -689,6 +695,7 @@ open class TextView: UITextView {
     ///
     open func remove(attachmentID: String) {
         storage.remove(attachmentID: attachmentID)
+        delegate?.textViewDidChange?(self)
     }
 
 
@@ -821,6 +828,7 @@ open class TextView: UITextView {
                      url: URL) {
         storage.update(attachment: attachment, alignment: alignment, size: size, url: url)
         layoutManager.invalidateLayoutForAttachment(attachment)
+        delegate?.textViewDidChange?(self)
     }
 
     /// Invalidates the layout of the attachment and marks it to be refresh on the next update

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -279,6 +279,10 @@ extension EditorDemoController : UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
         updateFormatBar()
     }
+
+    func textViewDidChange(_ textView: UITextView) {
+        print("Changed content")
+    }
 }
 
 extension EditorDemoController : Aztec.TextViewFormattingDelegate {


### PR DESCRIPTION
Make sure that all call on text view that change content programmatically trigger a didChange callback of the textview.

How to test:
 - Use all the format bar actions on the toolbar
 - Confirm that the text Changed Content is printed on the console to confirm that the change happened.
 - Test it also by removing an image using the action sheet
 - And also test when pressing enter/newlines inside lists or block quotes.