### PR TITLE
Padding between images

### DIFF
--- a/Aztec/Classes/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/TextKit/TextAttachment.swift
@@ -26,6 +26,8 @@ open class TextAttachment: NSTextAttachment
         /// The color to use when drawing progress indicators
         ///
         public var progressColor = UIColor.blue
+
+        public var imageMargin = CGFloat(10.0)
     }
 
 
@@ -87,6 +89,8 @@ open class TextAttachment: NSTextAttachment
     /// The color to use when drawing progress indicators
     ///
     open var progressColor: UIColor = TextAttachment.appearance.progressColor
+
+    open var imageMargin: CGFloat = TextAttachment.appearance.imageMargin
 
     /// A message to display overlaid on top of the image
     ///
@@ -193,14 +197,14 @@ open class TextAttachment: NSTextAttachment
     }
     // MARK: - Origin calculation
 
-    fileprivate func xPosition(forContainerWidth containerWidth: CGFloat) -> Int {
+    fileprivate func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
         let imageWidth = onScreenWidth(containerWidth)
 
         switch (alignment) {
         case .center:
-            return Int(floor((containerWidth - imageWidth) / 2))
+            return CGFloat(floor((containerWidth - imageWidth) / 2))
         case .right:
-            return Int(floor(containerWidth - imageWidth))
+            return CGFloat(floor(containerWidth - imageWidth))
         default:
             return 0
         }
@@ -211,7 +215,7 @@ open class TextAttachment: NSTextAttachment
             let targetWidth = onScreenWidth(containerWidth)
             let scale = targetWidth / image.size.width
 
-            return floor(image.size.height * scale)
+            return floor(image.size.height * scale) + (imageMargin * 2)
         } else {
             return 0
         }
@@ -252,7 +256,7 @@ open class TextAttachment: NSTextAttachment
     fileprivate func glyph(basedOnImage image:UIImage, forBounds bounds: CGRect) -> UIImage? {
 
         let containerWidth = bounds.size.width
-        let origin = CGPoint(x: xPosition(forContainerWidth: bounds.size.width), y: 0)
+        let origin = CGPoint(x: xPosition(forContainerWidth: bounds.size.width), y: imageMargin)
         let size = CGSize(width: onScreenWidth(containerWidth), height: onScreenHeight(containerWidth))
 
         UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)

--- a/Aztec/Classes/TextKit/TextAttachment.swift
+++ b/Aztec/Classes/TextKit/TextAttachment.swift
@@ -27,6 +27,8 @@ open class TextAttachment: NSTextAttachment
         ///
         public var progressColor = UIColor.blue
 
+        /// The margin apply to the images being displayed. This is to avoid that two images in a row get glued together.
+        ///
         public var imageMargin = CGFloat(10.0)
     }
 
@@ -90,6 +92,8 @@ open class TextAttachment: NSTextAttachment
     ///
     open var progressColor: UIColor = TextAttachment.appearance.progressColor
 
+    /// The margin apply to the images being displayed. This is to avoid that two images in a row get glued together.
+    ///
     open var imageMargin: CGFloat = TextAttachment.appearance.imageMargin
 
     /// A message to display overlaid on top of the image
@@ -257,7 +261,7 @@ open class TextAttachment: NSTextAttachment
 
         let containerWidth = bounds.size.width
         let origin = CGPoint(x: xPosition(forContainerWidth: bounds.size.width), y: imageMargin)
