### PR TITLE
Nukes Old School Provisioning Profile's Hash

### DIFF
--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -501,7 +501,7 @@
 				MODULE_NAME = AztecExample;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.AztecExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "1aa23f94-9d95-4000-a0a6-8b0a49a2eb62";
+				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Aztec Example Development";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -523,7 +523,7 @@
 				MODULE_NAME = AztecExample;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.AztecExample.Release;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "839aa3fc-0198-4ea8-bb9b-58c5e9b3e71c";
+				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Aztec Example Ad Hoc";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -616,7 +616,7 @@
 				MODULE_NAME = AztecExample;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.AztecExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "1aa23f94-9d95-4000-a0a6-8b0a49a2eb62";
+				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Aztec Example Development";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -699,7 +699,7 @@
 				MODULE_NAME = AztecExample;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.AztecExample.Alpha;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "3e277507-6579-4f06-95c1-93e8cd30fbe3";
+				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Aztec Example Alpha Distribution";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
### Details:
Since we're using the new Xcode's Provisioning Profile setting (matching by name), i'm cleaning up the old school **hash** setting.

### Testing:
Just clean and run the sample app in the device.

Needs Review: @diegoreymendez 
Thanks!!