### PR TITLE
Issue/381 fix range methods

### DIFF
--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -33,9 +33,7 @@ extension String
     }
 
     func location(after: Int) -> Int? {
-        guard let currentIndex = indexFromLocation(after),
-            currentIndex != endIndex
-        else {
+        guard let currentIndex = indexFromLocation(after), currentIndex != endIndex else {
             return nil
         }
         let afterIndex = index(after: currentIndex)
@@ -44,9 +42,7 @@ extension String
     }
 
     func location(before: Int) -> Int? {
-        guard let currentIndex = indexFromLocation(before),
-              currentIndex != startIndex
-        else {
+        guard let currentIndex = indexFromLocation(before), currentIndex != startIndex else {
             return nil
         }
 

--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -33,7 +33,9 @@ extension String
     }
 
     func location(after: Int) -> Int? {
-        guard let currentIndex = indexFromLocation(after) else {
+        guard let currentIndex = indexFromLocation(after),
+            currentIndex != endIndex
+        else {
             return nil
         }
         let afterIndex = index(after: currentIndex)
@@ -42,9 +44,12 @@ extension String
     }
 
     func location(before: Int) -> Int? {
-        guard let currentIndex = indexFromLocation(before) else {
+        guard let currentIndex = indexFromLocation(before),
+              currentIndex != startIndex
+        else {
             return nil
         }
+
         let beforeIndex = index(before: currentIndex)
         let before16 = beforeIndex.samePosition(in: utf16)
         return utf16.distance(from: utf16.startIndex, to: before16)

--- a/AztecTests/StringRangeConversionTests.swift
+++ b/AztecTests/StringRangeConversionTests.swift
@@ -139,5 +139,19 @@ class StringRangeConversionTests: XCTestCase {
         XCTAssertEqual("Hello ", wordCaptured)
     }
 
+    func testLocationBeforeAtLimits() {
+        // test at start of string
+        let string = ""
+        let nonExistentLocation = string.location(before: 0)
+        XCTAssertNil(nonExistentLocation)
+    }
+
+    func testLocationAfterAtLimits() {
+        // test at start of string
+        let string = ""
+        let nonExistentLocation = string.location(after: 0)
+        XCTAssertNil(nonExistentLocation)
+    }
+
     
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -527,4 +527,13 @@ class AztecVisualTextViewTests: XCTestCase {
 
         XCTAssertEqual(textView.getHTML(), "<a href=\"\(linkUrl)\">\(linkTitle)</a>")
     }
+
+    func testToggleBlockquoteWriteOneCharAndDelete() {
+        let textView = createEmptyTextView()
+
+        textView.toggleBlockquote(range: NSRange.zero)
+        textView.insertText("A")
+        textView.deleteBackward()
+        // The test not crashing would be successful.
+    }
 }


### PR DESCRIPTION
Fix #381 

This PR add fixes to the range methods to avoid trying to over the limits of the string.

How to test:
 - the unit test added covers the crash scenario, but some deletion around lists and block quotes on the demo app will be good.