### PR TITLE
Fixes addition of images.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -27,6 +27,7 @@ extension Libxml2 {
         // MARK: - Editing behavior configuration
 
         static let elementsThatInterruptStyleAtEdges: [StandardElementType] = [.a]
+        static let elementsThatCantHaveChildren: [StandardElementType] = [.a, .br, .img]
         
         // MARK: - Initializers
 
@@ -1294,7 +1295,9 @@ extension Libxml2 {
                 let child = childAndIntersection.child
                 let intersection = childAndIntersection.intersection
 
-                guard let childEditableNode = child as? EditableNode else {
+                guard child.canHaveChildren(),
+                    let childEditableNode = child as? EditableNode else {
+
                     if (index == 0 && preferLeftNode)
                         || (index == 1 && preferRightNode)
                         && string.characters.count > 0 {
@@ -1769,6 +1772,15 @@ extension Libxml2 {
         }
 
         // MARK: - Editing behavior
+
+        override func canHaveChildren() -> Bool {
+
+            guard let standardName = standardName else {
+                return true
+            }
+
+            return !ElementNode.elementsThatCantHaveChildren.contains(standardName)
+        }
 
         private func mustInterruptStyleAtEdges(forNode node: Node) -> Bool {
             guard !(node is TextNode) else {

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1302,7 +1302,7 @@ extension Libxml2 {
                         || (index == 1 && preferRightNode)
                         && string.characters.count > 0 {
 
-                        let offset = preferLeftNode ? 1 : 0
+                        let offset = intersection.location == 0 ? 0 : 1
 
                         let textNode = TextNode(text: string, editContext: editContext)
                         insert(textNode, at: indexOf(childNode: child) + offset)

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -27,7 +27,7 @@ extension Libxml2 {
         // MARK: - Editing behavior configuration
 
         static let elementsThatInterruptStyleAtEdges: [StandardElementType] = [.a]
-        static let elementsThatCantHaveChildren: [StandardElementType] = [.a, .br, .img]
+        static let elementsThatCantHaveChildren: [StandardElementType] = [.br, .img]
         
         // MARK: - Initializers
 

--- a/Aztec/Classes/Libxml2/DOM/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Node.swift
@@ -52,6 +52,10 @@ extension Libxml2 {
 
         // MARK: - Override in Subclasses
 
+        func canHaveChildren() -> Bool {
+            return false
+        }
+
         /// Override.
         ///
         func length() -> Int {

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -242,7 +242,7 @@ extension Libxml2 {
         /// - Parameters:
         ///     - range: the range to remove the style from.
         ///
-        func removeImageURL(spanning range: NSRange) {
+        func removeImage(spanning range: NSRange) {
             performAsyncUndoable { [weak self] in
                 self?.removeImageSynchronously(spanning: range)
             }
@@ -409,29 +409,27 @@ extension Libxml2 {
             }
         }
 
+        // MARK: - Images
+
         /// Applies an image to the specified range
         ///
         /// - Parameters:
         ///   - imageURL: the URL for the img src attribute
         ///   - range: the range to insert the image
         ///
-        func applyImageURL(imageURL: URL, spanning range:NSRange) {
+        func insertImage(imageURL: URL, replacing range:NSRange) {
             performAsyncUndoable { [weak self] in
-                self?.applyImageURLSynchronously(imageURL: imageURL, spanning: range)
+                self?.insertImageSynchronously(imageURL: imageURL, replacing: range)
             }
         }
 
-        // MARK: - Apply Styles Synchronously
-
-        private func applyImageURLSynchronously(imageURL: URL, spanning range: NSRange) {
+        private func insertImageSynchronously(imageURL: URL, replacing range: NSRange) {
             let imageURLString = imageURL.absoluteString
 
-            applyElement(.img, spanning: range, attributes: [StringAttribute(name:"src", value: imageURLString)])
-/*
             let elementDescriptor = ElementNodeDescriptor(elementType: .img,
                                                           attributes: [Libxml2.StringAttribute(name:"src", value: imageURLString)])
 
-            rootNode.replaceCharacters(inRange: range, withElement: elementDescriptor)*/
+            rootNode.replaceCharacters(inRange: range, withElement: elementDescriptor)
         }
         
         // MARK: - Styles to HTML elements

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -6,7 +6,10 @@ extension Libxml2 {
     /// a string.
     ///
     /// Any requests made to this class are performed in its own queue (sometimes synchronously,
-    /// sometimes asynchronously).
+    /// sometimes asynchronously).  Public methods are resopnsible for queueing requests, while all
+    /// private methods MUST be synchronous.  This is to ensure a simple design in which we are sure
+    /// we're not queueing an operation more than once.  Private methods can be called without
+    /// having to figure out if they'll be queueing additional operations (they won't).
     ///
     class DOMString {
         

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -218,24 +218,7 @@ extension Libxml2 {
             }
         }
 
-        // MARK: - Images
-        
-        fileprivate func setImageURLInDOM(_ imageURL: URL?, forRange range: NSRange) {
-            
-            let imageURLString = imageURL?.absoluteString ?? ""
-            
-            setImageURLStringInDOM(imageURLString, forRange: range)
-        }
-        
-        fileprivate func setImageURLStringInDOM(_ imageURLString: String, forRange range: NSRange) {
-            
-            let elementDescriptor = ElementNodeDescriptor(elementType: .img,
-                                                          attributes: [Libxml2.StringAttribute(name:"src", value: imageURLString)])
-            
-            rootNode.replaceCharacters(inRange: range, withElement: elementDescriptor)
-        }
-
-        // MARK: Remove Styles
+        // MARK: - Remove Styles
 
         func remove(element: StandardElementType, at range: NSRange){
             performAsyncUndoable { [weak self] in
@@ -254,13 +237,23 @@ extension Libxml2 {
             }
         }
 
+        /// Disables an image from the specified range.
+        ///
+        /// - Parameters:
+        ///     - range: the range to remove the style from.
+        ///
+        func removeImageURL(spanning range: NSRange) {
+            performAsyncUndoable { [weak self] in
+                self?.removeImageSynchronously(spanning: range)
+            }
+        }
+
         /// Disables italic from the specified range.
         ///
         /// - Parameters:
         ///     - range: the range to remove the style from.
         ///
         func removeItalic(spanning range: NSRange) {
-            //domQueue.async { [weak self] in
             performAsyncUndoable { [weak self] in
                 self?.removeItalicSynchronously(spanning: range)
             }
@@ -322,6 +315,10 @@ extension Libxml2 {
         private func removeBoldSynchronously(spanning range: NSRange) {
             rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.b.equivalentNames)
         }
+
+        private func removeImageSynchronously(spanning range: NSRange) {
+            rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.img.equivalentNames)
+        }
         
         private func removeItalicSynchronously(spanning range: NSRange) {
             rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.i.equivalentNames)
@@ -339,7 +336,7 @@ extension Libxml2 {
             rootNode.unwrap(range: range, fromElementsNamed: StandardElementType.blockquote.equivalentNames)
         }
         
-        // Apply Styles
+        // MARK: - Apply Styles
                 
         /// Applies bold to the specified range.
         ///
@@ -412,16 +409,29 @@ extension Libxml2 {
             }
         }
 
-        /// Replaces the characteres in the specified range for a an img element pointing to the provided URL
+        /// Applies an image to the specified range
         ///
         /// - Parameters:
         ///   - imageURL: the URL for the img src attribute
         ///   - range: the range to insert the image
         ///
-        func applyImage(imageURL: URL?, spanning range:NSRange) {
+        func applyImageURL(imageURL: URL, spanning range:NSRange) {
             performAsyncUndoable { [weak self] in
-                self?.setImageURLInDOM(imageURL, forRange: range)
+                self?.applyImageURLSynchronously(imageURL: imageURL, spanning: range)
             }
+        }
+
+        // MARK: - Apply Styles Synchronously
+
+        private func applyImageURLSynchronously(imageURL: URL, spanning range: NSRange) {
+            let imageURLString = imageURL.absoluteString
+
+            applyElement(.img, spanning: range, attributes: [StringAttribute(name:"src", value: imageURLString)])
+/*
+            let elementDescriptor = ElementNodeDescriptor(elementType: .img,
+                                                          attributes: [Libxml2.StringAttribute(name:"src", value: imageURLString)])
+
+            rootNode.replaceCharacters(inRange: range, withElement: elementDescriptor)*/
         }
         
         // MARK: - Styles to HTML elements

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -422,9 +422,9 @@ open class TextStorage: NSTextStorage {
                 return
             }
 
-            dom.applyImageURL(imageURL: urlToAdd, spanning: range)
+            dom.insertImage(imageURL: urlToAdd, replacing: range)
         } else if removeImageUrl {
-            dom.removeImageURL(spanning: range)
+            dom.removeImage(spanning: range)
         }
     }
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -351,9 +351,10 @@ open class TextStorage: NSTextStorage {
 
             processUnderlineDifferences(in: domRange, betweenOriginal: sourceStyle, andNew: targetStyle)
         case NSAttachmentAttributeName:
-            if let attachment = sourceValue as? TextAttachment {
-                dom.applyImage(imageURL: attachment.url, spanning: domRange)
-            }
+            let sourceAttachment = sourceValue as? TextAttachment
+            let targetAttachment = targetValue as? TextAttachment
+
+            processAttachmentDifferences(in: domRange, betweenOriginal: sourceAttachment, andNew: targetAttachment)
         case NSParagraphStyleAttributeName:
             let sourceStyle = sourceValue as? ParagraphStyle
             let targetStyle = targetValue as? ParagraphStyle
@@ -400,6 +401,30 @@ open class TextStorage: NSTextStorage {
             dom.applyBold(spanning: range)
         } else if removeBold {
             dom.removeBold(spanning: range)
+        }
+    }
+
+    private func processAttachmentDifferences(in range: NSRange, betweenOriginal original: TextAttachment?, andNew new: TextAttachment?) {
+
+        let originalUrl = original?.url
+        let newUrl = new?.url
+
+        guard originalUrl != newUrl else {
+            return
+        }
+
+        let addImageUrl = originalUrl == nil && newUrl != nil
+        let removeImageUrl = originalUrl != nil && newUrl == nil
+
+        if addImageUrl {
+            guard let urlToAdd = newUrl else {
+                assertionFailure("This should not be possible.  Review your logic.")
+                return
+            }
+
+            dom.applyImageURL(imageURL: urlToAdd, spanning: range)
+        } else if removeImageUrl {
+            dom.removeImageURL(spanning: range)
         }
     }
 


### PR DESCRIPTION
Fixes adding images to the DOM so that only differences will be applied.  Also removes some weird issues that were causing images to be duplicated.

Fixes #305 

**How to test the previous issue:**

1. Launch the editor in 0.5a4.
2. Open the empty editor demo.
3. Insert and image and type just "a".
4. Switch to HTML mode.

You'll notice the image tag is duplicated.