### PR TITLE
Improve more parsing

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -101,7 +101,9 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         if node.comment.hasPrefix("more") {
             var attributes = inheritedAttributes;
             let moreAttachment = MoreAttachment()
-            moreAttachment.message = NSAttributedString(string: NSLocalizedString("MORE", comment: "Text for the center of the more divider"), attributes: defaultAttributes)
+            let index = "more".endIndex
+            moreAttachment.message = node.comment.substring(from: index)            
+            moreAttachment.label = NSAttributedString(string: NSLocalizedString("MORE", comment: "Text for the center of the more divider"), attributes: defaultAttributes)
             attributes[NSAttachmentAttributeName] = moreAttachment
             return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
         }

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -98,10 +98,10 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
-        if node.comment == "more" {
+        if node.comment.hasPrefix("more") {
             var attributes = inheritedAttributes;
             let moreAttachment = MoreAttachment()
-            moreAttachment.message = NSAttributedString(string: NSLocalizedString("MORE", comment: "Text for the center of the   more divider"), attributes: defaultAttributes)
+            moreAttachment.message = NSAttributedString(string: NSLocalizedString("MORE", comment: "Text for the center of the more divider"), attributes: defaultAttributes)
             attributes[NSAttachmentAttributeName] = moreAttachment
             return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
         }

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -98,10 +98,11 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
-        if node.comment.hasPrefix("more") {
+        let moreLabel = "more"
+        if node.comment.hasPrefix(moreLabel) {
             var attributes = inheritedAttributes;
             let moreAttachment = MoreAttachment()
-            let index = "more".endIndex
+            let index = moreLabel.endIndex
             moreAttachment.message = node.comment.substring(from: index)            
             moreAttachment.label = NSAttributedString(string: NSLocalizedString("MORE", comment: "Text for the center of the more divider"), attributes: defaultAttributes)
             attributes[NSAttachmentAttributeName] = moreAttachment

--- a/Aztec/Classes/TextKit/MoreAttachment.swift
+++ b/Aztec/Classes/TextKit/MoreAttachment.swift
@@ -13,13 +13,15 @@ open class MoreAttachment: NSTextAttachment
 
     /// A message to display overlaid on top of the image
     ///
-    open var message: NSAttributedString = NSAttributedString(string: "MORE") {
+    open var label: NSAttributedString = NSAttributedString(string: "MORE") {
         willSet {
-            if newValue != message {
+            if newValue != label {
                 glyphImage = nil
             }
         }
     }
+
+    open var message: String = ""
 
     // MARK: - NSTextAttachmentContainer
 
@@ -40,8 +42,8 @@ open class MoreAttachment: NSTextAttachment
 
         UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
 
-        let colorMessage = NSMutableAttributedString(attributedString: message)
-        colorMessage.addAttribute(NSForegroundColorAttributeName, value: color, range: message.rangeOfEntireString)
+        let colorMessage = NSMutableAttributedString(attributedString: label)
+        colorMessage.addAttribute(NSForegroundColorAttributeName, value: color, range: label.rangeOfEntireString)
         let textRect = colorMessage.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
         let textPosition = CGPoint(x: ((size.width - textRect.width) / 2), y: ((size.height - textRect.height) / 2) )
         colorMessage.draw(in: CGRect(origin: textPosition , size: CGSize(width: size.width, height: textRect.size.height)))

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -17,7 +17,7 @@ I'm a test post.
 
 <a href="http://www.wordpress.com">I'm a link!</a><br/>
 
-<!--more-->
+<!--more Read more-->
 <p>
 <del datetime="2014-05-19T20:55:58+00:00">Strikethrough</del><br/>
 


### PR DESCRIPTION
According to this [documentation](https://en.support.wordpress.com/more-tag/) a more tag only need to start with the ```more``` comment text. All the text after is to be used has the label of the more tag when presenting in the final page.

This PR fix the parsing of the more comment and stores the text after for future editing.

How to test:
 - Open the demo app with content
 - Check if the more tag is parsed correctly