### PR TITLE
Fixes a crash with newlines on an empty editor.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -224,7 +224,7 @@ open class TextStorage: NSTextStorage {
     // MARK: - Overriden Methods
 
     override open func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [String : Any] {
-        return textStore.attributes(at: location, effectiveRange: range)
+        return textStore.length == 0 ? [:] : textStore.attributes(at: location, effectiveRange: range)
     }
 
     override open func replaceCharacters(in range: NSRange, with str: String) {

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -363,6 +363,16 @@ class AztecVisualtextViewTests: XCTestCase {
         XCTAssert(!textView.formatIdentifiersAtIndex(1).contains(.blockquote))
     }
 
+    // MARK: - Adding newlines
+
+    /// Tests that entering a newline in an empty editor does not crash it.
+    ///
+    func testAddingNewlineOnEmptyEditor() {
+        let textView = createTextView(withHTML: "")
+
+        textView.insertText("\n")
+    }
+
     // MARK: - Deleting newlines
 
     /// Tests that deleting a newline works by merging the component around it.

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -367,6 +367,9 @@ class AztecVisualtextViewTests: XCTestCase {
 
     /// Tests that entering a newline in an empty editor does not crash it.
     ///
+    /// Added to avoid regressions to the bug reported here:
+    /// https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/352
+    ///
     func testAddingNewlineOnEmptyEditor() {
         let textView = createTextView(withHTML: "")
 


### PR DESCRIPTION
<h3>Description:</h3>

Fixes a crash that is triggered by entering a newline in an empty editor view.

Fixes #352 

<h3>How to test:</h3>

I added a unit test that triggers the crash.  You can copy the test into develop to see it working.

Run the unit tests and make sure the crash isn't triggered in this branch.