### PR TITLE
Improve attributes formatter interface

### DIFF
--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -53,7 +53,7 @@ protocol AttributeFormatter {
 
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange
 
-    func worksInEmtpyRange() -> Bool
+    func worksInEmptyRange() -> Bool
 }
 
 
@@ -185,7 +185,7 @@ extension CharacterAttributeFormatter {
         return range
     }
 
-    func worksInEmtpyRange() -> Bool {
+    func worksInEmptyRange() -> Bool {
         return false
     }
 }
@@ -237,7 +237,7 @@ extension ParagraphAttributeFormatter {
         return newSelectedRange
     }
 
-    func worksInEmtpyRange() -> Bool {
+    func worksInEmptyRange() -> Bool {
         return true
     }
 }

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -114,7 +114,7 @@ extension AttributeFormatter {
     func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) {
         var rangeToApply = applicationRange(for: range, in: text)
 
-        if rangeToApply.length == 0 || text.length == 0 {
+        if worksInEmptyRange() && ( rangeToApply.length == 0 || text.length == 0)   {
             let placeholder = placeholderForEmptyLine(using: placeholderAttributes)
             text.insert(placeholder, at: rangeToApply.location)
             rangeToApply = NSMakeRange(text.length - 1, 1)

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -47,6 +47,14 @@ protocol AttributeFormatter {
     ///
     func remove(from attributes: [String: Any]) -> [String: Any]
 
+    /// Applies the Formatter's Attributes into a given string, at the specified range.
+    ///
+    func applyAttributes(to string: NSMutableAttributedString, at range: NSRange)
+
+    /// Removes the Formatter's Attributes from a given string, at the specified range.
+    ///
+    func removeAttributes(from string: NSMutableAttributedString, at range: NSRange)
+
     /// Checks if the attribute is present in a dictionary of attributes.
     ///
     func present(in attributes: [String: Any]) -> Bool
@@ -101,6 +109,58 @@ extension AttributeFormatter {
         }
     }
 
+    /// Applies the Formatter's Attributes into a given string, at the specified range.
+    ///
+    func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) {
+        var rangeToApply = applicationRange(for: range, in: text)
+
+        if rangeToApply.length == 0 || text.length == 0 {
+            let placeholder = placeholderForEmptyLine(using: placeholderAttributes)
+            text.insert(placeholder, at: rangeToApply.location)
+            rangeToApply = NSMakeRange(text.length - 1, 1)
+        }
+
+        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
+            let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)
+            let attributes = apply(to: currentAttributes)
+            text.addAttributes(attributes, range: range)
+        }
+    }
+
+    /// Removes the Formatter's Attributes from a given string, at the specified range.
+    ///
+    func removeAttributes(from text: NSMutableAttributedString, at range: NSRange) {
+        let rangeToApply = applicationRange(for: range, in: text)
+        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
+            let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)
+            let attributes = remove(from: currentAttributes)
+
+            let currentKeys = Set(currentAttributes.keys)
+            let newKeys = Set(attributes.keys)
+            let removedKeys = currentKeys.subtracting(newKeys)
+            for key in removedKeys {
+                text.removeAttribute(key, range: range)
+            }
+
+            text.addAttributes(attributes, range: range)
+        }
+    }
+
+    /// Toggles the Attribute Format, into a given string, at the specified range.
+    ///
+    @discardableResult
+    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {
+        //We decide if we need to apply or not the attribute based on the value on the initial position of the range
+        let shouldApply =  shouldApplyAttributes(to: text, at: range)
+
+        if shouldApply {
+            applyAttributes(to: text, at: range)
+        } else {
+            removeAttributes(from: text, at: range)
+        }
+
+        return nil
+    }
 }
 
 
@@ -124,30 +184,6 @@ private extension AttributeFormatter {
 
         return present(in: text, at: range) == false
     }
-
-    /// Applies the Formatter's Attributes into a given string, at the specified range.
-    ///
-    func applyAttributes(to string: NSMutableAttributedString, at range: NSRange) {
-        let currentAttributes = string.attributes(at: range.location, effectiveRange: nil)
-        let attributes = apply(to: currentAttributes)
-        string.addAttributes(attributes, range: range)
-    }
-
-    /// Removes the Formatter's Attributes from a given string, at the specified range.
-    ///
-    func removeAttributes(from string: NSMutableAttributedString, at range: NSRange) {
-        let currentAttributes = string.attributes(at: range.location, effectiveRange: nil)
-        let attributes = remove(from: currentAttributes)
-
-        let currentKeys = Set(currentAttributes.keys)
-        let newKeys = Set(attributes.keys)
-        let removedKeys = currentKeys.subtracting(newKeys)
-        for key in removedKeys {
-            string.removeAttribute(key, range: range)
-        }
-
-        string.addAttributes(attributes, range: range)
-    }
 }
 
 
