### PR TITLE
More unicode fixing

### DIFF
--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -24,4 +24,8 @@ extension String
             else { return nil }
         return from
     }
+
+    func isLastValidLocation(_ location: Int) -> Bool {
+        return index(before: endIndex) == indexFromLocation(location)
+    }
 }

--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 
-// MARK: - String Extensions
+// MARK: - String NSRange and Location convertion Extensions
 //
 extension String
 {    
@@ -27,5 +27,23 @@ extension String
 
     func isLastValidLocation(_ location: Int) -> Bool {
         return index(before: endIndex) == indexFromLocation(location)
+    }
+
+    func location(after: Int) -> Int? {
+        guard let currentIndex = indexFromLocation(after) else {
+            return nil
+        }
+        let afterIndex = index(after: currentIndex)
+        let after16 = afterIndex.samePosition(in: utf16)
+        return utf16.distance(from: utf16.startIndex, to: after16)
+    }
+
+    func location(before: Int) -> Int? {
+        guard let currentIndex = indexFromLocation(before) else {
+            return nil
+        }
+        let beforeIndex = index(before: currentIndex)
+        let before16 = beforeIndex.samePosition(in: utf16)
+        return utf16.distance(from: utf16.startIndex, to: before16)
     }
 }

--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -6,10 +6,10 @@ import Foundation
 extension String
 {    
     func rangeFromNSRange(_ nsRange : NSRange) -> Range<String.Index>? {
-        
+        let from16 = utf16.index(utf16.startIndex, offsetBy: nsRange.location)
+        let to16 = utf16.index(from16, offsetBy: nsRange.length)
+
         guard
-            let from16 = utf16.index(utf16.startIndex, offsetBy: nsRange.location, limitedBy: utf16.endIndex),
-            let to16 = utf16.index(from16, offsetBy: nsRange.length, limitedBy: utf16.endIndex),
             let from = from16.samePosition(in: self),
             let to = to16.samePosition(in: self)
             else { return nil }

--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -16,4 +16,12 @@ extension String
         return from ..< to
                 
     }
+
+    func indexFromLocation(_ location: Int) -> String.Index? {
+        guard
+            let from16 = utf16.index(utf16.startIndex, offsetBy: location, limitedBy: utf16.endIndex),
+            let from = from16.samePosition(in: self)
+            else { return nil }
+        return from
+    }
 }

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -157,8 +157,8 @@ extension Libxml2.In {
             }
 
             let noBreaksText = singleSpaceText.replacingOccurrences(of: String(.newline), with: "")
-            let endingSpace = noBreaksText.characters.count > 0 && hasAnEndingSpace ? String(.space) : ""
-            let startingSpace = noBreaksText.characters.count > 0 && hasAStartingSpace ? String(.space) : ""
+            let endingSpace = !noBreaksText.isEmpty && hasAnEndingSpace ? String(.space) : ""
+            let startingSpace = !noBreaksText.isEmpty && hasAStartingSpace ? String(.space) : ""
             return "\(startingSpace)\(noBreaksText)\(endingSpace)"
         }
     }

