### PR TITLE
Fix crash when trying to delete all content

### DIFF
--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -272,4 +272,18 @@ class TextStorageTests: XCTestCase
             XCTAssertNil(storage.attachment(withId: identifier))
         }
     }
+
+    /// This test verifies if we can delete all the content from a storage object that has html with a comment
+    ///
+    func testDeleteAllSelectionWhenContentHasComments() {
+        let storage = TextStorage()
+        let commentString = "This is a comment"
+        let html = "<!--\(commentString)-->"
+        storage.setHTML(html, withDefaultFontDescriptor: UIFont.systemFont(ofSize: 14).fontDescriptor)
+        storage.replaceCharacters(in: NSRange(location: 0, length: 1), with: NSAttributedString(string: ""))
+
+        let resultHTML = storage.getHTML()
+
+        XCTAssertEqual(html, resultHTML)
+    }
 }


### PR DESCRIPTION
This PR tries to fix the crash on delete all text on the textview when a comment is present in the HTML.