@@ -161,27 +197,6 @@ extension CharacterAttributeFormatter {
     var placeholderAttributes: [String : Any]? { return nil }
 
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
-        return range
-    }
-
-    /// Toggles the Attribute Format, into a given string, at the specified range.
-    ///
-    @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {
-        guard range.location < text.length else {
-            return range
-        }
-        //We decide if we need to apply or not the attribute based on the value on the initial position of the range
-        let shouldApply =  shouldApplyAttributes(to: text, at: range)
-        // Then we go trough for the range with different attributes and apply or remove accordingly.
-        text.enumerateAttributes(in: range, options: []) { (attributes, range, stop) in
-            if shouldApply {
-                applyAttributes(to: text, at: range)
-            } else {
-                removeAttributes(from: text, at: range)
-            }
-        }
-
         return range
     }
 
@@ -200,41 +215,6 @@ extension ParagraphAttributeFormatter {
 
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
         return text.paragraphRange(for: range)
-    }
-
-    /// Toggles an attribute in the specified range of a text storage, and returns the new Selected Range.
-    ///
-    /// - Note: Whenever either the application paragraph is empty, or the entire storage is empty,
-    ///   we'll need to insert a placeholder (Zero Width String). Reason why? Because some formatters
-    ///   (TextList / Blockquote) need to display a custom UI, even when there is no content to display.
-    ///   In those scenarios, TextView's TypingAttributes just don't do the trick.
-    ///
-    /// - Note: For the reasons mentioned above, the first thing we'll do is to determine if the attribute should
-    ///   be applied or not. Order of events is important. 
-    ///   Why? because we *may need* to insert an empty string placeholder, and this operation may alter this result!
-    ///
-    @discardableResult
-    func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange? {
-        let shouldApply = shouldApplyAttributes(to: text, at: range)
-        var rangeToApply = applicationRange(for: range, in: text)
-        var newSelectedRange: NSRange?
-
-        if rangeToApply.length == 0 || text.length == 0 {
-            let placeholder = placeholderForEmptyLine(using: placeholderAttributes)
-            text.insert(placeholder, at: rangeToApply.location)
-            newSelectedRange = NSRange(location: text.length, length: 0)
-            rangeToApply = NSMakeRange(text.length - 1, 1)
-        }
-
-        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
-            if shouldApply {
-                applyAttributes(to: text, at: range)
-            } else {
-                removeAttributes(from: text, at: range)
-            }
-        }
-
-        return newSelectedRange
     }
 
     func worksInEmptyRange() -> Bool {

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -17,11 +17,13 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
-        newParagraphStyle.headIndent += Metrics.defaultIndentation
-        newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-        newParagraphStyle.tailIndent -= Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
+        if newParagraphStyle.blockquote == nil {
+            newParagraphStyle.headIndent += Metrics.defaultIndentation
+            newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+            newParagraphStyle.tailIndent -= Metrics.defaultIndentation
+            newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
+            newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
+        }
         newParagraphStyle.blockquote = Blockquote()
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
         return resultingAttributes
@@ -35,11 +37,13 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
             return resultingAttributes
         }
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        newParagraphStyle.headIndent -= Metrics.defaultIndentation
-        newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-        newParagraphStyle.tailIndent += Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
+        if newParagraphStyle.blockquote != nil {
+            newParagraphStyle.headIndent -= Metrics.defaultIndentation
+            newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+            newParagraphStyle.tailIndent += Metrics.defaultIndentation
+            newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
+            newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
+        }
         newParagraphStyle.blockquote = nil
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
         return resultingAttributes

--- a/Aztec/Classes/Formatters/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/HeaderFormatter.swift
@@ -40,9 +40,12 @@ class HeaderFormatter: ParagraphAttributeFormatter {
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
+        if newParagraphStyle.headerLevel == .none  && headerLevel != .none {
+            newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
+            newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
+        }
         newParagraphStyle.headerLevel = headerLevel.rawValue
-        newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
+
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
 
         if let font = attributes[NSFontAttributeName] as? UIFont {
@@ -61,10 +64,11 @@ class HeaderFormatter: ParagraphAttributeFormatter {
             return resultingAttributes
         }
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        
+        if newParagraphStyle.headerLevel != .none  && headerLevel == .none {
+            newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
+            newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
+        }
         newParagraphStyle.headerLevel = HeaderType.none.rawValue
-        newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
 
         if let font = attributes[NSFontAttributeName] as? UIFont {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -628,7 +628,7 @@ open class TextStorage: NSTextStorage {
     // MARK: - Styles: Toggling
     @discardableResult func toggle(formatter: AttributeFormatter, at range: NSRange) -> NSRange? {
         let applicationRange = formatter.applicationRange(for: range, in: self)
-        if applicationRange.length == 0, !formatter.worksInEmtpyRange() {
+        if applicationRange.length == 0, !formatter.worksInEmptyRange() {
             return applicationRange
         }
 


### PR DESCRIPTION
This PR improves and cleanups the AttributeFormatter interface by allowing the following:

 - Allows apply and remove of formatters attributes directly, not only by toggling
 - Shares more common code between character formatters and paragraph formatters
 - Cleans up the code on TextView that was using toggles instead of direct apply and remove of attributes.

How to test:
 - Run the demo app
 - Interact with different styles and check if they update correctly
 - Try applying and remove newlines inside and around paragraph styles (list, block quotes, headers)
 - Check if unit tests pass


