### PR TITLE
Improve headers toolbar

### DIFF
--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -26,6 +26,9 @@ extension String
     }
 
     func isLastValidLocation(_ location: Int) -> Bool {
+        if self.isEmpty {
+            return false
+        }
         return index(before: endIndex) == indexFromLocation(location)
     }
 

--- a/Aztec/Classes/Formatters/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/HeaderFormatter.swift
@@ -1,9 +1,9 @@
 import Foundation
 import UIKit
 
-class HeaderFormatter: ParagraphAttributeFormatter {
+open class HeaderFormatter: ParagraphAttributeFormatter {
 
-    enum HeaderType: Int {
+    public enum HeaderType: Int {
         case none = 0
         case h1 = 1
         case h2 = 2
@@ -21,6 +21,18 @@ class HeaderFormatter: ParagraphAttributeFormatter {
             case .h4: return 16
             case .h5: return 14
             case .h6: return 11
+            }
+        }
+
+        public var description: String {
+            switch self {
+            case .none: return "Paragraph"
+            case .h1: return "Heading 1"
+            case .h2: return "Heading 2"
+            case .h3: return "Heading 3"
+            case .h4: return "Heading 4"
+            case .h5: return "Heading 5"
+            case .h6: return "Heading 6"
             }
         }
     }

--- a/Aztec/Classes/Formatters/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/HeaderFormatter.swift
@@ -12,7 +12,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         case h5 = 5
         case h6 = 6
 
-        var fontSize: CGFloat {
+        public var fontSize: CGFloat {
             switch self {
             case .none: return 14
             case .h1: return 36

--- a/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
@@ -12,5 +12,10 @@ public enum FormattingIdentifier: String
     case link = "link"
     case media = "media"
     case sourcecode = "sourcecode"
-    case header = "header"
+    case header1 = "header1"
+    case header2 = "header2"
+    case header3 = "header3"
+    case header4 = "header4"
+    case header5 = "header5"
+    case header6 = "header6"
 }

--- a/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
@@ -12,6 +12,7 @@ public enum FormattingIdentifier: String
     case link = "link"
     case media = "media"
     case sourcecode = "sourcecode"
+    case header  = "header"
     case header1 = "header1"
     case header2 = "header2"
     case header3 = "header3"

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -13,7 +13,7 @@ extension Libxml2 {
     ///
     class DOMString {
 
-        private static let headerLevels: [StandardElementType] = [.h1, .h2, .h4, .h5, .h6]
+        private static let headerLevels: [StandardElementType] = [.h1, .h2, .h3, .h4, .h5, .h6]
 
         private lazy var editContext: EditContext = {
             return EditContext(undoManager: self.domUndoManager)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -279,7 +279,12 @@ open class TextView: UITextView {
         .orderedlist: TextListFormatter(style: .ordered),
         .unorderedlist: TextListFormatter(style: .unordered),
         .blockquote: BlockquoteFormatter(),
-        .header: HeaderFormatter(),
+        .header1: HeaderFormatter(headerLevel: .h1, placeholderAttributes: nil),
+        .header2: HeaderFormatter(headerLevel: .h2, placeholderAttributes: nil),
+        .header3: HeaderFormatter(headerLevel: .h3, placeholderAttributes: nil),
+        .header4: HeaderFormatter(headerLevel: .h4, placeholderAttributes: nil),
+        .header5: HeaderFormatter(headerLevel: .h5, placeholderAttributes: nil),
+        .header6: HeaderFormatter(headerLevel: .h6, placeholderAttributes: nil),
     ]
 
     /// Get a list of format identifiers spanning the specified range as a String array.
@@ -461,8 +466,8 @@ open class TextView: UITextView {
     ///
     /// - Parameter range: The NSRange to edit.
     ///
-    open func toggleHeader(range: NSRange) {
-        let formatter = HeaderFormatter(placeholderAttributes: typingAttributes)
+    open func toggleHeader(_ headerType: HeaderFormatter.HeaderType, range: NSRange) {
+        let formatter = HeaderFormatter(headerLevel: headerType, placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
         forceRedrawCursorAfterDelay()
     }

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */; };
+		FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
 /* End PBXBuildFile section */
 
@@ -93,6 +94,7 @@
 		607FACE51AFB9204008FA782 /* AztecExample-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AztecExample-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorDemoController.swift; sourceTree = "<group>"; };
+		FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsTableView.swift; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -182,6 +184,7 @@
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
 				59280F271D47CAF40083FB59 /* SampleContent */,
 				607FACD31AFB9204008FA782 /* Supporting Files */,
+				FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */,
 			);
 			name = "Example for WordPress-Aztec-iOS";
 			path = Example;
@@ -348,6 +351,7 @@
 			files = (
 				599F25701D8BCF57002871D6 /* AppDelegate.swift in Sources */,
 				59D2873B1D8C599B00B99C80 /* AttachmentDetailsViewController.swift in Sources */,
+				FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */,
 				E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 			);

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -273,8 +273,10 @@ class EditorDemoController: UIViewController {
         // Filter multiple header identifier to single header identifier
         identifiers = identifiers.map({ (identifier) -> FormattingIdentifier in
             switch identifier {
-            case .header1, .header2, .header3, .header4, .header5, .header6: return .header
-            default: return identifier
+            case .header1, .header2, .header3, .header4, .header5, .header6:
+                return .header
+            default:
+                return identifier
             }
         })
         toolbar.selectItemsMatchingIdentifiers(identifiers)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -356,7 +356,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
             showImagePicker()
         case .sourcecode:
             toggleEditingMode()
-        case .header:
+        case .header1, .header2, .header3, .header4, .header5, .header6:
             toggleHeader()
         }
 
@@ -398,7 +398,21 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func toggleHeader() {
-        richTextView.toggleHeader(range: richTextView.selectedRange)
+        richTextView.resignFirstResponder()
+        let headerPicker = UIPickerView()
+        headerPicker.dataSource = self
+        headerPicker.delegate = self
+
+        var identifiers = [FormattingIdentifier]()
+        if (richTextView.selectedRange.length > 0) {
+            identifiers = richTextView.formatIdentifiersSpanningRange(richTextView.selectedRange)
+        } else {
+            identifiers = richTextView.formatIdentifiersForTypingAttributes()
+        }
+        headerPicker.selectRow(6, inComponent: 0, animated: false)
+        headerPicker.showsSelectionIndicator = true
+        richTextView.inputView = headerPicker
+        richTextView.becomeFirstResponder()
     }
 
 
@@ -569,7 +583,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
                 flex,
                 Aztec.FormatBarItem(image: Gridicon.iconOfType(.addImage).withRenderingMode(.alwaysTemplate), identifier: .media),
                 flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header),
+                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header1),
                 flex,
                 Aztec.FormatBarItem(image: Gridicon.iconOfType(.bold).withRenderingMode(.alwaysTemplate), identifier: .bold),
                 flex,
@@ -596,7 +610,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
                 flex,
                 Aztec.FormatBarItem(image: Gridicon.iconOfType(.addImage).withRenderingMode(.alwaysTemplate), identifier: .media),
                 flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header),
+                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header1),
                 flex,
                 Aztec.FormatBarItem(image: Gridicon.iconOfType(.bold).withRenderingMode(.alwaysTemplate), identifier: .bold),
                 fixed,
@@ -849,5 +863,33 @@ extension EditorDemoController: UIGestureRecognizerDelegate
             richTextView.refreshLayoutFor(attachment: attachment)
             currentSelectedAttachment = attachment
         }
+    }
+}
+
+extension EditorDemoController: UIPickerViewDelegate, UIPickerViewDataSource {
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return HeaderFormatter.HeaderType.h6.rawValue + 1
+    }
+
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        guard let headerType = HeaderFormatter.HeaderType(rawValue: row) else {
+            return ""
+        }
+        return headerType.description
+    }
+
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        guard let headerType = HeaderFormatter.HeaderType(rawValue: row) else {
+            return
+        }
+        richTextView.toggleHeader(headerType, range: richTextView.selectedRange)
+        richTextView.resignFirstResponder()
+        richTextView.inputView = nil
+        richTextView.becomeFirstResponder()
     }
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -270,6 +270,13 @@ class EditorDemoController: UIViewController {
         } else {
             identifiers = richTextView.formatIdentifiersForTypingAttributes()
         }
