### PR TITLE
More: Public API + Format Bar Support

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -99,7 +99,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
         let moreLabel = "more"
-        if node.comment.hasPrefix(moreLabel) {
+        if node.comment.lowercased().hasPrefix(moreLabel) {
             var attributes = inheritedAttributes;
             let moreAttachment = MoreAttachment()
             let index = moreLabel.endIndex

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -98,8 +98,8 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
-        let moreLabel = "more"
-        if node.comment.lowercased().hasPrefix(moreLabel) {
+        let moreLabel = "MORE"
+        if node.comment.hasPrefix(moreLabel) {
             var attributes = inheritedAttributes;
             let moreAttachment = MoreAttachment()
             let index = moreLabel.endIndex

--- a/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
@@ -6,6 +6,11 @@ import UIKit
 //
 extension NSAttributedString
 {
+    /// Indicates the Attributed String Length of a single TextAttachment
+    ///
+    static let lengthOfTextAttachment = NSAttributedString(attachment: NSTextAttachment()).length
+
+
     /// Loads any NSTextAttachment's lazy file reference, into a UIImage instance, in memory.
     ///
     func loadLazyAttachments() {

--- a/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
@@ -11,6 +11,7 @@ public enum FormattingIdentifier: String {
     case blockquote = "blockquote"
     case link = "link"
     case media = "media"
+    case more = "more"
     case sourcecode = "sourcecode"
     case header  = "header"
     case header1 = "header1"

--- a/Aztec/Classes/Libxml2/DOM/Data/CommentNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/CommentNode.swift
@@ -35,5 +35,13 @@ extension Libxml2 {
         override func text() -> String {
             return String(.newline)
         }
+
+        override func deleteCharacters(inRange range: NSRange) {
+            guard range.location == 0 && range.length == length() else {
+                return
+            }
+
+            removeFromParent()
+        }
     }
 }

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -493,18 +493,18 @@ extension Libxml2 {
             rootNode.replaceCharacters(in: range, with: descriptor)
         }
 
-        /// Replaces the specified range with a Horizontal Ruler.
+        /// Replaces the specified range with a Horizontal Ruler Style.
         ///
         /// - Parameters:
         ///     - range: the range to apply the style to.
         ///
         func replaceWithHorizontalRuler(_ range: NSRange) {
             performAsyncUndoable { [weak self] in
-                self?.replaceSynchronouslyWithHorizontalRuler(range)
+                self?.replaceSynchronouslyWithHorizontalRulerStyle(range)
             }
         }
 
-        private func replaceSynchronouslyWithHorizontalRuler(_ range: NSRange) {
+        private func replaceSynchronouslyWithHorizontalRulerStyle(_ range: NSRange) {
             let descriptor = ElementNodeDescriptor(elementType: .hr)
 
             rootNode.replaceCharacters(in: range, with: descriptor)

--- a/Aztec/Classes/TextKit/MoreAttachment.swift
+++ b/Aztec/Classes/TextKit/MoreAttachment.swift
@@ -24,7 +24,7 @@ open class MoreAttachment: NSTextAttachment
     /// Comment's Text.
     /// This is a temporary helper property, and will be removed as soon as we merge MoreAttachment + CommentAttachment.
     ///
-    let text = "more"
+    let text = "MORE"
 
 
     open var message: String = ""

--- a/Aztec/Classes/TextKit/MoreAttachment.swift
+++ b/Aztec/Classes/TextKit/MoreAttachment.swift
@@ -24,7 +24,7 @@ open class MoreAttachment: NSTextAttachment
     /// Comment's Text.
     /// This is a temporary helper property, and will be removed as soon as we merge MoreAttachment + CommentAttachment.
     ///
-    let text = "MORE"
+    let text = "more"
 
 
     open var message: String = ""

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -453,23 +453,16 @@ open class TextStorage: NSTextStorage {
 
     private func processLineAttachmentDifferences(in range: NSRange, betweenOriginal original: LineAttachment?, andNew new: LineAttachment?) {
 
-        let add = original == nil && new != nil
-        let remove = original != nil && new == nil
-
-        if add {
-            dom.replaceWithHorizontalRuler(range)
-        } else if remove {
-            dom.remove(element: .hr, at: range)
-        }
+        dom.replaceWithHorizontalRuler(range)
     }
 
     private func processMoreAttachmentDifferences(in range: NSRange, betweenOriginal original: MoreAttachment?, andNew new: MoreAttachment?) {
 
-        if let newAttachment = new, original == nil {
-            dom.replace(range, with: newAttachment.text)
-        } else if original != nil, new == nil {
-            deleteCharacters(in: range)
+        guard let newAttachment = new else {
+            return
         }
+
+        dom.replace(range, with: newAttachment.text)
     }
 
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -700,7 +700,7 @@ open class TextStorage: NSTextStorage {
     ///
     /// - Parameter range: the range where the element will be inserted
     ///
-    func insertHorizontalRuler(at range: NSRange) {
+    func replaceRangeWithHorizontalRuler(_ range: NSRange) {
         let line = LineAttachment()
 
         let attachmentString = NSAttributedString(attachment: line)
@@ -783,7 +783,7 @@ open class TextStorage: NSTextStorage {
     /// Inserts the MoreAttachment at the specified position
     ///
     @discardableResult
-    open func insertMoreAttachment(at position: Int) -> MoreAttachment {
+    open func replaceRangeWithMoreAttachment(_ range: NSRange) -> MoreAttachment {
         let message = "MORE"
         let label = NSLocalizedString("MORE", comment: "Text for the center of the more divider")
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -792,8 +792,7 @@ open class TextStorage: NSTextStorage {
         attachment.label = NSAttributedString(string: label, attributes: [:])
 
         let payload = NSAttributedString(attachment: attachment)
-        let target = NSMakeRange(position, 0)
-        replaceCharacters(in: target, with: payload)
+        replaceCharacters(in: range, with: payload)
 
         return attachment
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -783,16 +783,19 @@ open class TextStorage: NSTextStorage {
     /// Inserts the MoreAttachment at the specified position
     ///
     @discardableResult
-    open func replaceRangeWithMoreAttachment(_ range: NSRange) -> MoreAttachment {
+    open func replaceRangeWithMoreAttachment(_ range: NSRange, attributes: [String: Any]) -> MoreAttachment {
         let message = "MORE"
         let label = NSLocalizedString("MORE", comment: "Text for the center of the more divider")
-
+        
         let attachment = MoreAttachment()
         attachment.message = message
         attachment.label = NSAttributedString(string: label, attributes: [:])
 
-        let payload = NSAttributedString(attachment: attachment)
-        replaceCharacters(in: range, with: payload)
+        let stringWithAttachment = NSAttributedString(attachment: attachment)
+        replaceCharacters(in: range, with: stringWithAttachment)
+
+        let attachmentRange = NSRange(location: range.location, length: NSAttributedString.lengthOfTextAttachment)
+        addAttributes(attributes, range: attachmentRange)
 
         return attachment
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -177,10 +177,10 @@ open class TextStorage: NSTextStorage {
         
         attributedString.enumerateAttribute(NSAttachmentAttributeName, in: fullRange, options: []) { (object, range, stop) in
 
-            guard let object = object else {
+            guard let object = object, !(object is MoreAttachment) else {
                 return
             }
-            
+
             guard let attachmentsDelegate = attachmentsDelegate else {
                 assertionFailure("This class can't really handle not having an image provider set.")
                 return
@@ -739,6 +739,23 @@ open class TextStorage: NSTextStorage {
             replaceCharacters(in: corrected, with: NSAttributedString(string: ""))
             delta += range.length
         }
+    }
+
+    /// Inserts the MoreAttachment at the specified position
+    ///
+    open func insertMoreAttachment(at position: Int) -> MoreAttachment {
+        let message = "MORE"
+        let label = NSLocalizedString("MORE", comment: "Text for the center of the more divider")
+
+        let attachment = MoreAttachment()
+        attachment.message = message
+        attachment.label = NSAttributedString(string: label, attributes: [:])
+
+        let payload = NSAttributedString(attachment: attachment)
+        let target = NSMakeRange(position, 0)
+        replaceCharacters(in: target, with: payload)
+
+        return attachment
     }
 
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -467,8 +467,8 @@ open class TextStorage: NSTextStorage {
 
         if let newAttachment = new, original == nil {
             dom.replace(range, with: newAttachment.text)
-        } else if let _ = original, new == nil {
-            dom.replaceCharacters(inRange: range, withString: String(), preferLeftNode: false)
+        } else if original != nil, new == nil {
+            deleteCharacters(in: range)
         }
     }
 
@@ -789,6 +789,7 @@ open class TextStorage: NSTextStorage {
 
     /// Inserts the MoreAttachment at the specified position
     ///
+    @discardableResult
     open func insertMoreAttachment(at position: Int) -> MoreAttachment {
         let message = "MORE"
         let label = NSLocalizedString("MORE", comment: "Text for the center of the more divider")

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -529,8 +529,8 @@ open class TextView: UITextView {
     ///
     /// - Parameter range: the range where the ruler will be inserted
     ///
-    open func replaceWithHorizontalRuler(at range: NSRange) {
-        storage.insertHorizontalRuler(at: range)
+    open func replaceRangeWithHorizontalRuler(_ range: NSRange) {
+        storage.replaceRangeWithHorizontalRuler(range)
         let length = NSAttributedString(attachment:NSTextAttachment()).length
         textStorage.addAttributes(typingAttributes, range: NSMakeRange(range.location, length))
         selectedRange = NSMakeRange(range.location + length, 0)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1007,14 +1007,14 @@ open class TextView: UITextView {
 
     /// Inserts the More Comment at the specified position.
     ///
-    /// - Parameter position: The character position at which to insert the more attachment.
+    /// - Parameter range: The character range that must be replaced by a More Attachment.
     ///
     /// - Returns: the attachment object that can be used for further calls
     ///
     @discardableResult
-    open func insertMoreAttachment(at position: Int) -> MoreAttachment {
-        let attachment = storage.insertMoreAttachment(at: position)
-        let attachmentRange = NSRange(location: position, length: NSAttributedString.lengthOfTextAttachment)
+    open func replaceRangeWithMoreAttachment(_ range: NSRange) -> MoreAttachment {
+        let attachment = storage.replaceRangeWithMoreAttachment(range)
+        let attachmentRange = NSRange(location: range.location, length: NSAttributedString.lengthOfTextAttachment)
 
         storage.addAttributes(typingAttributes, range: attachmentRange)
         

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1013,12 +1013,9 @@ open class TextView: UITextView {
     ///
     @discardableResult
     open func replaceRangeWithMoreAttachment(_ range: NSRange) -> MoreAttachment {
-        let attachment = storage.replaceRangeWithMoreAttachment(range)
-        let attachmentRange = NSRange(location: range.location, length: NSAttributedString.lengthOfTextAttachment)
+        let attachment = storage.replaceRangeWithMoreAttachment(range, attributes: typingAttributes)
 
-        storage.addAttributes(typingAttributes, range: attachmentRange)
-        
-        selectedRange = NSMakeRange(attachmentRange.endLocation, 0)
+        selectedRange = NSMakeRange(range.location + NSAttributedString.lengthOfTextAttachment, 0)
         delegate?.textViewDidChange?(self)
 
         return attachment

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -734,7 +734,7 @@ open class TextView: UITextView {
     ///
     open func insertImage(sourceURL url: URL, atPosition position: Int, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> TextAttachment {
         let attachment = storage.insertImage(sourceURL: url, atPosition: position, placeHolderImage: placeHolderImage ?? defaultMissingImage, identifier: identifier)
-        let length = NSAttributedString(attachment:NSTextAttachment()).length
+        let length = NSAttributedString.lengthOfTextAttachment
         textStorage.addAttributes(typingAttributes, range: NSMakeRange(position, length))
         selectedRange = NSMakeRange(position+length, 0)
         delegate?.textViewDidChange?(self)
@@ -930,7 +930,29 @@ open class TextView: UITextView {
     ///
     open func refreshLayoutFor(attachment: TextAttachment) {
         layoutManager.invalidateLayoutForAttachment(attachment)
-    }    
+    }
+
+
+    // MARK: - More
+
+    /// Inserts the More Comment at the specified position.
+    ///
+    /// - Parameter position: The character position at which to insert the more attachment.
+    ///
+    /// - Returns: the attachment object that can be used for further calls
+    ///
+    @discardableResult
+    open func insertMoreAttachment(at position: Int) -> MoreAttachment {
+        let attachment = storage.insertMoreAttachment(at: position)
+        let attachmentRange = NSRange(location: position, length: NSAttributedString.lengthOfTextAttachment)
+
+        storage.addAttributes(typingAttributes, range: attachmentRange)
+        
+        selectedRange = NSMakeRange(attachmentRange.endLocation, 0)
+        delegate?.textViewDidChange?(self)
+
+        return attachment
+    }
 }
 
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -286,6 +286,20 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(html, "<hr>")
     }
 
+    /// This test check if the insertion of antwo horizontal ruler works correctly and the hr tag(s) are inserted
+    ///
+    func testInsertTwoHorizontalRulersGeneratesExpectedHTML() {
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+
+        storage.insertHorizontalRuler(at: NSRange.zero)
+        storage.insertHorizontalRuler(at: NSRange.zero)
+        let html = storage.getHTML()
+
+        XCTAssertEqual(html, "<hr><hr>")
+    }
+
     /// This test check if the insertion of an horizontal ruler over an image attachment works correctly and the hr tag is inserted
     ///
     func testInsertHorizontalRulerOverImage() {
@@ -298,5 +312,30 @@ class TextStorageTests: XCTestCase
         let html = storage.getHTML()
 
         XCTAssertEqual(html, "<hr>")
+    }
+
+
+    /// This test check if the insertion of a More Attachment works correctly and the <!--more--> tag is inserted
+    ///
+    func testInsertMoreAttachmentCorretlyGeneratesHTMLComment() {
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+
+        storage.insertMoreAttachment(at: 0)
+        let html = storage.getHTML()
+
+        XCTAssertEqual(html, "<!--more-->")
+    }
+
+    /// This test check if the insertion of a More Attachment works correctly and the <!--more--> tag is inserted
+    ///
+    func testInsertTwoMoreAttachmentsDoNotCrashTheEditor() {
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+
+        storage.insertMoreAttachment(at: 0)
+        storage.insertMoreAttachment(at: 0)
     }
 }

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -324,7 +324,7 @@ class TextStorageTests: XCTestCase
         storage.replaceRangeWithMoreAttachment(.zero, attributes: [:])
         let html = storage.getHTML()
 
-        XCTAssertEqual(html, "<!--more-->")
+        XCTAssertEqual(html, "<!--MORE-->")
     }
 
     /// This test check if the insertion of a More Attachment works correctly and the <!--more--> tag is inserted
@@ -339,7 +339,7 @@ class TextStorageTests: XCTestCase
 
         let html = storage.getHTML()
 
-        XCTAssertEqual(html, "<!--more--><!--more-->")
+        XCTAssertEqual(html, "<!--MORE--><!--MORE-->")
     }
 
     /// This test verifies if we can delete all the content from a storage object that has html with a comment

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -322,7 +322,7 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        storage.replaceRangeWithMoreAttachment(.zero)
+        storage.replaceRangeWithMoreAttachment(.zero, attributes: [:])
         let html = storage.getHTML()
 
         XCTAssertEqual(html, "<!--more-->")
@@ -335,8 +335,8 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        storage.replaceRangeWithMoreAttachment(.zero)
-        storage.replaceRangeWithMoreAttachment(.zero)
+        storage.replaceRangeWithMoreAttachment(.zero, attributes: [:])
+        storage.replaceRangeWithMoreAttachment(.zero, attributes: [:])
 
         let html = storage.getHTML()
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -280,7 +280,7 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        storage.insertHorizontalRuler(at: NSRange.zero)
+        storage.replaceRangeWithHorizontalRuler(.zero)
         let html = storage.getHTML()
 
         XCTAssertEqual(html, "<hr>")
@@ -302,13 +302,13 @@ class TextStorageTests: XCTestCase
 
     /// This test check if the insertion of an horizontal ruler over an image attachment works correctly and the hr tag is inserted
     ///
-    func testInsertHorizontalRulerOverImage() {
+    func testReplaceRangeWithHorizontalRulerRulerOverImage() {
         let storage = TextStorage()
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
         let _ = storage.insertImage(sourceURL: URL(string: "https://wordpress.com")!, atPosition: 0, placeHolderImage: UIImage())
-        storage.insertHorizontalRuler(at: NSRange(location: 0, length:1))
+        storage.replaceRangeWithHorizontalRuler(NSRange(location: 0, length:1))
         let html = storage.getHTML()
 
         XCTAssertEqual(html, "<hr>")
@@ -317,12 +317,12 @@ class TextStorageTests: XCTestCase
 
     /// This test check if the insertion of a More Attachment works correctly and the <!--more--> tag is inserted
     ///
-    func testInsertMoreAttachmentCorretlyGeneratesHTMLComment() {
+    func testReplaceRangeWithMoreAttachmentGeneratesExpectedHTMLComment() {
         let storage = TextStorage()
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        storage.insertMoreAttachment(at: 0)
+        storage.replaceRangeWithMoreAttachment(.zero)
         let html = storage.getHTML()
 
         XCTAssertEqual(html, "<!--more-->")
@@ -330,13 +330,13 @@ class TextStorageTests: XCTestCase
 
     /// This test check if the insertion of a More Attachment works correctly and the <!--more--> tag is inserted
     ///
-    func testInsertTwoMoreAttachmentsDoNotCrashTheEditor() {
+    func testReplaceRangeWithMoreAttachmentDoNotCrashTheEditorWhenCalledSequentially() {
         let storage = TextStorage()
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        storage.insertMoreAttachment(at: 0)
-        storage.insertMoreAttachment(at: 0)
+        storage.replaceRangeWithMoreAttachment(.zero)
+        storage.replaceRangeWithMoreAttachment(.zero)
 
         let html = storage.getHTML()
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -337,5 +337,9 @@ class TextStorageTests: XCTestCase
 
         storage.insertMoreAttachment(at: 0)
         storage.insertMoreAttachment(at: 0)
+
+        let html = storage.getHTML()
+
+        XCTAssertEqual(html, "<!--more--><!--more-->")
     }
 }

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -275,7 +275,7 @@ class TextStorageTests: XCTestCase
 
     /// This test check if the insertion of an horizontal ruler works correctly and the hr tag is inserted
     ///
-    func testInsertHorizontalRuler() {
+    func testReplaceRangeWithHorizontalRuler() {
         let storage = TextStorage()
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
@@ -288,13 +288,13 @@ class TextStorageTests: XCTestCase
 
     /// This test check if the insertion of antwo horizontal ruler works correctly and the hr tag(s) are inserted
     ///
-    func testInsertTwoHorizontalRulersGeneratesExpectedHTML() {
+    func testReplaceRangeWithHorizontalRulerGeneratesExpectedHTMLWhenExecutedSequentially() {
         let storage = TextStorage()
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        storage.insertHorizontalRuler(at: NSRange.zero)
-        storage.insertHorizontalRuler(at: NSRange.zero)
+        storage.replaceRangeWithHorizontalRuler(.zero)
+        storage.replaceRangeWithHorizontalRuler(.zero)
         let html = storage.getHTML()
 
         XCTAssertEqual(html, "<hr><hr>")

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -493,8 +493,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func insertMoreAttachment() {
-        let position = richTextView.selectedRange.location
-        richTextView.insertMoreAttachment(at: position)
+        richTextView.replaceRangeWithMoreAttachment(richTextView.selectedRange)
     }
 
     func showLinkDialog(forURL url: URL?, title: String?, range: NSRange) {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -393,6 +393,8 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
             toggleEditingMode()
         case .header, .header1, .header2, .header3, .header4, .header5, .header6:
             toggleHeader()
+        case .more:
+            insertMoreAttachment()
         }
 
         updateFormatBar()
@@ -498,6 +500,11 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
 
         linkTitle = richTextView.attributedText.attributedSubstring(from: linkRange).string
         showLinkDialog(forURL: linkURL, title: linkTitle, range: linkRange)
+    }
+
+    func insertMoreAttachment() {
+        let position = richTextView.selectedRange.location
+        richTextView.insertMoreAttachment(at: position)
     }
 
     func showLinkDialog(forURL url: URL?, title: String?, range: NSRange) {
@@ -659,7 +666,8 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
             FormatBarItem(image: Gridicon.iconOfType(.quote), identifier: .blockquote),
             FormatBarItem(image: Gridicon.iconOfType(.listUnordered), identifier: .unorderedlist),
             FormatBarItem(image: Gridicon.iconOfType(.listOrdered), identifier: .orderedlist),
-            FormatBarItem(image: Gridicon.iconOfType(.link), identifier: .link)
+            FormatBarItem(image: Gridicon.iconOfType(.link), identifier: .link),
+            FormatBarItem(image: Gridicon.iconOfType(.readMore), identifier: .more)
         ]
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -421,7 +421,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func insertHorizontalRuler() {
-        richTextView.replaceWithHorizontalRuler(at: richTextView.selectedRange)
+        richTextView.replaceRangeWithHorizontalRuler(richTextView.selectedRange)
     }
 
     func toggleHeader() {


### PR DESCRIPTION
### Details:
In this PR we're implementing a public API to support the insertion of the More Attachment.

Please, note that (since we're updating the exact same spot), we've patched the `HR` tag "diffing" snippet, since HR tags can be only inserted, not removed, by means of string diffing.

Closes #361

### Testing:
- Verify that all of the unit tests pass
- Verify that pressing the `More` format bar button effectively inserts the more section
- Verify the generated HTML
- Verify that inserting `<!--MORE-->` in html mode (case insensitive) renders as an attachment, in rich mode

Needs Review: @diegoreymendez + @SergioEstevao
Thanks in advance!!