### PR TITLE
Fixes disappearing blockquotes

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -225,11 +225,9 @@ open class TextView: UITextView {
                 return
         }
 
-        let string = storage.string
+        let firstOldCharacterIndex = storage.string.index(storage.string.startIndex, offsetBy: selectedRange.length)
 
-        let firstOldCharacterIndex = string.index(string.startIndex, offsetBy: selectedRange.length)
-
-        guard string.characters[firstOldCharacterIndex] != Character(.newline) else {
+        guard storage.string.characters[firstOldCharacterIndex] != Character(.newline) else {
             return
         }
 


### PR DESCRIPTION
<h3>Description:</h3>

Some styles are removed when inserting text at location 0.

Fixes #312 

<h3>How to test:</h3>

**Test 1:**

Run the unit tests.

**Test 2:**

Follow the steps described in #312 and make sure the bug can't be reproduced anymore.