### PR TITLE
Update gridicon to version 0.5

### DIFF
--- a/Example/Cartfile.resolved
+++ b/Example/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Automattic/Gridicons-iOS" "8582ace3eae40bfb56f5e341c76295ccc830eaed"
+github "Automattic/Gridicons-iOS" "977cbfaa88d35e2fdaceef496be211cbe4578f8b"

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -38,6 +38,6 @@ Pod::Spec.new do |s|
   s.xcconfig = {'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2'}
   s.preserve_paths = 'Aztec/Modulemaps/libxml2/*'
 
-  s.dependency 'Gridicons', '0.4'
+  s.dependency 'Gridicons', '0.5'
 
 end


### PR DESCRIPTION
This PR just updates to the latest version of gridicons. No change in terms off icons for Aztec in there but just better to be on the latest.