### PR TITLE
Aztec: Format Bar

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		B5BC4FEE1DA2C17800614582 /* NSAttributedString+Lists.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */; };
 		B5BC4FF21DA2D17000614582 /* NSAttributedStringListsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */; };
 		B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FF51DA2D76600614582 /* TextList.swift */; };
+		B5C99D3F1E72E2E700335355 /* UIStackView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C99D3E1E72E2E700335355 /* UIStackView+Helpers.swift */; };
 		B5E607331DA56EC700C8A389 /* TextListFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */; };
 		B5F84B611E70595B0089A76C /* NSAttributedString+Analyzers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F84B601E70595B0089A76C /* NSAttributedString+Analyzers.swift */; };
 		B5F84B631E706B720089A76C /* NSAttributedStringAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F84B621E706B720089A76C /* NSAttributedStringAnalyzerTests.swift */; };
@@ -181,6 +182,7 @@
 		B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Lists.swift"; sourceTree = "<group>"; };
 		B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringListsTests.swift; path = Extensions/NSAttributedStringListsTests.swift; sourceTree = "<group>"; };
 		B5BC4FF51DA2D76600614582 /* TextList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextList.swift; sourceTree = "<group>"; };
+		B5C99D3E1E72E2E700335355 /* UIStackView+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStackView+Helpers.swift"; sourceTree = "<group>"; };
 		B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatterTests.swift; sourceTree = "<group>"; };
 		B5F84B601E70595B0089A76C /* NSAttributedString+Analyzers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Analyzers.swift"; sourceTree = "<group>"; };
 		B5F84B621E706B720089A76C /* NSAttributedStringAnalyzerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringAnalyzerTests.swift; path = Extensions/NSAttributedStringAnalyzerTests.swift; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 				599F25261D8BC9A1002871D6 /* String+RangeConversion.swift */,
 				B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */,
 				B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */,
+				B5C99D3E1E72E2E700335355 /* UIStackView+Helpers.swift */,
 				599F25271D8BC9A1002871D6 /* UITextView+Helpers.swift */,
 				F1A218141E02D5B3000AF5EB /* UndoManager.swift */,
 			);
@@ -745,6 +748,7 @@
 				F1288BAF1DD0B1EF00E67ABC /* HTMLNodeToNSAttributedString.swift in Sources */,
 				B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */,
 				F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */,
+				B5C99D3F1E72E2E700335355 /* UIStackView+Helpers.swift in Sources */,
 				F1C05B991E37F99D007510EA /* Character+Name.swift in Sources */,
 				599F253B1D8BC9A1002871D6 /* InNodesConverter.swift in Sources */,
 				B5B86D3C1DA41A550083DB3F /* TextListFormatter.swift in Sources */,