+        // Filter multiple header identifier to single header identifier
+        identifiers = identifiers.map({ (identifier) -> FormattingIdentifier in
+            switch identifier {
+            case .header1, .header2, .header3, .header4, .header5, .header6: return .header
+            default: return identifier
+            }
+        })
         toolbar.selectItemsMatchingIdentifiers(identifiers)
     }
 
@@ -366,7 +373,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
             showImagePicker()
         case .sourcecode:
             toggleEditingMode()
-        case .header1, .header2, .header3, .header4, .header5, .header6:
+        case .header, .header1, .header2, .header3, .header4, .header5, .header6:
             toggleHeader()
         }
 
@@ -620,7 +627,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
                 flex,
                 Aztec.FormatBarItem(image: Gridicon.iconOfType(.addImage).withRenderingMode(.alwaysTemplate), identifier: .media),
                 flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header1),
+                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header),
                 flex,
                 Aztec.FormatBarItem(image: Gridicon.iconOfType(.bold).withRenderingMode(.alwaysTemplate), identifier: .bold),
                 flex,
@@ -647,7 +654,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
                 flex,
                 Aztec.FormatBarItem(image: Gridicon.iconOfType(.addImage).withRenderingMode(.alwaysTemplate), identifier: .media),
                 flex,
-                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header1),
+                Aztec.FormatBarItem(image: Gridicon.iconOfType(.heading).withRenderingMode(.alwaysTemplate), identifier: .header),
                 flex,
                 Aztec.FormatBarItem(image: Gridicon.iconOfType(.bold).withRenderingMode(.alwaysTemplate), identifier: .bold),
                 fixed,

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -316,6 +316,7 @@ class EditorDemoController: UIViewController {
 extension EditorDemoController : UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
         updateFormatBar()
+        changeRichTextInputView(to: nil)
     }
 
     func textViewDidChange(_ textView: UITextView) {        
@@ -432,6 +433,9 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func changeRichTextInputView(to: UIView?) {
+        if richTextView.inputView == to {
+            return
+        }
         richTextView.resignFirstResponder()
         richTextView.inputView = to
         richTextView.becomeFirstResponder()

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -418,6 +418,11 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func toggleHeader() {
+        // check if we already showing a custom view.
+        if richTextView.inputView != nil {
+            changeRichTextInputView(to: nil)
+            return
+        }
         let headerOptions = headers.map { (headerType) -> NSAttributedString in
             NSAttributedString(string: headerType.description, attributes:[NSFontAttributeName: UIFont.systemFont(ofSize: headerType.fontSize)])
         }

--- a/Example/Example/OptionsTableView.swift
+++ b/Example/Example/OptionsTableView.swift
@@ -1,0 +1,61 @@
+
+
+import UIKit
+
+class OptionsTableView: UITableView {
+
+    var options = [NSAttributedString]()
+
+    var onSelect: ((_ selected: Int) -> Void)?
+
+    init(frame: CGRect, options: [NSAttributedString]) {
+        self.options = options
+        super.init(frame: frame, style: .plain)
+        self.delegate = self
+        self.dataSource = self
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+
+}
+
+extension OptionsTableView: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) else {
+            return
+        }
+        cell.accessoryType = .none
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) else {
+            return
+        }
+
+        cell.accessoryType = .checkmark
+        onSelect?(indexPath.row)
+    }
+}
+
+extension OptionsTableView: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return options.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let reuseCell = self.dequeueReusableCell(withIdentifier: "OptionCell") ?? UITableViewCell(style: .subtitle, reuseIdentifier: "OptionCell")
+        reuseCell.textLabel?.attributedText = options[indexPath.row]
+        reuseCell.accessoryType = indexPath.row == super.indexPathForSelectedRow?.row ? .checkmark : .none
+        reuseCell.isSelected = indexPath.row == super.indexPathForSelectedRow?.row
+        return reuseCell
+    }
+}

--- a/Example/Example/OptionsTableView.swift
+++ b/Example/Example/OptionsTableView.swift
@@ -1,5 +1,3 @@
-
-
 import UIKit
 
 class OptionsTableView: UITableView {
@@ -18,8 +16,6 @@ class OptionsTableView: UITableView {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-
-
 }
 
 extension OptionsTableView: UITableViewDelegate {


### PR DESCRIPTION
Related to #324 

This PR adds support for selection of the header type to apply when using the format toolbar.
It uses a custom input view that allows to choose what header the user wants to apply.

How to test:
 - Start the demo app
 - Start the editor with content
 - Tap on one of the paragraphs with header
 - Tap on the Header button on the toolbar
 - Check if the selection made on the input view is correct
 - Change the style and see if the style is correct.