### PR TITLE
Fixes 350 crash when using visual only element

### DIFF
--- a/Aztec/Classes/NSAttributedString/VisualOnlyElementFactory.swift
+++ b/Aztec/Classes/NSAttributedString/VisualOnlyElementFactory.swift
@@ -31,7 +31,7 @@ class VisualOnlyElementFactory {
     func zeroWidthSpace(inheritingAttributes inheritedAttributes: [String:Any]? = nil) -> NSAttributedString {
         var attributes = inheritedAttributes ?? [String:Any]()
 
-        attributes[VisualOnlyAttributeName] = VisualOnlyElement.zeroWidthSpace.rawValue
+        //attributes[VisualOnlyAttributeName] = VisualOnlyElement.zeroWidthSpace.rawValue
 
         return NSAttributedString(.zeroWidthSpace, attributes: attributes)
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -656,7 +656,7 @@ open class TextStorage: NSTextStorage {
     }
     
     // MARK: - Styles: Toggling
-    @discardableResult func toggle(formatter: AttributeFormatter, at range: NSRange) -> NSRange? {
+    @discardableResult func toggle(formatter: AttributeFormatter, at range: NSRange) -> NSRange {
         let applicationRange = formatter.applicationRange(for: range, in: self)
         if applicationRange.length == 0, !formatter.worksInEmptyRange() {
             return applicationRange

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -426,9 +426,8 @@ open class TextView: UITextView {
     // MARK: - Formatting
 
     func toggle(formatter: AttributeFormatter, atRange range: NSRange) {
-        let newSelectedRange = storage.toggle(formatter: formatter, at: range)         
-        selectedRange = newSelectedRange ?? selectedRange
-        if selectedRange.length == 0 {
+        let applicationRange = storage.toggle(formatter: formatter, at: range)        
+        if applicationRange.length == 0 {
             typingAttributes = formatter.toggle(in: typingAttributes)
         } else {
             // NOTE: We are making sure that the selectedRange location is inside the string

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -16,6 +16,12 @@ class AztecVisualtextViewTests: XCTestCase {
 
     // MARK: - TextView construction
 
+    func createEmptyTextView() -> Aztec.TextView {
+        let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: Gridicon.iconOfType(.attachment))
+
+        return richTextView
+    }
+
     func createTextView(withHTML html: String) -> Aztec.TextView {
         let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: Gridicon.iconOfType(.attachment))
 
@@ -208,6 +214,18 @@ class AztecVisualtextViewTests: XCTestCase {
 
         XCTAssert(!textView.formatIdentifiersAtIndex(1).contains(.blockquote))
         XCTAssert(!textView.formatIdentifiersSpanningRange(range).contains(.blockquote))
+    }
+
+    /// This test was created to prevent regressions related to this issue:
+    /// https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/350
+    ///
+    func testToggleBlockquoteAndStrikethrough() {
+        let textView = createEmptyTextView()
+
+        textView.toggleStrikethrough(range: NSRange.zero)
+        textView.toggleBlockquote(range: NSRange.zero)
+
+        // There's no need to check any condition, as long as the test doesn't crash.
     }
 
     func testToggleOrderedList() {


### PR DESCRIPTION
Fixes #350 

This PR at the moment fixes the crash by removing the visual only attributes to the zero width space.

This space is used when applying paragraph attributes that need a character in order to be visible.

@diegoreymendez I think we are missing a visual to DOM mapping somewhere in the process but I'm struggling to find here to do it.