### PR TITLE
Issue/278 support underline on spans

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -204,15 +204,6 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             attributeValue = attachment
         }
 
-        if node.isNodeType(.span) {
-            if let elementStyle = node.valueForStringAttribute(named: "style") {
-                let styles = parseStyle(style: elementStyle)
-                if !styles.isEmpty, let colorString = styles["color"] {
-                    attributeValue = UIColor(hexString: colorString)
-                }
-            }           
-        }
-
         for (key, formatter) in elementToFormattersMap {
             if node.isNodeType(key) {
                 if let standardValueFormatter = formatter as? StandardAttributeFormatter,
@@ -223,6 +214,19 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             }
         }
 
+        if let elementStyle = node.valueForStringAttribute(named: "style") {
+            let styles = parseStyle(style: elementStyle)
+            for (key, (formatter, parser)) in styleToFormattersMap {
+                guard let styleString = styles[key],
+                      let standardValueFormatter = formatter as? StandardAttributeFormatter,
+                      let value = parser(styleString)
+                    else {
+                        continue
+                    }
+                    standardValueFormatter.attributeValue = value
+                    attributes = standardValueFormatter.apply(to: attributes);
+            }
+        }
         return attributes
     }
 
@@ -243,7 +247,11 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         .h4: HeaderFormatter(headerLevel: .h4),
         .h5: HeaderFormatter(headerLevel: .h5),
         .h6: HeaderFormatter(headerLevel: .h6),
-        .span: ColorFormatter()
+    ]
+
+    public let styleToFormattersMap: [String: (AttributeFormatter, (String)->Any?)] = [
+        "color": (ColorFormatter(), {(value) in return UIColor(hexString: value)}),
+        "text-decoration": (UnderlineFormatter(), { (value) in return value == "underline" ? NSUnderlineStyle.styleSingle.rawValue : nil})
     ]
 
     func parseStyle(style: String) -> [String: String] {

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -15,7 +15,7 @@
 <u>Underlined text</u><br/>
 <del>Strikethrough</del><br/>
 <span style="color: #ff0000;">Colors</span><br/>
-
+<span style="text-decoration: underline;">Alternative underline text</span><br/>
 <a href="http://www.wordpress.com">I'm a link!</a><br/>
 
 <!--more-->


### PR DESCRIPTION
Refs #278 

This PR adds support for the underline style on spans.

How to text:
 - Run the demo app
 - Check if underline style shows correctly for the Alternative Underline text.

Note:

 - This PR doesn't address removing or adding underlines on the visual using this kind of HTML.