### PR TITLE
Fixes empty TextView crash when inserting a link.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -643,8 +643,7 @@ open class TextView: UITextView {
     open func setLink(_ url: URL, title: String, inRange range: NSRange) {
         let formatter = LinkFormatter()
         formatter.attributeValue = url        
-        var attributes = storage.attributes(at: range.location, effectiveRange: nil)
-        attributes = formatter.apply(to: attributes)
+        let attributes = formatter.apply(to: typingAttributes)
         storage.replaceCharacters(in: range, with: NSAttributedString(string: title, attributes: attributes))
         delegate?.textViewDidChange?(self)
     }

--- a/AztecTests/AztecVisualEditorTests.swift
+++ b/AztecTests/AztecVisualEditorTests.swift
@@ -337,6 +337,30 @@ class AztecVisualEditorTests: XCTestCase {
         XCTAssert(!editor.formatIdentifiersAtIndex(1).contains(.blockquote))
     }
 
+    // MARK: - Insert links
+
+    /// Tests that inserting a link on an empty editor works.  Also that it doesn't crash the
+    /// editor (which was the reason why this test was first introduced).
+    ///
+    /// Input:
+    ///     - Link URL is: "www.wordpress.com"
+    ///     - Link Title: "WordPress.com"
+    ///     - Insertion range: (loc: 0, len: 0)
+    ///
+    func testInsertingLinkWorks() {
+
+        let linkUrl = "www.wordpress.com"
+        let linkTitle = "WordPress.com"
+        let insertionRange = NSRange(location: 0, length: 0)
+
+        let textView = editorConfiguredForTesting(withHTML: "")
+        let url = URL(string: linkUrl)!
+
+        textView.setLink(url, title: linkTitle, inRange: insertionRange)
+
+        XCTAssertEqual(textView.getHTML(), "<a href=\"\(linkUrl)\">\(linkTitle)</a>")
+    }
+
     // MARK: - Helpers
     let paragraph = "Lorem ipsum dolar sit amet.\n"
 


### PR DESCRIPTION
<h3>Description:</h3>

Makes sure an empty TextView doesn't crash when inserting a link.  Includes a unit test to make sure there's no regression on this issue.

Fixes #308 

<h3>How to test:</h3>

**Test 1:** Run the unit tests.

**Test 2:**

1. Launch the empty editor demo.
2. Insert a link while the editor is empty.
3. Make sure it doesn't crash.

**Test 3:**

1. Launch the editor demo with content.
2. Select a range of text with a style.
3. Tap the link button and insert a link.
4. Make sure the first stile in the range is kept.  (Other ranges are not kept but that issue was not introduced by this PR).