### PR TITLE
Check for attachment and insert image if needed in DOM.

### DIFF
--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -384,6 +384,12 @@ extension Libxml2 {
                 self?.applyElement(.u, spanning: range)
             }
         }
+
+        func applyImage(imageURL: URL?, spanning range:NSRange) {
+            performAsyncUndoable { [weak self] in
+                self?.setImageURLInDOM(imageURL, forRange: range)
+            }
+        }
         
         // MARK: - Styles to HTML elements
         

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -385,6 +385,12 @@ extension Libxml2 {
             }
         }
 
+        /// Replaces the characteres in the specified range for a an img element pointing to the provided URL
+        ///
+        /// - Parameters:
+        ///   - imageURL: the URL for the img src attribute
+        ///   - range: the range to insert the image
+        ///
         func applyImage(imageURL: URL?, spanning range:NSRange) {
             performAsyncUndoable { [weak self] in
                 self?.setImageURLInDOM(imageURL, forRange: range)

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -357,7 +357,7 @@ open class TextStorage: NSTextStorage {
                 processUnderlineDifferences(in: domRange, betweenOriginal: targetStyle, andNew: sourceStyle)
             case NSAttachmentAttributeName:
                 if let attachment = sourceValue as? TextAttachment {
-                    dom.applyImage(imageURL: attachment.url ,spanning: domRange)
+                    dom.applyImage(imageURL: attachment.url, spanning: domRange)
                 }
             default:
                 break

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -355,6 +355,10 @@ open class TextStorage: NSTextStorage {
                 let targetStyle = targetValue as? NSNumber
 
                 processUnderlineDifferences(in: domRange, betweenOriginal: targetStyle, andNew: sourceStyle)
+            case NSAttachmentAttributeName:
+                if let attachment = sourceValue as? TextAttachment {
+                    dom.applyImage(imageURL: attachment.url ,spanning: domRange)
+                }
             default:
                 break
             }

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -136,4 +136,17 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(attachment.url, URL(string: "https://wordpress.com"))
         XCTAssertEqual(html, "<img src=\"https://wordpress.com\">")
     }
+
+    func testUpdateImage() {
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+        let url = URL(string: "https://wordpress.com")!
+        let attachment = storage.insertImage(sourceURL: url, atPosition: 0, placeHolderImage: UIImage())
+        storage.update(attachment: attachment, alignment: .left, size: .medium, url: url)
+        let html = storage.getHTML()
+
+        XCTAssertEqual(attachment.url, url)
+        XCTAssertEqual(html, "<img src=\"https://wordpress.com\" class=\"alignleft size-medium\">")
+    }
 }

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -124,4 +124,16 @@ class TextStorageTests: XCTestCase
 
         XCTAssertTrue(mockDelegate.deletedAttachmendIDCalledWithString == attachment.identifier)
     }
+
+    func testInsertImage() {
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+
+        let attachment = storage.insertImage(sourceURL: URL(string: "https://wordpress.com")!, atPosition: 0, placeHolderImage: UIImage())
+        let html = storage.getHTML()
+
+        XCTAssertEqual(attachment.url, URL(string: "https://wordpress.com"))
+        XCTAssertEqual(html, "<img src=\"https://wordpress.com\">")
+    }
 }


### PR DESCRIPTION
This PR adds code to detect image attachments and applies/insert img elements to the DOM

### How to test

- Start the demo app
- Tap on the insert image button
- Wait for image to be inserted
- Switch to HTML mode
- Check that the img tag is present