### PR TITLE
Remove all Attachments API

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -725,6 +725,23 @@ open class TextStorage: NSTextStorage {
         }
     }
 
+    /// Removes all of the TextAttachments from the storage
+    ///
+    open func removeTextAttachments() {
+        var ranges = [NSRange]()
+        enumerateAttachmentsOfType(TextAttachment.self) { (attachment, range, _) in
+            ranges.append(range)
+        }
+
+        var delta = 0
+        for range in ranges {
+            let corrected = NSRange(location: range.location - delta, length: range.length)
+            replaceCharacters(in: corrected, with: NSAttributedString(string: ""))
+            delta += range.length
+        }
+    }
+
+
     // MARK: - Toggle Attributes
 
     fileprivate func toggleAttribute(_ attributeName: String, value: AnyObject, range: NSRange) {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -755,6 +755,12 @@ open class TextView: UITextView {
         delegate?.textViewDidChange?(self)
     }
 
+    /// Removes all of the text attachments contained within the storage
+    ///
+    open func removeTextAttachments() {
+        storage.removeTextAttachments()
+        delegate?.textViewDidChange?(self)
+    }
 
     /// Inserts a Video attachment at the specified index
     ///

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -234,4 +234,42 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(secondAttachment.url, URL(string: "https://wordpress.com"))
         XCTAssertEqual(html, "<img src=\"https://wordpress.com\"><img src=\"https://wordpress.com\">")
     }
+
+    /// This test verifies if the `removeTextAttachements` call effectively nukes all of the TextAttachments present
+    /// in the storage.
+    ///
+    func testRemoveAllTextAttachmentsNukeTextAttachmentInstances() {
+        // Mockup Storage
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+
+        let sample = NSMutableAttributedString(string: "Some string here")
+        storage.append(sample)
+
+        // New string with 10 attachments
+        var identifiers = [String]()
+        let count = 10
+
+        for _ in 0 ..< count {
+            let sourceURL = URL(string:"test://")!
+            let attachment = storage.insertImage(sourceURL: sourceURL, atPosition: 0, placeHolderImage: UIImage())
+
+            identifiers.append(attachment.identifier)
+        }
+
+
+        // Verify the attachments are there
+        for identifier in identifiers {
+            XCTAssertNotNil(storage.attachment(withId: identifier))
+        }
+
+        // Nuke
+        storage.removeTextAttachments()
+
+        // Verify the attachments are there
+        for identifier in identifiers {
+            XCTAssertNil(storage.attachment(withId: identifier))
+        }
+    }
 }


### PR DESCRIPTION
### Details:
This PR implements a new API, that would nuke all of the TextAttachments. This is required in order to address [this WordPress iOS Issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/6827).

### Testing:
Please, just run the unit tests, and verify everything looks smooth.

@SergioEstevao although we've discussed about only removing the links tied up to the `Old Selected Site`, since WordPress.com uses links that look like... `lanteanartest.files.wordpress.com`, i'm afraid we can't really match by domain.

For Mark I, let's replicate the old behavior, and build on top of that!

Needs Review: @SergioEstevao 
Thanks in advance!!
