### PR TITLE
More: Lowercase Tag

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -98,11 +98,10 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
-        let moreLabel = "MORE"
-        if node.comment.hasPrefix(moreLabel) {
+        if node.comment.hasPrefix(MoreAttachment.commentNodeText) {
             var attributes = inheritedAttributes;
             let moreAttachment = MoreAttachment()
-            let index = moreLabel.endIndex
+            let index = MoreAttachment.commentNodeText.endIndex
             moreAttachment.message = node.comment.substring(from: index)            
             moreAttachment.label = NSAttributedString(string: NSLocalizedString("MORE", comment: "Text for the center of the more divider"), attributes: defaultAttributes)
             attributes[NSAttachmentAttributeName] = moreAttachment

--- a/Aztec/Classes/TextKit/MoreAttachment.swift
+++ b/Aztec/Classes/TextKit/MoreAttachment.swift
@@ -24,7 +24,7 @@ open class MoreAttachment: NSTextAttachment
     /// Comment's Text.
     /// This is a temporary helper property, and will be removed as soon as we merge MoreAttachment + CommentAttachment.
     ///
-    let text = "MORE"
+    static let commentNodeText = "more"
 
 
     open var message: String = ""

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -458,11 +458,7 @@ open class TextStorage: NSTextStorage {
 
     private func processMoreAttachmentDifferences(in range: NSRange, betweenOriginal original: MoreAttachment?, andNew new: MoreAttachment?) {
 
-        guard let newAttachment = new else {
-            return
-        }
-
-        dom.replace(range, with: newAttachment.text)
+        dom.replace(range, with: MoreAttachment.commentNodeText)
     }
 
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -324,7 +324,7 @@ class TextStorageTests: XCTestCase
         storage.replaceRangeWithMoreAttachment(.zero, attributes: [:])
         let html = storage.getHTML()
 
-        XCTAssertEqual(html, "<!--MORE-->")
+        XCTAssertEqual(html, "<!--more-->")
     }
 
     /// This test check if the insertion of a More Attachment works correctly and the <!--more--> tag is inserted
@@ -339,7 +339,7 @@ class TextStorageTests: XCTestCase
 
         let html = storage.getHTML()
 
-        XCTAssertEqual(html, "<!--MORE--><!--MORE-->")
+        XCTAssertEqual(html, "<!--more--><!--more-->")
     }
 
     /// This test verifies if we can delete all the content from a storage object that has html with a comment


### PR DESCRIPTION
### Details:
We're switching the **more** attachment to lowercase, in order to match Calypso's behavior.

### Steps:
1. Insert a More Tag
2. Verify that the HTML generated is a lowercase `more` comment
3. Toggle back to Rich Mode
4. Verify that the More Tag gets properly displayed

Needs Review: @diegoreymendez 
Thanks!
