### PR TITLE
Fixes some issues with text fragmentation.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1304,8 +1304,7 @@ extension Libxml2 {
 
                         let offset = intersection.location == 0 ? 0 : 1
 
-                        let textNode = TextNode(text: string, editContext: editContext)
-                        insert(textNode, at: indexOf(childNode: child) + offset)
+                        insert(string, atNodeIndex: indexOf(childNode: child) + offset)
                         textInserted = true
                     }
 

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1323,6 +1323,20 @@ class ElementNodeTests: XCTestCase {
         XCTAssertEqual(paragraph.children[1], boldNode)
     }
 
+    // MARK: - replaceCharactersInRange
+
+    func testInsertingTextDoesntFragmentTextNodes() {
+        let textNode = TextNode(text: "")
+        let paragraphNode = ElementNode(name: StandardElementType.p.rawValue, attributes: [], children: [textNode])
+
+        paragraphNode.replaceCharacters(inRange: NSRange(location: 0, length: 0), withString: "a")
+        paragraphNode.replaceCharacters(inRange: NSRange(location: 1, length: 0), withString: "b")
+        paragraphNode.replaceCharacters(inRange: NSRange(location: 2, length: 0), withString: "c")
+
+        XCTAssertEqual(paragraphNode.children.count, 1)
+        XCTAssert(paragraphNode.children[0] is TextNode)
+    }
+
     /// Tests `replaceCharacters(inRange:withString:)`.
     ///
     /// Input HTML: `<p>Click on this <a href="http://www.wordpress.com">link</a></p>`

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1328,7 +1328,7 @@ class ElementNodeTests: XCTestCase {
     /// ElementNode's `replaceCharacters(inRange:withString:)` has produced `TextNode` fragmentation
     /// more than once in the past.
     ///
-    /// This test tries to make sure we don't have regressions on `TextNode` fragmentation.
+    /// This test tries to make sure we don't have regressions causing `TextNode` fragmentation.
     ///
     func testInsertingTextDoesntFragmentTextNodes() {
         let textNode = TextNode(text: "")

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1325,6 +1325,11 @@ class ElementNodeTests: XCTestCase {
 
     // MARK: - replaceCharactersInRange
 
+    /// ElementNode's `replaceCharacters(inRange:withString:)` has produced `TextNode` fragmentation
+    /// more than once in the past.
+    ///
+    /// This test tries to make sure we don't have regressions on `TextNode` fragmentation.
+    ///
     func testInsertingTextDoesntFragmentTextNodes() {
         let textNode = TextNode(text: "")
         let paragraphNode = ElementNode(name: StandardElementType.p.rawValue, attributes: [], children: [textNode])


### PR DESCRIPTION
Fixes some issues that were causing `TextNode` fragmentation.

**How to test:**

1. Open the empty editor demo.
2. Type in "Abcdef"
3. In Xcode, place a breakpoint in `ElementNode:1289`
4. In the editor, type 1 last character "g".

Xcode should break.  Type:

`po self`

Make sure the whole text (minus the last "g") is in a single text node.