--- a/Aztec/Classes/Libxml2/DOM/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/ElementNode.swift
@@ -1620,7 +1620,7 @@ extension Libxml2 {
         ///     - elementNames: the name of the elements we want to unwrap the nodes from.
         ///
         func unwrapChildren(intersectingRange range: NSRange, fromElementsNamed elementNames: [String]) {
-            if isBlockLevelElement() && (range.location == self.length() - 1) {
+            if isBlockLevelElement() && text().isLastValidLocation(range.location) {
                     return
             }
 

--- a/Aztec/Classes/Libxml2/DOM/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/TextNode.swift
@@ -70,7 +70,7 @@ extension Libxml2 {
                     parent.insert(separator, at: insertionIndex)
                     insertionIndex = insertionIndex + 1
                     
-                    if component.characters.count > 0 {
+                    if !component.isEmpty {
                         let textNode = TextNode(text: component, editContext: editContext)
                         
                         parent.insert(textNode, at: insertionIndex)
@@ -271,10 +271,11 @@ extension Libxml2 {
             guard location > 0 && location < length() else {
                 fatalError("Out of bounds!")
             }
+
             
-            let index = text().characters.index(text().startIndex, offsetBy: location)
-            
-            guard let parent = parent,
+            guard
+                let index = text().indexFromLocation(location),
+                let parent = parent,
                 let nodeIndex = parent.children.index(of: self) else {
                     
                     fatalError("This scenario should not be possible. Review the logic.")

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -583,11 +583,12 @@ open class TextStorage: NSTextStorage {
     }
 
     private func doesPreferLeftNode(atCaretPosition caretPosition: Int) -> Bool {
-        guard caretPosition != 0 else {
+        guard caretPosition != 0,
+            let previousLocation = textStore.string.location(before:caretPosition) else {
             return false
         }
 
-        return canAppendToNodeRepresentedByCharacter(atIndex: caretPosition - 1)
+        return canAppendToNodeRepresentedByCharacter(atIndex: previousLocation)
     }
 
     private func hasHorizontalLine(atIndex index: Int) -> Bool {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -316,7 +316,7 @@ open class TextStorage: NSTextStorage {
     ///         It's the offset this method will use to apply the styles found in the source string.
     ///
     private func applyStylesToDom(from attributedString: NSAttributedString, startingAt location: Int) {
-        let originalAttributes = location == 0 ? [:] : textStore.attributes(at: location - 1, effectiveRange: nil)
+        let originalAttributes = location == 0 ? [:] : textStore.attributes(at: textStore.string.location(before:location)!, effectiveRange: nil)
         let fullRange = NSRange(location: 0, length: attributedString.length)
 
         let domLocation = map(visualLocation: location)

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -333,15 +333,14 @@ class ElementNodeTests: XCTestCase {
     ///     - The original paragraph object should point to the first child paragraph.
     ///
     func testSplitAtLocation1() {
-        let text1 = "Hello"
+        let text1 = "Hello🇮🇳"
         let text2 = " World!"
         
         let textNode = TextNode(text: "\(text1)\(text2)")
         let paragraph = ElementNode(name: "p", attributes: [], children: [textNode])
         let div = ElementNode(name: "div", attributes: [], children: [paragraph])
         
-        let splitLocation = text1.characters.count
-        
+        let splitLocation = (text1 as NSString).length
         paragraph.split(atLocation: splitLocation)
         
         XCTAssertEqual(div.children.count, 2)
@@ -1689,13 +1688,13 @@ class ElementNodeTests: XCTestCase {
     /// - Output: `<div>This is a paragraph in a div</div>\n\nThis is some unwrapped text`
     ///
     func testInsertNewlineAfterDivShouldNotCrash() {
-        let text1 = "This is a paragraph in a div"
+        let text1 = "🇮🇳 This is a paragraph in a div"
         let text2 = "\nThis is some unwrapped text"
         let divText = TextNode(text: text1)
         let div = ElementNode(name: "div", attributes: [], children: [divText])
         let unwrappedText = TextNode(text: text2)
         let rootNode = RootNode(children: [div, unwrappedText])
-        let location = text1.characters.count
+        let location = (text1 as NSString).length
 
         rootNode.insert("\n", atLocation: location)
     }

--- a/AztecTests/StringRangeConversionTests.swift
+++ b/AztecTests/StringRangeConversionTests.swift
@@ -13,7 +13,7 @@ class StringRangeConversionTests: XCTestCase {
         super.tearDown()
     }
     
-    func testConversion() {
+    func testRangeConversion() {
         // test simple word
         var nsString: NSString = "Hello World!"
         var string: String = nsString as String
@@ -61,6 +61,56 @@ class StringRangeConversionTests: XCTestCase {
         wordCaptured = string.substring(with: range!)
 
         XCTAssertEqual(wordToCapture, wordCaptured)
+    }
+
+    func testLocationConversion() {
+        // test simple word
+        var nsString: NSString = "Hello World!"
+        var string: String = nsString as String
+
+        var wordToCapture = "World"
+        var nsRange = nsString.range(of: wordToCapture)
+        var index = string.indexFromLocation(nsRange.location)!
+
+        var wordCaptured = string.substring(to: index)
+
+        XCTAssertEqual("Hello ", wordCaptured)
+
+        // test with emoji size 2
+        nsString = "Hello 🌍!"
+        string = nsString as String
+
+        wordToCapture = "🌍"
+        nsRange = nsString.range(of: wordToCapture)
+        index = string.indexFromLocation(nsRange.location)!
+
+        wordCaptured = string.substring(to: index)
+
+        XCTAssertEqual("Hello ", wordCaptured)
+
+        // test with emoji size 4
+        nsString = "Hello 🇮🇳!"
+        string = nsString as String
+
+        wordToCapture = "🇮🇳"
+        nsRange = nsString.range(of: wordToCapture)
+        index = string.indexFromLocation(nsRange.location)!
+
+        wordCaptured = string.substring(to: index)
+
+        XCTAssertEqual("Hello ", wordCaptured)
+
+        // test with two emojis
+        nsString = "Hello 🇮🇳 🌍!"
+        string = nsString as String
+
+        wordToCapture = "🌍"
+        nsRange = nsString.range(of: wordToCapture)
+        index = string.indexFromLocation(nsRange.location)!
+
+        wordCaptured = string.substring(to: index)
+        
+        XCTAssertEqual("Hello 🇮🇳 ", wordCaptured)
     }
 
     

--- a/AztecTests/StringRangeConversionTests.swift
+++ b/AztecTests/StringRangeConversionTests.swift
@@ -113,5 +113,31 @@ class StringRangeConversionTests: XCTestCase {
         XCTAssertEqual("Hello 🇮🇳 ", wordCaptured)
     }
 
+    func testLocationBefore() {
+        var nsString: NSString = "Hello World!"
+        var string: String = nsString as String
+
+        var wordToCapture = "World"
+        var nsRange = nsString.range(of: wordToCapture)
+        var location = string.location(before: nsRange.location)!
+        var index = string.indexFromLocation(location)!
+        var wordCaptured = string.substring(to: index)
+
+        XCTAssertEqual("Hello", wordCaptured)
+
+        // test with emoji size 2
+        nsString = "Hello 🌍!"
+        string = nsString as String
+
+        wordToCapture = "🌍"
+        nsRange = nsString.range(of: wordToCapture)
+        location = string.location(before: nsRange.endLocation)!
+        index = string.indexFromLocation(location)!
+
+        wordCaptured = string.substring(to: index)
+        
+        XCTAssertEqual("Hello ", wordCaptured)
+    }
+
     
 }


### PR DESCRIPTION
This PR adds some more conversion methods between location on NSString and index on String.

How to test:
 - Run the unit tests.
 - Run the demo app
 - Add and remove emoji:
   -  On the end start of styles, 
   - On the end/start of lists and blockquotes
   - On the end of lines.
 - Check if no crashes occur
