### PR TITLE
Refactor attachment touch/selection to be part of the text view.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -48,7 +48,7 @@ public protocol TextViewMediaDelegate: class {
     /// - Parameters:
     ///   - textView: the textview where the attachment is.
     ///   - attachment: the attachment that was selected.
-    ///   - position: touch position
+    ///   - position: touch position relative to the textview.
     ///
     func textView(_ textView: TextView, selectedAttachment attachment: TextAttachment, atPosition position: CGPoint)
 
@@ -57,7 +57,7 @@ public protocol TextViewMediaDelegate: class {
     /// - Parameters:
     ///   - textView: the textview where the attachment is.
     ///   - attachment: the attachment that was deselected.
-    ///   - position: touch position
+    ///   - position: touch position relative to the textView
     ///
     func textView(_ textView: TextView, deselectedAttachment attachment: TextAttachment, atPosition position: CGPoint)
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -985,6 +985,9 @@ extension TextView: TextStorageAttachmentsDelegate {
     }
 
     func richTextViewWasPressed(_ recognizer: UIGestureRecognizer) {
+        guard recognizer.state == .recognized else {
+            return
+        }
         let locationInTextView = recognizer.location(in: textView)
         // check if we have an attachment in the position we tapped
         guard let attachment = textView.attachmentAtPoint(locationInTextView) else {
@@ -992,9 +995,8 @@ extension TextView: TextStorageAttachmentsDelegate {
         }
 
         // move the selection to the position of the attachment
-        if currentSelectedAttachment != attachment {
-            textView.moveSelectionToPoint(locationInTextView)
-        }
+
+        textView.moveSelectionToPoint(locationInTextView)
 
         if textView.isPointInsideAttachmentMargin(point: locationInTextView) {
             if let selectedAttachment = currentSelectedAttachment {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -154,14 +154,10 @@ open class TextView: UITextView {
     }()
 
     private func setupAttachmentTouchDetection() {
-
-        addGestureRecognizer(attachmentGestureRecognizer)
-
         for gesture in gestureRecognizers ?? [] {
-            if gesture != attachmentGestureRecognizer {
-                gesture.require(toFail: attachmentGestureRecognizer)
-            }
+            gesture.require(toFail: attachmentGestureRecognizer)
         }
+        addGestureRecognizer(attachmentGestureRecognizer)
     }
 
     // MARK: - Intercept copy paste operations

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -657,6 +657,11 @@ extension EditorDemoController: TextViewMediaDelegate
             //if it's the same attachment has before let's display the options
             displayActions(forAttachment: attachment, position: position)
         } else {
+            if let selectedAttachment = currentSelectedAttachment {
+                selectedAttachment.clearAllOverlays()
+                richTextView.refreshLayoutFor(attachment: selectedAttachment)
+            }
+
             // and mark the newly tapped attachment
             let message = NSLocalizedString("Tap to edit\n And change options", comment: "Options to show when tapping on a image on the post/page editor.")
             attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -654,7 +654,6 @@ extension EditorDemoController: TextViewMediaDelegate
     func textView(_ textView: TextView, selectedAttachment attachment: TextAttachment, atPosition position: CGPoint) {
 
         if (currentSelectedAttachment == attachment) {
-            //if it's the same attachment has before let's display the options
             displayActions(forAttachment: attachment, position: position)
         } else {
             if let selectedAttachment = currentSelectedAttachment {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -23,13 +23,6 @@ class EditorDemoController: UIViewController {
         textView.delegate = self
         textView.formattingDelegate = self
         textView.mediaDelegate = self
-        textView.addGestureRecognizer(self.tapGestureRecognizer)
-
-        for gesture in textView.gestureRecognizers ?? [] {
-            if let otherTapGesture = gesture as? UITapGestureRecognizer, otherTapGesture != self.tapGestureRecognizer {
-                otherTapGesture.require(toFail: self.tapGestureRecognizer)
-            }
-        }
 
         return textView
     }()
@@ -92,16 +85,7 @@ class EditorDemoController: UIViewController {
             richTextView.isHidden = editingMode == .html
             htmlTextView.isHidden = editingMode == .richText
         }
-    }
-
-    fileprivate(set) lazy var tapGestureRecognizer: UIGestureRecognizer = {
-        let recognizer = UITapGestureRecognizer(target: self, action: #selector(richTextViewWasPressed))
-        recognizer.cancelsTouchesInView = true
-        recognizer.delaysTouchesBegan = true
-        recognizer.delaysTouchesEnded = true
-        recognizer.delegate = self
-        return recognizer
-    }()
+    }    
 
     fileprivate var currentSelectedAttachment: TextAttachment?
 
@@ -666,6 +650,26 @@ extension EditorDemoController: TextViewMediaDelegate
     func textView(_ textView: TextView, deletedAttachmentWithID attachmentID: String) {
         print("Attachment \(attachmentID) removed.\n")
     }
+
+    func textView(_ textView: TextView, selectedAttachment attachment: TextAttachment, atPosition position: CGPoint) {
+
+        if (currentSelectedAttachment == attachment) {
+            //if it's the same attachment has before let's display the options
+            displayActions(forAttachment: attachment, position: position)
+        } else {
+            // and mark the newly tapped attachment
+            let message = NSLocalizedString("Tap to edit\n And change options", comment: "Options to show when tapping on a image on the post/page editor.")
+            attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)
+            attachment.overlayImage = Gridicon.iconOfType(.pencil).withRenderingMode(.alwaysTemplate)
+            richTextView.refreshLayoutFor(attachment: attachment)
+            currentSelectedAttachment = attachment
+        }
+    }
+
+    func textView(_ textView: TextView, deselectedAttachment attachment: TextAttachment, atPosition position: CGPoint) {
+        attachment.clearAllOverlays()
+        richTextView.refreshLayoutFor(attachment: attachment)
+    }
 }
 
 extension EditorDemoController: UINavigationControllerDelegate
@@ -815,63 +819,5 @@ private extension EditorDemoController
 
         let navigationController = UINavigationController(rootViewController: detailsViewController)        
         present(navigationController, animated: true, completion: nil)
-    }
-}
-
-// MARK: - UIGestureRecognizerDelegate
-
-extension EditorDemoController: UIGestureRecognizerDelegate
-{
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
-    }
-
-    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        let locationInTextView = gestureRecognizer.location(in: richTextView)
-        // check if we have an attachment in the position we tapped
-        guard richTextView.attachmentAtPoint(locationInTextView) != nil else {
-            // if we have a current selected attachment marked lets unmark it
-            if let selectedAttachment = currentSelectedAttachment {
-                selectedAttachment.clearAllOverlays()
-                richTextView.refreshLayoutFor(attachment: selectedAttachment)
-                currentSelectedAttachment = nil
-            }
-            return false
-        }
-        return true
-    }
-
-    func richTextViewWasPressed(_ recognizer: UIGestureRecognizer) {
-        let locationInTextView = recognizer.location(in: richTextView)
-        // check if we have an attachment in the position we tapped
-        guard let attachment = richTextView.attachmentAtPoint(locationInTextView) else {
-            return
-        }
-        // move the selection to the position of the attachment
-        richTextView.moveSelectionToPoint(locationInTextView)
-        if richTextView.isPointInsideAttachmentMargin(point: locationInTextView) {
-            if let selectedAttachment = currentSelectedAttachment {
-                selectedAttachment.clearAllOverlays()
-                richTextView.refreshLayoutFor(attachment: selectedAttachment)
-                currentSelectedAttachment = nil
-            }
-            return
-        }
-        if attachment == currentSelectedAttachment {
-            //if it's the same attachment has before let's display the options
-            displayActions(forAttachment: attachment, position: locationInTextView)
-        } else {
-            // if it's a new attachment tapped let unmark the previous one
-            if let selectedAttachment = currentSelectedAttachment {
-                selectedAttachment.clearAllOverlays()
-                richTextView.refreshLayoutFor(attachment: selectedAttachment)
-            }
-            // and mark the newly tapped attachment
-            let message = NSLocalizedString("Tap to edit\n And change options", comment: "Options to show when tapping on a image on the post/page editor.")
-            attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)
-            attachment.overlayImage = Gridicon.iconOfType(.pencil).withRenderingMode(.alwaysTemplate)
-            richTextView.refreshLayoutFor(attachment: attachment)
-            currentSelectedAttachment = attachment
-        }
     }
 }


### PR DESCRIPTION
This PR refactors the attachment touch detection to use delegate callback from the UITextView instead of relaying on the client to do that detection. 

This avoid code duplication in users of the library, it also hides implementation details from users of the library ( no need to know about margin, moving cursor and other implementation details).

How to test:
 - Start a new post
 - Insert multiple images
 - Tap on the image and the text outside and see if the interaction works correctly
 - Tap on the white space between images and check if the cursor/caret moves to the correct position.

@diegoreymendez mind to have a look on this? The only main architecture question I have is if the new new delegate methods should be part of the current media delegate or I should create a new one. What do you think?