### PR TITLE
Change attachment interface.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -33,7 +33,7 @@ protocol TextStorageAttachmentsDelegate {
     ///
     /// - Returns: the requested `NSURL` where the image is stored.
     ///
-    func storage(_ storage: TextStorage, urlForImage image: UIImage) -> URL
+    func storage(_ storage: TextStorage, urlForAttachment attachment: TextAttachment) -> URL
 
     /// Called when a attachment is removed from the storage.
     ///
@@ -207,7 +207,7 @@ open class TextStorage: NSTextStorage {
             let replacementAttachment = TextAttachment()
             replacementAttachment.imageProvider = self
             replacementAttachment.image = image
-            replacementAttachment.url = attachmentsDelegate.storage(self, urlForImage: image)
+            replacementAttachment.url = attachmentsDelegate.storage(self, urlForAttachment: replacementAttachment)
             
             finalString.addAttribute(NSAttachmentAttributeName, value: replacementAttachment, range: range)
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -22,18 +22,18 @@ public protocol TextViewMediaDelegate: class {
         onSuccess success: @escaping (UIImage) -> Void,
         onFailure failure: @escaping (Void) -> Void) -> UIImage
 
-    /// Called when an image is about to be added to the storage as an attachment (copy/paste), so that the
-    /// delegate can specify an URL where that image is available.
+    /// Called when an attachment is about to be added to the storage as an attachment (copy/paste), so that the
+    /// delegate can specify an URL where that attachment is available.
     ///
     /// - Parameters:
     ///     - textView: The textView that is requesting the image.
-    ///     - image: The image that was added to the storage.
+    ///     - attachment: The attachment that was added to the storage.
     ///
     /// - Returns: the requested `NSURL` where the image is stored.
     ///
     func textView(
         _ textView: TextView,
-        urlForImage image: UIImage) -> URL
+        urlForAttachment attachment: TextAttachment) -> URL
 
 
     /// Called when a attachment is removed from the storage.
@@ -870,13 +870,13 @@ extension TextView: TextStorageAttachmentsDelegate {
         return defaultMissingImage
     }
     
-    func storage(_ storage: TextStorage, urlForImage image: UIImage) -> URL {
+    func storage(_ storage: TextStorage, urlForAttachment attachment: TextAttachment) -> URL {
         
         guard let mediaDelegate = mediaDelegate else {
             fatalError("This class requires a media delegate to be set.")
         }
         
-        return mediaDelegate.textView(self, urlForImage: image)
+        return mediaDelegate.textView(self, urlForAttachment: attachment)
     }
 
     func storage(_ storage: TextStorage, deletedAttachmentWithID attachmentID: String) {

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -100,7 +100,7 @@ class TextStorageTests: XCTestCase
             deletedAttachmendIDCalledWithString = attachmentID
         }
 
-        func storage(_ storage: TextStorage, urlForImage image: UIImage) -> URL {
+        func storage(_ storage: TextStorage, urlForAttachment attachment: TextAttachment) -> URL {
             return URL(string:"test://")!
         }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -579,11 +579,14 @@ extension EditorDemoController: TextViewMediaDelegate
         return Gridicon.iconOfType(.image)
     }
     
-    func textView(_ textView: TextView, urlForImage image: UIImage) -> URL {
+    func textView(_ textView: TextView, urlForAttachment attachment: TextAttachment) -> URL {
         
         // TODO: start fake upload process
-        
-        return saveToDisk(image: image)
+        if let image = attachment.image {
+            return saveToDisk(image: image)
+        } else {
+            return URL(string: "placeholder://")!
+        }
     }
 
     func textView(_ textView: TextView, deletedAttachmentWithID attachmentID: String) {


### PR DESCRIPTION
This PR changes the attachment interface when doing copy/paste to allows integration on the main WP app and other apps.

For details of why the change check this [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/6758) on the main WordPress app.

How to test:
 - Start the demo app
 - Use the empty demo
 - Switch to the Photos a[[
 - Copy an image on the Photos app
 - Switch to the Aztec demo
 - Paste the image
 - Check if the integration worked.