### PR TITLE
Move caret position after inserting a link.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -701,8 +701,9 @@ open class TextView: UITextView {
         let formatter = LinkFormatter()
         formatter.attributeValue = url        
         let attributes = formatter.apply(to: typingAttributes)
+        let linkWasPresent = formatter.present(in: storage, at: range)
         storage.replaceCharacters(in: range, with: NSAttributedString(string: title, attributes: attributes))
-        if range.length == 0 {
+        if range.length == 0 && !linkWasPresent {
             selectedRange = NSMakeRange(range.location + (title as NSString).length, 0)
         }
         delegate?.textViewDidChange?(self)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -702,6 +702,9 @@ open class TextView: UITextView {
         formatter.attributeValue = url        
         let attributes = formatter.apply(to: typingAttributes)
         storage.replaceCharacters(in: range, with: NSAttributedString(string: title, attributes: attributes))
+        if range.length == 0 {
+            selectedRange = NSMakeRange(range.location + (title as NSString).length, 0)
+        }
         delegate?.textViewDidChange?(self)
     }
 


### PR DESCRIPTION
Fixes #345 

How to test:
 - Start the demo app
 - Tap on insert link button
 - Write some link description ( extra points for use emoji on the linked text)
 - Check that the cursor moves to the end of the link.

 - Try the same with an range selected
 - Check if the range stays the same

