### PR TITLE
Issue/387 newline after style

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -168,7 +168,7 @@ extension Libxml2 {
                 if let siblingElement = sibling as? ElementNode {
                     return siblingElement.isBlockLevelElement()
                 } else {
-                    return sibling.isLastInBlockLevelElement()
+                    return false
                 }
             } else {
                 return parent.isLastInBlockLevelElement()

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -394,6 +394,17 @@ class AztecVisualTextViewTests: XCTestCase {
         textView.insertText("\n")
     }
 
+    /// Tests that the visual newline is shown at the correct position.
+    ///
+    /// Added to avoid regressions to the bug reported here:
+    /// https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/387
+    ///
+    func testNewlineRenderedAtTheCorrectPosition() {
+        let textView = createTextView(withHTML: "<p>Testing <b>bold</b> newlines</p>")
+
+        XCTAssertEqual(textView.text, "Testing bold newlines\n")
+    }
+
     // MARK: - Deleting newlines
 
     /// Tests that deleting a newline works by merging the component around it.


### PR DESCRIPTION
<h3>Description</h3>

Newlines were being added at the last style in a block-level element.

Fixes #387.

<h3>How to test:</h3>

**Test 1:**

Review and run the unit tests.

**Test 2:**

1. Open the empty editor.
2. Switch to HTML mode.
3. Add any block level element with a style followed by a text node, such as: `<p>Hello <b>there</b> friend!</p>`
4. Switch to visual mode and make sure there are no extra newlines.