-        let size = CGSize(width: onScreenWidth(containerWidth), height: onScreenHeight(containerWidth))
+        let size = CGSize(width: onScreenWidth(containerWidth), height: onScreenHeight(containerWidth) - imageMargin)
 
         UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -720,20 +720,31 @@ open class TextView: UITextView {
 
         guard let locationAfter = textStorage.string.location(after: index) else {
             selectedRange = NSRange(location: index, length: 0)
-            forceRedrawCursorAfterDelay()
             return;
         }
         var newLocation = locationAfter
-        // Check if there is an attachment at the location we are moving. If there is one check if we want to move before or after the attachment based on the margins.
-        if let attachment = self.attachmentAtPoint(point) {
+        if isPointInsideAttachmentMargin(point: point) {
+            newLocation = index
+        }
+        selectedRange = NSRange(location: newLocation, length: 0)
+    }
+
+
+    /// // Check if there is an attachment at the location we are moving. If there is one check if we want to move before or after the attachment based on the margins.
+    ///
+    /// - Parameter point: the point to check.
+    /// - Returns: true if the point fall inside an attachment margin
+    open func isPointInsideAttachmentMargin(point: CGPoint) -> Bool {
+        let index = layoutManager.characterIndex(for: point, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
+
+        if let attachment = attachmentAtPoint(point) {
             let glyphRange = layoutManager.glyphRange(forCharacterRange: NSRange(location: index, length: 1), actualCharacterRange: nil)
             let rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
             if point.y >= rect.origin.y && point.y <= (rect.origin.y + (2*attachment.imageMargin)) {
-                newLocation = index
+                return true
             }
         }
-        selectedRange = NSRange(location: newLocation, length: 0)
-        forceRedrawCursorAfterDelay()
+        return false
     }
 
     // MARK: - Links

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -718,7 +718,21 @@ open class TextView: UITextView {
             return
         }
 
-        selectedRange = NSRange(location: index + 1, length: 0)
+        guard let locationAfter = textStorage.string.location(after: index) else {
+            selectedRange = NSRange(location: index, length: 0)
+            forceRedrawCursorAfterDelay()
+            return;
+        }
+        var newLocation = locationAfter
+        // Check if there is an attachment at the location we are moving. If there is one check if we want to move before or after the attachment based on the margins.
+        if let attachment = self.attachmentAtPoint(point) {
+            let glyphRange = layoutManager.glyphRange(forCharacterRange: NSRange(location: index, length: 1), actualCharacterRange: nil)
+            let rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+            if point.y >= rect.origin.y && point.y <= (rect.origin.y + (2*attachment.imageMargin)) {
+                newLocation = index
+            }
+        }
+        selectedRange = NSRange(location: newLocation, length: 0)
         forceRedrawCursorAfterDelay()
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -845,7 +845,11 @@ extension EditorDemoController: UIGestureRecognizerDelegate
         let locationInTextView = recognizer.location(in: richTextView)
         // check if we have an attachment in the position we tapped
         guard let attachment = richTextView.attachmentAtPoint(locationInTextView) else {
-            // if we have an attachment marked lets unmark it
+            return
+        }
+        // move the selection to the position of the attachment
+        richTextView.moveSelectionToPoint(locationInTextView)
+        if richTextView.isPointInsideAttachmentMargin(point: locationInTextView) {
             if let selectedAttachment = currentSelectedAttachment {
                 selectedAttachment.clearAllOverlays()
                 richTextView.refreshLayoutFor(attachment: selectedAttachment)
@@ -853,8 +857,6 @@ extension EditorDemoController: UIGestureRecognizerDelegate
             }
             return
         }
-        // move the selection to the position of the attachment
-        richTextView.moveSelectionToPoint(locationInTextView)
         if attachment == currentSelectedAttachment {
             //if it's the same attachment has before let's display the options
             displayActions(forAttachment: attachment, position: locationInTextView)


### PR DESCRIPTION
Fixes: #331 

This PR adds the possibility to have padding between images/attachments and other content. This is mainly to avoid that images inserted one after the other are "stitched" together.
This PR also improves interaction when tapping in between the images to allow the cursor to stay in the middle of two images.

How to test:
 - Start the empty demo app
 - Insert three images one after the other.
 - Check if they have margin between them vertically.
 - Tap in the middle empty area between the images and check if the caret position is made between the two images.
