### PR TITLE
Deleting visual newlines: right-hand lists.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -1447,6 +1447,25 @@ extension Libxml2 {
             }
         }
 
+        func unwrapChildren(first amount: Int) {
+            assert(children.count >= amount)
+
+            guard let parent = parent else {
+                assertionFailure("Cannot execute this method if a parent isn't set.")
+                return
+            }
+
+            let myIndex = parent.indexOf(childNode: self)
+
+            for _ in 0...(amount - 1) {
+                parent.insert(children[0], at: myIndex)
+            }
+
+            if children.count == 0 {
+                removeFromParent()
+            }
+        }
+
         /// Unwraps the receiver's children from the receiver.
         ///
         @discardableResult

--- a/Aztec/Classes/Libxml2/DOM/Logic/DOMEditor.swift
+++ b/Aztec/Classes/Libxml2/DOM/Logic/DOMEditor.swift
@@ -324,7 +324,19 @@ extension Libxml2 {
             if let rightElement = rightSibling as? ElementNode,
                 rightElement.isBlockLevelElement() {
 
-                finalRightNodes = rightElement.unwrapChildren()
+                if rightElement.children.count > 0,
+                    let rightChildElement = rightElement.children[0] as? ElementNode,
+                    rightChildElement.isBlockLevelElement() {
+
+                    rightElement.unwrapChildren(first: 1)
+
+                    // This case was designed for lists.  They need to unwrap the first list element
+                    // from both the ul / ol and the li elements.
+                    //
+                    finalRightNodes = rightChildElement.unwrapChildren()
+                } else {
+                    finalRightNodes = rightElement.unwrapChildren()
+                }
             } else {
                 finalRightNodes = [rightSibling]
             }

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -113,9 +113,10 @@ extension Libxml2 {
             } catch {
                 fatalError("Could not convert the HTML.")
             }
-            
+
             domQueue.sync {
                 self.rootNode = output.rootNode
+                self.domEditor = DOMEditor(with: output.rootNode)
             }
             
             return output.attributedString

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -487,16 +487,17 @@ class AztecVisualTextViewTests: XCTestCase {
     /// Tests that deleting a newline works by merging the component around it.
     ///
     /// Input:
-    ///     - Initial HTML: "List<ul><li>first</li><li>second</li>"
+    ///     - Initial HTML: "List<ul><li>first</li><li>second</li><li>third</li></ul>"
     ///     - Deletion range: (loc: 4, len 1)
     ///     - Second deletion range: (loc: 9, len: 1)
+    ///     - Third deletion range: (loc: 15, len: 1)
     ///
     /// Output:
     ///     - Final HTML: "Listfirstsecond"
     ///
     func testDeleteNewline5() {
 
-        let textView = createTextView(withHTML: "List<ul><li>first</li><li>second</li>")
+        let textView = createTextView(withHTML: "List<ul><li>first</li><li>second</li><li>third</li></ul>")
 
         let rangeStart = textView.position(from: textView.beginningOfDocument, offset: 4)!
         let rangeEnd = textView.position(from: rangeStart, offset: 1)!
@@ -504,7 +505,7 @@ class AztecVisualTextViewTests: XCTestCase {
 
         textView.replace(range, withText: "")
 
-        XCTAssertEqual(textView.getHTML(), "Listfirst<ul><li>second</li></ul>")
+        XCTAssertEqual(textView.getHTML(), "Listfirst<ul><li>second</li><li>third</li></ul>")
 
         let rangeStart2 = textView.position(from: textView.beginningOfDocument, offset: 9)!
         let rangeEnd2 = textView.position(from: rangeStart2, offset: 1)!
@@ -512,7 +513,15 @@ class AztecVisualTextViewTests: XCTestCase {
 
         textView.replace(range2, withText: "")
 
-        XCTAssertEqual(textView.getHTML(), "Listfirstsecond")
+        XCTAssertEqual(textView.getHTML(), "Listfirstsecond<ul><li>third</li></ul>")
+
+        let rangeStart3 = textView.position(from: textView.beginningOfDocument, offset: 15)!
+        let rangeEnd3 = textView.position(from: rangeStart3, offset: 1)!
+        let range3 = textView.textRange(from: rangeStart3, to: rangeEnd3)!
+
+        textView.replace(range3, withText: "")
+
+        XCTAssertEqual(textView.getHTML(), "Listfirstsecondthird")
     }
 
     /// Tests that deleting a newline works at the end of text with paragraph with header before works.

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -484,6 +484,37 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<p>HelloWorld!</p>")
     }
 
+    /// Tests that deleting a newline works by merging the component around it.
+    ///
+    /// Input:
+    ///     - Initial HTML: "List<ul><li>first</li><li>second</li>"
+    ///     - Deletion range: (loc: 4, len 1)
+    ///     - Second deletion range: (loc: 9, len: 1)
+    ///
+    /// Output:
+    ///     - Final HTML: "Listfirstsecond"
+    ///
+    func testDeleteNewline5() {
+
+        let textView = createTextView(withHTML: "List<ul><li>first</li><li>second</li>")
+
+        let rangeStart = textView.position(from: textView.beginningOfDocument, offset: 4)!
+        let rangeEnd = textView.position(from: rangeStart, offset: 1)!
+        let range = textView.textRange(from: rangeStart, to: rangeEnd)!
+
+        textView.replace(range, withText: "")
+
+        XCTAssertEqual(textView.getHTML(), "Listfirst<ul><li>second</li></ul>")
+
+        let rangeStart2 = textView.position(from: textView.beginningOfDocument, offset: 9)!
+        let rangeEnd2 = textView.position(from: rangeStart2, offset: 1)!
+        let range2 = textView.textRange(from: rangeStart2, to: rangeEnd2)!
+
+        textView.replace(range2, withText: "")
+
+        XCTAssertEqual(textView.getHTML(), "Listfirstsecond")
+    }
+
     /// Tests that deleting a newline works at the end of text with paragraph with header before works.
     ///
     /// Input:


### PR DESCRIPTION
<h3>Description:</h3>

Takes care of handling the deletion of newlines that have a list at their right-hand.

Part of #216.

<h3>Testing:</h3>

**Test 1:**

Run the unit tests.  I added a specific one for this scenario.

**Test 2:**

1. Use an initial HTML such as: `<p>Hello</p><ol><li>1</li><li>2</li><li>3</li></ol>`
2. Delete the newline between "Hello" and "1"
3. Switch to HTML mode and make sure the output is as expected.
4. Repeat from step 2 for the other list items.