### PR TITLE
Updates the caret position after pasting into the editor.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -123,7 +123,7 @@ open class TextView: UITextView {
     }
 
 
-    // MARK: - Intersect copy paste operations
+    // MARK: - Intercept copy paste operations
 
     open override func copy(_ sender: Any?) {
         super.copy(sender)
@@ -143,6 +143,7 @@ open class TextView: UITextView {
         string.loadLazyAttachments()
 
         storage.replaceCharacters(in: selectedRange, with: string)
+        delegate?.textViewDidChange?(self)
         selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
     }
 
@@ -152,17 +153,17 @@ open class TextView: UITextView {
             return
         }
 
-
         let range = string.rangeOfEntireString
         string.addAttributes(typingAttributes, range: range)
         string.loadLazyAttachments()
 
         storage.replaceCharacters(in: selectedRange, with: string)
+        delegate?.textViewDidChange?(self)
         selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
     }
 
 
-    // MARK: - Intersect keyboard operations
+    // MARK: - Intercept keyboard operations
 
     open override func insertText(_ text: String) {
         // Note:

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -141,7 +141,9 @@ open class TextView: UITextView {
         }
 
         string.loadLazyAttachments()
+
         storage.replaceCharacters(in: selectedRange, with: string)
+        selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
     }
 
     open func pasteAndMatchStyle(_ sender: Any?) {
@@ -156,6 +158,7 @@ open class TextView: UITextView {
         string.loadLazyAttachments()
 
         storage.replaceCharacters(in: selectedRange, with: string)
+        selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
     }
 
 


### PR DESCRIPTION
Fixes #301

To test:

Just paste something and make sure the caret position is moved to the end of the pasted content.