### PR TITLE
Remove compiler warning on Xcode 8.3

### DIFF
--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -134,6 +134,6 @@ open class ParagraphStyle: NSMutableParagraphStyle {
     }
 
     open override var description:String {
-        return super.description + "\nTextList:\(textList?.style)\nBlockquote:\(blockquote)\nHeaderLevel:\(headerLevel)"
+        return super.description + "\nTextList:\(String(describing: textList?.style))\nBlockquote:\(String(describing:blockquote))\nHeaderLevel:\(headerLevel)"
     }
 }


### PR DESCRIPTION
How to test:
 - Just build the project and see if no warning show up.