--- a/Aztec/Classes/Extensions/UIStackView+Helpers.swift
+++ b/Aztec/Classes/Extensions/UIStackView+Helpers.swift
@@ -1,0 +1,24 @@
+import Foundation
+import UIKit
+
+
+// MARK: - StackView Helpers
+//
+extension UIStackView {
+
+    /// Adds a collection of arranged Subviews
+    ///
+    func addArrangedSubviews(_ subviews: [UIView]) {
+        for subview in subviews {
+            addArrangedSubview(subview)
+        }
+    }
+
+    /// Removes a collection fo arranged subviews
+    ///
+    func removeArrangedSubviews(_ subviews: [UIView]) {
+        for subview in subviews {
+            removeArrangedSubview(subview)
+        }
+    }
+}

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -209,7 +209,7 @@ open class FormatBar: UIView {
 
 
 
-// MARK: - Private Helpers
+// MARK: - Configuration Helpers
 //
 private extension FormatBar {
 
@@ -294,9 +294,50 @@ private extension FormatBar {
 }
 
 
+
+// MARK: - Animation Helpers
+//
+extension FormatBar {
+
+    private var scrollableContentSize: CGSize {
+        return scrollView.contentSize
+    }
+
+    private var scrollabeVisibleSize: CGSize {
+        return scrollView.frame.size
+    }
+
+    open func animateSlightPeekWhenOverflows() {
+        guard scrollableContentSize.width > scrollabeVisibleSize.width else {
+            return
+        }
+
+        let originalRect = CGRect(origin: .zero, size: scrollabeVisibleSize)
+        let peekOrigin = CGPoint(x: scrollableContentSize.width * Animations.peekWidthRatio, y: 0)
+        let peekRect = CGRect(origin: peekOrigin, size: scrollabeVisibleSize)
+
+        UIView.animate(withDuration: Animations.durationLong, delay: Animations.delayZero, options: .curveEaseInOut, animations: {
+            self.scrollView.scrollRectToVisible(peekRect, animated: false)
+        }, completion: { _ in
+            UIView.animate(withDuration: Animations.durationShort, delay: Animations.delayZero, options: .curveEaseInOut, animations: {
+                self.scrollView.scrollRectToVisible(originalRect, animated: false)
+            }, completion: nil)
+        })
+    }
+}
+
+
+
 // MARK: - Private Constants
 //
 private extension FormatBar {
+
+    struct Animations {
+        static let durationLong = TimeInterval(0.3)
+        static let durationShort = TimeInterval(0.15)
+        static let delayZero = TimeInterval(0)
+        static let peekWidthRatio = CGFloat(0.05)
+    }
 
     struct Constants {
         static let fixedSeparatorMidPointPaddingX = CGFloat(5)

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -2,15 +2,21 @@ import Foundation
 import UIKit
 
 
-open class FormatBar: UIToolbar
-{
+// MARK: - FormatBar
+//
+open class FormatBar: UIView {
 
     open weak var formatter: FormatBarDelegate?
 
 
-    override open var items: [UIBarButtonItem]? {
+    open var items = [FormatBarItem]() {
+        willSet {
+            for item in items {
+                item.removeFromSuperview()
+            }
+        }
         didSet {
-            for item in formatBarItems {
+            for item in items {
                 configureButtonStyle(item)
                 configureButtonAction(item)
             }
@@ -20,7 +26,7 @@ open class FormatBar: UIToolbar
 
     override open var tintColor: UIColor? {
         didSet {
-            for item in formatBarItems {
+            for item in items {
                 item.tintColor = tintColor
             }
         }
@@ -29,7 +35,7 @@ open class FormatBar: UIToolbar
 
     open var selectedTintColor: UIColor? {
         didSet {
-            for item in formatBarItems {
+            for item in items {
                 item.selectedTintColor = selectedTintColor
             }
         }
@@ -38,7 +44,7 @@ open class FormatBar: UIToolbar
 
     open var highlightedTintColor: UIColor? {
         didSet {
-            for item in formatBarItems {
+            for item in items {
                 item.highlightedTintColor = highlightedTintColor
             }
         }
@@ -47,7 +53,7 @@ open class FormatBar: UIToolbar
 
     open var disabledTintColor: UIColor? {
         didSet {
-            for item in formatBarItems {
+            for item in items {
                 item.disabledTintColor = disabledTintColor
             }
         }
@@ -56,23 +62,13 @@ open class FormatBar: UIToolbar
 
     open var enabled = true {
         didSet {
-            for item in formatBarItems {
+            for item in items {
                 item.isEnabled = enabled
             }
         }
     }
 
 
-    open var formatBarItems: [FormatBarItem] {
-        guard let items = items else {
-            return [FormatBarItem]()
-        }
-        return items.filter({ (element) -> Bool in
-            if let _ = element as? FormatBarItem {
-                return true
-            }
-            return false
-        }) as! [FormatBarItem]
     }
 
 

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -119,6 +119,27 @@ open class FormatBar: UIView {
     open var topBorderColor = UIColor.darkGray
 
 
+    /// Bounds Change Observer
+    ///
+    override open var bounds: CGRect {
+        didSet {
+            // Note: Under certain conditions, frame.didSet might get called instead of bounds.didSet.
+            // We're observing both for that reason!
+            refreshScrollingLock()
+        }
+    }
+
+
+    /// Bounds Change Observer
+    ///
+    override open var frame: CGRect {
+        didSet {
+            // Note: Under certain conditions, frame.didSet might get called instead of bounds.didSet.
+            // We're observing both for that reason!
+            refreshScrollingLock()
+        }
+    }
+
 
     // MARK: - Initializers
 
@@ -189,7 +210,6 @@ open class FormatBar: UIView {
     override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         refreshStackViewsSpacing()
-        refreshScrollingLock()
     }
 
 
@@ -312,7 +332,7 @@ private extension FormatBar {
     /// Disables scrolling whenever there's no actual overflow
     ///
     func refreshScrollingLock() {
-        scrollView.layoutIfNeeded()
+        layoutIfNeeded()
         scrollView.isScrollEnabled = scrollView.contentSize.width > scrollView.frame.width
     }
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -189,6 +189,7 @@ open class FormatBar: UIView {
     override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         refreshStackViewsSpacing()
+        refreshScrollingLock()
     }
 
 
@@ -305,6 +306,14 @@ private extension FormatBar {
 
         scrollableStackView.spacing = stackViewSpacing
         fixedStackView.spacing = stackViewSpacing
+    }
+
+
+    /// Disables scrolling whenever there's no actual overflow
+    ///
+    func refreshScrollingLock() {
+        scrollView.layoutIfNeeded()
+        scrollView.isScrollEnabled = scrollView.contentSize.width > scrollView.frame.width
     }
 }
 

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -126,6 +126,9 @@ open class FormatBar: UIView {
     public init() {
         super.init(frame: .zero)
 
+        // Make sure we getre-drawn whenever the bounds change!
+        layer.needsDisplayOnBoundsChange = true
+
         configure(scrollView: scrollView)
         configure(stackView: scrollableStackView)
         configure(stackView: fixedStackView)
@@ -155,11 +158,9 @@ open class FormatBar: UIView {
         }
 
         // Setup the Context
-        let scale = UIScreen.main.scale
-        let lineWidthInPoints = Constants.topBorderHeightInPixels / scale
+        let lineWidthInPoints = Constants.topBorderHeightInPixels / UIScreen.main.scale
 
         context.clear(rect)
-        context.setShouldAntialias(false)
         context.setLineWidth(lineWidthInPoints)
 
         // Background
@@ -170,8 +171,18 @@ open class FormatBar: UIView {
         // Top Separator
         topBorderColor.setStroke()
 
+        context.setShouldAntialias(false)
         context.move(to: CGPoint(x: 0, y: lineWidthInPoints))
         context.addLine(to: CGPoint(x: bounds.maxX, y: lineWidthInPoints))
+        context.strokePath()
+
+        // Scrollable / Fixed `>` Separator
+        let originX = fixedStackView.frame.minX - Constants.fixedStackViewInsets.left
+
+        context.setShouldAntialias(true)
+        context.move(to: CGPoint(x: originX, y: bounds.minY))
+        context.addLine(to: CGPoint(x: originX + Constants.fixedSeparatorMidPointPaddingX, y: bounds.midY))
+        context.addLine(to: CGPoint(x: originX, y: bounds.maxY))
         context.strokePath()
     }
 
@@ -288,6 +299,7 @@ private extension FormatBar {
 private extension FormatBar {
 
     struct Constants {
+        static let fixedSeparatorMidPointPaddingX = CGFloat(5)
         static let fixedStackViewInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 10)
         static let scrollableStackViewInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
         static let stackViewSpacing = CGFloat(7)

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -91,9 +91,9 @@ open class FormatBar: UIView {
     ///
     ///
     open func selectItemsMatchingIdentifiers(_ identifiers: [FormattingIdentifier]) {
-        for item in formatBarItems {
+        for item in items {
             if let identifier = item.identifier {
-                item.selected = identifiers.contains(identifier)
+                item.isSelected = identifiers.contains(identifier)
             }
         }
     }

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -106,3 +106,98 @@ open class FormatBar: UIView {
         formatter?.handleActionForIdentifier(sender.identifier!)
     }
 }
+
+
+
+// MARK: - Private Helpers
+//
+private extension FormatBar {
+
+    /// Detaches a given collection of FormatBarItem's
+    ///
+    func detach(items: [FormatBarItem]) {
+        for item in items {
+            item.removeFromSuperview()
+        }
+    }
+
+
+    /// Sets up a given collection of FormatBarItem's1
+    ///
+    func configure(items: [FormatBarItem]) {
+        for item in items {
+            configure(item: item)
+        }
+    }
+
+
+    /// Sets up a given FormatBarItem
+    ///
+    func configure(item: FormatBarItem) {
+        item.tintColor = tintColor
+        item.selectedTintColor = selectedTintColor
+        item.highlightedTintColor = highlightedTintColor
+        item.disabledTintColor = disabledTintColor
+
+        item.addTarget(self, action: #selector(handleButtonAction), for: .touchUpInside)
+    }
+
+
+    /// Sets up a given StackView
+    ///
+    func configure(stackView: UIStackView) {
+        stackView.axis = .horizontal
+        stackView.spacing = Constants.stackViewSpacing
+        stackView.alignment = .center
+        stackView.distribution = .equalCentering
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+
+    /// Sets up the ScrollView
+    ///
+    func configure(scrollView: UIScrollView) {
+        scrollView.isScrollEnabled = true
+        scrollView.alwaysBounceHorizontal = true
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+
+    /// Sets up the Constraints
+    ///
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: fixedStackView.leadingAnchor, constant: -1 * Constants.fixedLeftPadding)
+            ])
+
+        NSLayoutConstraint.activate([
+            fixedStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1 * Constants.edgesSpacing),
+            fixedStackView.topAnchor.constraint(equalTo: topAnchor),
+            fixedStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ])
+
+        NSLayoutConstraint.activate([
+            scrollableStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: Constants.edgesSpacing),
+            scrollableStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -1 * Constants.edgesSpacing),
+            scrollableStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            scrollableStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            scrollableStackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
+            scrollableStackView.widthAnchor.constraint(greaterThanOrEqualTo: scrollView.widthAnchor, constant: -2 *  Constants.edgesSpacing)
+            ])
+    }
+}
+
+
+// MARK: - Private Constants
+//
+private extension FormatBar {
+
+    struct Constants {
+        static let edgesSpacing = CGFloat(10)
+        static let fixedLeftPadding = CGFloat(10)
+        static let stackViewSpacing = CGFloat(7)
+    }
+}

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -255,26 +255,29 @@ private extension FormatBar {
     /// Sets up the Constraints
     ///
     func configureConstraints() {
+        let fixedInsets = Constants.fixedStackViewInsets
+        let scrollableInsets = Constants.scrollableStackViewInsets
+
         NSLayoutConstraint.activate([
             scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
             scrollView.topAnchor.constraint(equalTo: topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: fixedStackView.leadingAnchor, constant: -1 * Constants.fixedLeftPadding)
             ])
 
         NSLayoutConstraint.activate([
-            fixedStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1 * Constants.edgesSpacing),
+            fixedStackView.leadingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: fixedInsets.left),
+            fixedStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1 * fixedInsets.right),
             fixedStackView.topAnchor.constraint(equalTo: topAnchor),
             fixedStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
             ])
 
         NSLayoutConstraint.activate([
-            scrollableStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: Constants.edgesSpacing),
-            scrollableStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -1 * Constants.edgesSpacing),
+            scrollableStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: scrollableInsets.left),
+            scrollableStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -1 * scrollableInsets.right),
             scrollableStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
             scrollableStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             scrollableStackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
-            scrollableStackView.widthAnchor.constraint(greaterThanOrEqualTo: scrollView.widthAnchor, constant: -2 *  Constants.edgesSpacing)
+            scrollableStackView.widthAnchor.constraint(greaterThanOrEqualTo: scrollView.widthAnchor, constant: -1 * (scrollableInsets.left + scrollableInsets.right))
             ])
     }
 }
@@ -285,8 +288,8 @@ private extension FormatBar {
 private extension FormatBar {
 
     struct Constants {
-        static let edgesSpacing = CGFloat(10)
-        static let fixedLeftPadding = CGFloat(10)
+        static let fixedStackViewInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 10)
+        static let scrollableStackViewInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
         static let stackViewSpacing = CGFloat(7)
         static let topBorderHeightInPixels = CGFloat(1)
     }

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -6,6 +6,8 @@ import UIKit
 //
 open class FormatBar: UIView {
 
+    /// Format Bar's Delegate
+    ///
     open weak var formatter: FormatBarDelegate?
 
 
@@ -24,6 +26,8 @@ open class FormatBar: UIView {
     }
 
 
+    /// Tint Color
+    ///
     override open var tintColor: UIColor? {
         didSet {
             for item in items {
@@ -33,6 +37,8 @@ open class FormatBar: UIView {
     }
 
 
+    /// Tint Color to be applied over Selected Items
+    ///
     open var selectedTintColor: UIColor? {
         didSet {
             for item in items {
@@ -42,6 +48,8 @@ open class FormatBar: UIView {
     }
 
 
+    /// Tint Color to be applied over Highlighted Items
+    ///
     open var highlightedTintColor: UIColor? {
         didSet {
             for item in items {
@@ -51,6 +59,8 @@ open class FormatBar: UIView {
     }
 
 
+    /// Tint Color to be applied over Disabled Items
+    ///
     open var disabledTintColor: UIColor? {
         didSet {
             for item in items {
@@ -60,6 +70,8 @@ open class FormatBar: UIView {
     }
 
 
+    /// Enables or disables all of the Format Bar Items
+    ///
     open var enabled = true {
         didSet {
             for item in items {
@@ -69,10 +81,9 @@ open class FormatBar: UIView {
     }
 
 
-    }
 
+    // MARK: - Initializers
 
-    // MARK: - Styles
 
 
     func configureButtonStyle(_ button: FormatBarItem) {
@@ -88,7 +99,9 @@ open class FormatBar: UIView {
     }
 
 
-    ///
+    // MARK: - Styles
+
+    /// Selects all of the FormatBarItems matching a collection of Identifiers
     ///
     open func selectItemsMatchingIdentifiers(_ identifiers: [FormattingIdentifier]) {
         for item in items {
@@ -100,7 +113,6 @@ open class FormatBar: UIView {
 
 
     // MARK: - Actions
-
 
     @IBAction func handleButtonAction(_ sender: FormatBarItem) {
         formatter?.handleActionForIdentifier(sender.identifier!)

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -64,7 +64,7 @@ open class FormatBar: UIView {
     override open var tintColor: UIColor? {
         didSet {
             for item in items {
-                item.tintColor = tintColor
+                item.normalTintColor = tintColor
             }
         }
     }

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -11,21 +11,54 @@ open class FormatBar: UIView {
     open weak var formatter: FormatBarDelegate?
 
 
-    open var items = [FormatBarItem]() {
+    /// Container ScrollView
+    ///
+    fileprivate let scrollView = UIScrollView()
+
+
+    /// StackView embedded within the ScrollView
+    ///
+    fileprivate let scrollableStackView = UIStackView()
+
+
+    /// Fixed StackView
+    ///
+    fileprivate let fixedStackView = UIStackView()
+
+
+    /// FormatBarItems to be embedded within the Scrollable StackView
+    ///
+    open var scrollableItems = [FormatBarItem]() {
         willSet {
-            for item in items {
-                item.removeFromSuperview()
-            }
+            scrollableStackView.removeArrangedSubviews(scrollableItems)
         }
         didSet {
-            for item in items {
-                configureButtonStyle(item)
-                configureButtonAction(item)
-            }
+            configure(items: scrollableItems)
+            scrollableStackView.addArrangedSubviews(scrollableItems)
         }
     }
 
 
+    /// FormatBarItems to be embedded within the Fixed StackView
+    ///
+    open var fixedItems = [FormatBarItem]() {
+        willSet {
+            fixedStackView.removeArrangedSubviews(fixedItems)
+        }
+        didSet {
+            configure(items: fixedItems)
+            fixedStackView.addArrangedSubviews(fixedItems)
+        }
+    }
+
+
+    /// Returns the collection of all of the FormatBarItem's (Scrollable + Fixed)
+    ///
+    private var items: [FormatBarItem] {
+        return scrollableItems + fixedItems
+    }
+
+    
     /// Tint Color
     ///
     override open var tintColor: UIColor? {
@@ -85,17 +118,24 @@ open class FormatBar: UIView {
     // MARK: - Initializers
 
 
+    public init() {
+        super.init(frame: .zero)
 
-    func configureButtonStyle(_ button: FormatBarItem) {
-        button.tintColor = tintColor
-        button.selectedTintColor = selectedTintColor
-        button.highlightedTintColor = highlightedTintColor
-        button.disabledTintColor = disabledTintColor
+        configure(scrollView: scrollView)
+        configure(stackView: scrollableStackView)
+        configure(stackView: fixedStackView)
+
+        scrollView.addSubview(scrollableStackView)
+        addSubview(scrollView)
+        addSubview(fixedStackView)
+
+        configureConstraints()
     }
 
 
-    func configureButtonAction(_ button: FormatBarItem) {
-        button.addTarget(self, action: #selector(handleButtonAction), for: .touchUpInside)
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        fatalError("init(coder:) has not been implemented")
     }
 
 

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -84,8 +84,7 @@ open class FormatBar: UIView {
 
 
     func configureButtonAction(_ button: FormatBarItem) {
-        button.target = self
-        button.action = #selector(type(of: self).handleButtonAction(_:))
+        button.addTarget(self, action: #selector(handleButtonAction), for: .touchUpInside)
     }
 
 
@@ -103,8 +102,7 @@ open class FormatBar: UIView {
     // MARK: - Actions
 
 
-    func handleButtonAction(_ sender: FormatBarItem) {
+    @IBAction func handleButtonAction(_ sender: FormatBarItem) {
         formatter?.handleActionForIdentifier(sender.identifier!)
     }
-
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -186,6 +186,11 @@ open class FormatBar: UIView {
         context.strokePath()
     }
 
+    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        refreshStackViewsSpacing()
+    }
+
 
     // MARK: - Styles
 
@@ -247,7 +252,7 @@ private extension FormatBar {
     ///
     func configure(stackView: UIStackView) {
         stackView.axis = .horizontal
-        stackView.spacing = Constants.stackViewSpacing
+        stackView.spacing = Constants.stackViewCompactSpacing
         stackView.alignment = .center
         stackView.distribution = .equalCentering
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -288,8 +293,18 @@ private extension FormatBar {
             scrollableStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
             scrollableStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             scrollableStackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
-            scrollableStackView.widthAnchor.constraint(greaterThanOrEqualTo: scrollView.widthAnchor, constant: -1 * (scrollableInsets.left + scrollableInsets.right))
             ])
+    }
+
+
+    /// Refreshes the Stack View(s) Spacing, according to the Horizontal Size Class
+    ///
+    func refreshStackViewsSpacing() {
+        let horizontallyCompact = traitCollection.horizontalSizeClass == .compact
+        let stackViewSpacing = horizontallyCompact ? Constants.stackViewCompactSpacing : Constants.stackViewRegularSpacing
+
+        scrollableStackView.spacing = stackViewSpacing
+        fixedStackView.spacing = stackViewSpacing
     }
 }
 
@@ -343,7 +358,8 @@ private extension FormatBar {
         static let fixedSeparatorMidPointPaddingX = CGFloat(5)
         static let fixedStackViewInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 10)
         static let scrollableStackViewInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
-        static let stackViewSpacing = CGFloat(7)
+        static let stackViewCompactSpacing = CGFloat(7)
+        static let stackViewRegularSpacing = CGFloat(20)
         static let topBorderHeightInPixels = CGFloat(1)
     }
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -114,6 +114,11 @@ open class FormatBar: UIView {
     }
 
 
+    /// Top Border's Separator Color
+    ///
+    open var topBorderColor = UIColor.darkGray
+
+
 
     // MARK: - Initializers
 
@@ -136,6 +141,38 @@ open class FormatBar: UIView {
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         fatalError("init(coder:) has not been implemented")
+    }
+
+
+
+    // MARK: - Drawing!
+
+    open override func draw(_ rect: CGRect) {
+        super.draw(rect)
+
+        guard let context = UIGraphicsGetCurrentContext() else {
+            return
+        }
+
+        // Setup the Context
+        let scale = UIScreen.main.scale
+        let lineWidthInPoints = Constants.topBorderHeightInPixels / scale
+
+        context.clear(rect)
+        context.setShouldAntialias(false)
+        context.setLineWidth(lineWidthInPoints)
+
+        // Background
+        let bgColor = backgroundColor ?? .white
+        bgColor.setFill()
+        context.fill(rect)
+
+        // Top Separator
+        topBorderColor.setStroke()
+
+        context.move(to: CGPoint(x: 0, y: lineWidthInPoints))
+        context.addLine(to: CGPoint(x: bounds.maxX, y: lineWidthInPoints))
+        context.strokePath()
     }
 
 
@@ -251,5 +288,6 @@ private extension FormatBar {
         static let edgesSpacing = CGFloat(10)
         static let fixedLeftPadding = CGFloat(10)
         static let stackViewSpacing = CGFloat(7)
+        static let topBorderHeightInPixels = CGFloat(1)
     }
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 
-public protocol FormatBarDelegate : NSObjectProtocol
-{
+public protocol FormatBarDelegate : NSObjectProtocol {
+
     func handleActionForIdentifier(_ identifier: FormattingIdentifier)
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
@@ -2,97 +2,60 @@ import Foundation
 import UIKit
 
 
+open class FormatBarItem: UIButton {
 
-open class FormatBarItem: UIBarButtonItem
-{
+    var selectedTintColor: UIColor?
+    var highlightedTintColor: UIColor?
+    var disabledTintColor: UIColor?
+    var normalTintColor: UIColor?
 
     open var identifier: FormattingIdentifier?
 
 
-    fileprivate var button: AztecFormatBarButton? {
-        return customView as? AztecFormatBarButton
-    }
-
 
     override open var tintColor: UIColor? {
         didSet {
-            button?.normalTintColor = tintColor
-            button?.tintColor = tintColor
-        }
-    }
-
-
-    open var selectedTintColor: UIColor? {
-        get {
-            return button?.selectedTintColor
-        }
-        set {
-            button?.selectedTintColor = newValue
-        }
-    }
-
-
-    open var highlightedTintColor: UIColor? {
-        get {
-            return button?.highlightedTintColor
-        }
-        set {
-            button?.highlightedTintColor = newValue
-        }
-    }
-
-
-    open var disabledTintColor: UIColor? {
-        get {
-            return button?.disabledTintColor
-        }
-        set {
-            button?.disabledTintColor = newValue
+            normalTintColor = tintColor
         }
     }
 
 
     open override var isEnabled: Bool {
         didSet {
-            button?.isEnabled = isEnabled
+            updateTintColor()
         }
     }
 
 
-    open var selected: Bool {
-        get {
-            return button?.isSelected ?? false
-        }
-        set {
-            button?.isSelected = newValue
+    open override var isHighlighted: Bool {
+        didSet {
+            updateTintColor()
         }
     }
+
+
+    open override var isSelected: Bool {
+        didSet {
+            updateTintColor()
+        }
+    }
+
 
 
     // MARK: - Lifecycle
 
     public convenience init(image: UIImage, identifier: FormattingIdentifier) {
         let defaultFrame = CGRect(x: 0, y: 0, width: 44, height: 44)
-        self.init(image: image, frame: defaultFrame, target: nil, action: nil)
+        self.init(image: image, frame: defaultFrame)
         self.identifier = identifier
     }
 
 
-    init(image: UIImage, frame: CGRect, target: AnyObject?, action: Selector?) {
-        super.init()
-
-        self.target = target
-        self.action = action
-
-        let button = AztecFormatBarButton(type: .custom)
-        button.frame = frame
-        button.setImage(image, for: UIControlState())
-        button.addTarget(self, action: #selector(type(of: self).handleButtonTapped(_:)), for: .touchUpInside)
-        button.adjustsImageWhenDisabled = true
-        button.adjustsImageWhenHighlighted = true
-
-        style = .plain
-        customView = button
+    public init(image: UIImage, frame: CGRect) {
+        super.init(frame: frame)
+        self.setImage(image, for: UIControlState())
+        self.adjustsImageWhenDisabled = true
+        self.adjustsImageWhenHighlighted = true
     }
 
 
@@ -102,48 +65,6 @@ open class FormatBarItem: UIBarButtonItem
 
 
     // MARK: - Actions
-
-    func handleButtonTapped(_ sender: UIButton) {
-        guard let target = target,
-            let action = action else {
-            return
-        }
-        
-        _ = target.perform(action, with: self)
-    }
-
-}
-
-
-class AztecFormatBarButton: UIButton
-{
-
-    var selectedTintColor: UIColor?
-    var highlightedTintColor: UIColor?
-    var disabledTintColor: UIColor?
-    var normalTintColor: UIColor?
-
-
-    override var isSelected: Bool {
-        didSet {
-            updateTintColor()
-        }
-    }
-
-
-    override var isHighlighted: Bool {
-        didSet {
-            updateTintColor()
-        }
-    }
-
-
-    override var isEnabled: Bool {
-        didSet {
-            updateTintColor()
-        }
-    }
-
 
     func updateTintColor() {
         if state.contains(.disabled) {
@@ -163,5 +84,4 @@ class AztecFormatBarButton: UIButton
 
         tintColor = normalTintColor
     }
-
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
@@ -2,38 +2,56 @@ import Foundation
 import UIKit
 
 
+// MARK: - FormatBarItem
+//
 open class FormatBarItem: UIButton {
 
+    /// Tint Color to be applied whenever the button is selected
+    ///
     var selectedTintColor: UIColor?
-    var highlightedTintColor: UIColor?
-    var disabledTintColor: UIColor?
-    var normalTintColor: UIColor?
 
+    /// Tint Color to be applied whenever the button is highlighted
+    ///
+    var highlightedTintColor: UIColor?
+
+    /// Tint Color to be applied whenever the button is disabled
+    ///
+    var disabledTintColor: UIColor?
+
+    /// Tint Color, as set by the user, by means of the tintColor property
+    ///
+    private var normalTintColor: UIColor?
+
+    /// Formatting Identifier
+    ///
     open var identifier: FormattingIdentifier?
 
-
-
+    /// TintColor
+    ///
     override open var tintColor: UIColor? {
         didSet {
             normalTintColor = tintColor
         }
     }
 
-
+    /// Enabled Listener: Update Tint Colors, as needed
+    ///
     open override var isEnabled: Bool {
         didSet {
             updateTintColor()
         }
     }
 
-
+    /// Highlight Listener: Update Tint Colors, as needed
+    ///
     open override var isHighlighted: Bool {
         didSet {
             updateTintColor()
         }
     }
 
-
+    /// Selection Listener: Update Tint Colors, as needed
+    ///
     open override var isSelected: Bool {
         didSet {
             updateTintColor()
@@ -66,7 +84,7 @@ open class FormatBarItem: UIButton {
 
     // MARK: - Actions
 
-    func updateTintColor() {
+    private func updateTintColor() {
         if state.contains(.disabled) {
             tintColor = disabledTintColor
             return

--- a/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
@@ -6,33 +6,46 @@ import UIKit
 //
 open class FormatBarItem: UIButton {
 
-    /// Tint Color to be applied whenever the button is selected
-    ///
-    var selectedTintColor: UIColor?
-
-    /// Tint Color to be applied whenever the button is highlighted
-    ///
-    var highlightedTintColor: UIColor?
-
-    /// Tint Color to be applied whenever the button is disabled
-    ///
-    var disabledTintColor: UIColor?
-
-    /// Tint Color, as set by the user, by means of the tintColor property
-    ///
-    private var normalTintColor: UIColor?
-
     /// Formatting Identifier
     ///
     open var identifier: FormattingIdentifier?
 
-    /// TintColor
+
+    /// Tint Color to be applied whenever the button is selected
     ///
-    override open var tintColor: UIColor? {
+    var selectedTintColor: UIColor? {
         didSet {
-            normalTintColor = tintColor
+            updateTintColor()
         }
     }
+
+
+    /// Tint Color to be applied whenever the button is highlighted
+    ///
+    var highlightedTintColor: UIColor? {
+        didSet {
+            updateTintColor()
+        }
+    }
+
+
+    /// Tint Color to be applied whenever the button is disabled
+    ///
+    var disabledTintColor: UIColor? {
+        didSet {
+            updateTintColor()
+        }
+    }
+
+
+    /// Tint Color to be applied to the "Normal" State
+    ///
+    var normalTintColor: UIColor? {
+        didSet {
+            updateTintColor()
+        }
+    }
+
 
     /// Enabled Listener: Update Tint Colors, as needed
     ///
@@ -42,6 +55,7 @@ open class FormatBarItem: UIButton {
         }
     }
 
+
     /// Highlight Listener: Update Tint Colors, as needed
     ///
     open override var isHighlighted: Bool {
@@ -50,6 +64,7 @@ open class FormatBarItem: UIButton {
         }
     }
 
+    
     /// Selection Listener: Update Tint Colors, as needed
     ///
     open override var isSelected: Bool {

--- a/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public enum FormattingIdentifier: String
-{
+public enum FormattingIdentifier: String {
+    
     case bold = "bold"
     case italic = "italic"
     case underline = "underline"

--- a/Example/Cartfile
+++ b/Example/Cartfile
@@ -1,1 +1,1 @@
-github "Automattic/Gridicons-iOS" "8582ace3eae40bfb56f5e341c76295ccc830eaed"
+github "Automattic/Gridicons-iOS" "977cbfaa88d35e2fdaceef496be211cbe4578f8b"

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -544,7 +544,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         if htmlMode {
             for item in items {
                 item.isEnabled = false
-                if let sourceItem = item as? FormatBarItem, sourceItem.identifier == .sourcecode {
+                if item.identifier == .sourcecode {
                     item.isEnabled = true
                 }
             }
@@ -561,64 +561,20 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         return toolbar
     }
 
-    var itemsForToolbar: [UIBarButtonItem] {
-        let flex = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let fixed = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
-        if self.traitCollection.horizontalSizeClass == .compact {
-            let items = [
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.addImage).withRenderingMode(.alwaysTemplate), identifier: .media),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.bold).withRenderingMode(.alwaysTemplate), identifier: .bold),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.italic).withRenderingMode(.alwaysTemplate), identifier: .italic),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.underline).withRenderingMode(.alwaysTemplate), identifier: .underline),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.strikethrough).withRenderingMode(.alwaysTemplate), identifier: .strikethrough),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.quote).withRenderingMode(.alwaysTemplate), identifier: .blockquote),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.listUnordered).withRenderingMode(.alwaysTemplate), identifier: .unorderedlist),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.listOrdered).withRenderingMode(.alwaysTemplate), identifier: .orderedlist),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.link).withRenderingMode(.alwaysTemplate), identifier: .link),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.code).withRenderingMode(.alwaysTemplate), identifier: .sourcecode),
-                flex,
-                ]
-            return items
-        } else {
-            let items = [
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.addImage).withRenderingMode(.alwaysTemplate), identifier: .media),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.bold).withRenderingMode(.alwaysTemplate), identifier: .bold),
-                fixed,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.italic).withRenderingMode(.alwaysTemplate), identifier: .italic),
-                fixed,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.underline).withRenderingMode(.alwaysTemplate), identifier: .underline),
-                fixed,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.strikethrough).withRenderingMode(.alwaysTemplate), identifier: .strikethrough),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.quote).withRenderingMode(.alwaysTemplate), identifier: .blockquote),
-                fixed,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.listUnordered).withRenderingMode(.alwaysTemplate), identifier: .unorderedlist),
-                fixed,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.listOrdered).withRenderingMode(.alwaysTemplate), identifier: .orderedlist),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.link).withRenderingMode(.alwaysTemplate), identifier: .link),
-                flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.code).withRenderingMode(.alwaysTemplate), identifier: .sourcecode),
-                flex,
-                ]
-            return items
-        }
+    var itemsForToolbar: [FormatBarItem] {
+        return [
+            FormatBarItem(image: Gridicon.iconOfType(.addImage), identifier: .media),
+            FormatBarItem(image: Gridicon.iconOfType(.heading), identifier: .header),
+            FormatBarItem(image: Gridicon.iconOfType(.bold), identifier: .bold),
+            FormatBarItem(image: Gridicon.iconOfType(.italic), identifier: .italic),
+            FormatBarItem(image: Gridicon.iconOfType(.underline), identifier: .underline),
+            FormatBarItem(image: Gridicon.iconOfType(.strikethrough), identifier: .strikethrough),
+            FormatBarItem(image: Gridicon.iconOfType(.quote), identifier: .blockquote),
+            FormatBarItem(image: Gridicon.iconOfType(.listUnordered), identifier: .unorderedlist),
+            FormatBarItem(image: Gridicon.iconOfType(.listOrdered), identifier: .orderedlist),
+            FormatBarItem(image: Gridicon.iconOfType(.link), identifier: .link),
+            FormatBarItem(image: Gridicon.iconOfType(.code), identifier: .sourcecode),
+            ]
     }
 
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -140,16 +140,18 @@ class EditorDemoController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(type(of: self).keyboardWillShow(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(type(of: self).keyboardWillHide(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(keyboardWillShow), name: .UIKeyboardWillShow, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardWillHide), name: .UIKeyboardWillHide, object: nil)
     }
 
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillShow, object: nil)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+        let nc = NotificationCenter.default
+        nc.removeObserver(self, name: .UIKeyboardWillShow, object: nil)
+        nc.removeObserver(self, name: .UIKeyboardWillHide, object: nil)
     }
 
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -97,6 +97,8 @@ class EditorDemoController: UIViewController {
 
     fileprivate var currentSelectedAttachment: TextAttachment?
 
+    fileprivate var formatBarAnimatedPeek = false
+
     var loadSampleHTML = false
 
 
@@ -143,6 +145,7 @@ class EditorDemoController: UIViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(keyboardWillShow), name: .UIKeyboardWillShow, object: nil)
         nc.addObserver(self, selector: #selector(keyboardWillHide), name: .UIKeyboardWillHide, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardDidShow), name: .UIKeyboardDidShow, object: nil)
     }
 
 
@@ -152,6 +155,7 @@ class EditorDemoController: UIViewController {
         let nc = NotificationCenter.default
         nc.removeObserver(self, name: .UIKeyboardWillShow, object: nil)
         nc.removeObserver(self, name: .UIKeyboardWillHide, object: nil)
+        nc.removeObserver(self, name: .UIKeyboardDidShow, object: nil)
     }
 
 
@@ -228,7 +232,6 @@ class EditorDemoController: UIViewController {
         refreshInsets(forKeyboardFrame: keyboardFrame)
     }
 
-
     func keyboardWillHide(_ notification: Notification) {
         guard
             let userInfo = notification.userInfo as? [String: AnyObject],
@@ -238,6 +241,16 @@ class EditorDemoController: UIViewController {
         }
 
         refreshInsets(forKeyboardFrame: keyboardFrame)
+    }
+
+    func keyboardDidShow(_ notification: Notification) {
+        guard richTextView.isFirstResponder, !formatBarAnimatedPeek else {
+            return
+        }
+
+        let formatBar = richTextView.inputAccessoryView as? FormatBar
+        formatBar?.animateSlightPeekWhenOverflows()
+        formatBarAnimatedPeek = true
     }
 
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -537,12 +537,14 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
 
     func createToolbar(htmlMode: Bool) -> Aztec.FormatBar {
 
-        let items = itemsForToolbar
+        let scrollableItems = scrollableItemsForToolbar
+        let fixedItems = fixedItemsForToolbar
 
         let toolbar = Aztec.FormatBar()
 
         if htmlMode {
-            for item in items {
+            let merged = scrollableItems + fixedItems
+            for item in merged {
                 item.isEnabled = false
                 if item.identifier == .sourcecode {
                     item.isEnabled = true
@@ -550,18 +552,19 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
             }
         }
 
-        toolbar.items = items
-        toolbar.tintColor = UIColor.gray
-        toolbar.highlightedTintColor = UIColor.blue
-        toolbar.selectedTintColor = UIColor.darkGray
-        toolbar.disabledTintColor = UIColor.lightGray
-        toolbar.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44.0)
+        toolbar.scrollableItems = scrollableItems
+        toolbar.fixedItems = fixedItems
+        toolbar.tintColor = .gray
+        toolbar.highlightedTintColor = .blue
+        toolbar.selectedTintColor = .darkGray
+        toolbar.disabledTintColor = .lightGray
+        toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 44.0)
         toolbar.formatter = self
 
         return toolbar
     }
 
-    var itemsForToolbar: [FormatBarItem] {
+    var scrollableItemsForToolbar: [FormatBarItem] {
         return [
             FormatBarItem(image: Gridicon.iconOfType(.addImage), identifier: .media),
             FormatBarItem(image: Gridicon.iconOfType(.heading), identifier: .header),
@@ -572,9 +575,14 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
             FormatBarItem(image: Gridicon.iconOfType(.quote), identifier: .blockquote),
             FormatBarItem(image: Gridicon.iconOfType(.listUnordered), identifier: .unorderedlist),
             FormatBarItem(image: Gridicon.iconOfType(.listOrdered), identifier: .orderedlist),
-            FormatBarItem(image: Gridicon.iconOfType(.link), identifier: .link),
-            FormatBarItem(image: Gridicon.iconOfType(.code), identifier: .sourcecode),
-            ]
+            FormatBarItem(image: Gridicon.iconOfType(.link), identifier: .link)
+        ]
+    }
+
+    var fixedItemsForToolbar: [FormatBarItem] {
+        return [
+            FormatBarItem(image: Gridicon.iconOfType(.code), identifier: .sourcecode)
+        ]
     }
 
 }


### PR DESCRIPTION
### Details:
In this PR we're matching Android's Format Bar behavior:

     **[ Scrollable Items ]** < **[ Fixed Items]**

We'll be adding new Format Bar actions in (upcoming) issues. Few notes:

- **Aztec.FormatBar** no longer inherits from **UIToolbar**.
- **Aztec.FormatBarItem** no longer inherits from **UIBarButtonItem**

Needs Review: @diegoreymendez @SergioEstevao 
Thanks in advance gentlemen!!

### Testing:
1. Launch Aztec on an iPhone SE device
2. Verify that the format bar animates, as soon as it becomes visible
3. Verify that the "Scrollable Items" work as expected
4. Rotate the device and verify everything looks right

Re-test on an iPhone 7 // 7 Plus // iPad (Multitasking). Note that whenever the horizontal sizeClass is regular (7 Plus in landscape, iPad fullscreen), the "Scrollable Items" spacing should be higher.

### Screenshots:
![simulator screen shot mar 10 2017 4 38 38 pm](https://cloud.githubusercontent.com/assets/1195260/23810513/b18aa0ac-05b0-11e7-949b-45d9c77367e5.png)

![simulator screen shot mar 10 2017 4 44 07 pm](https://cloud.githubusercontent.com/assets/1195260/23810549/cce12b32-05b0-11e7-9308-888315b96ae0.png)
