### PR TITLE
Unknown HTML Support

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -51,7 +51,9 @@
 		B572AC281E817CFE008948C2 /* CommentAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B572AC271E817CFE008948C2 /* CommentAttachment.swift */; };
 		B577DC651E7B18E90012A1F8 /* NodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B577DC641E7B18E90012A1F8 /* NodeDescriptor.swift */; };
 		B577DC671E7B18F80012A1F8 /* CommentNodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B577DC661E7B18F80012A1F8 /* CommentNodeDescriptor.swift */; };
+		B57D1C3D1E92C38000EA4B16 /* HTMLAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */; };
 		B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */; };
+		B5AF89321E93CFC80051EFDB /* RenderableAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */; };
 		B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */; };
 		B5B86D3C1DA41A550083DB3F /* TextListFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */; };
 		B5B96DAB1E01B2F300791315 /* UIPasteboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */; };
@@ -186,7 +188,9 @@
 		B572AC271E817CFE008948C2 /* CommentAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachment.swift; sourceTree = "<group>"; };
 		B577DC641E7B18E90012A1F8 /* NodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NodeDescriptor.swift; path = Descriptors/NodeDescriptor.swift; sourceTree = "<group>"; };
 		B577DC661E7B18F80012A1F8 /* CommentNodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommentNodeDescriptor.swift; path = Descriptors/CommentNodeDescriptor.swift; sourceTree = "<group>"; };
+		B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachment.swift; sourceTree = "<group>"; };
 		B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Traits.swift"; sourceTree = "<group>"; };
+		B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderableAttachmentDelegate.swift; sourceTree = "<group>"; };
 		B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatter.swift; sourceTree = "<group>"; };
 		B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIPasteboard+Helpers.swift"; sourceTree = "<group>"; };
 		B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Lists.swift"; sourceTree = "<group>"; };
@@ -459,9 +463,11 @@
 		599F252E1D8BC9A1002871D6 /* TextKit */ = {
 			isa = PBXGroup;
 			children = (
+				B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */,
 				B572AC271E817CFE008948C2 /* CommentAttachment.swift */,
-				599F25301D8BC9A1002871D6 /* TextAttachment.swift */,
+				B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */,
 				FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */,
+				599F25301D8BC9A1002871D6 /* TextAttachment.swift */,
 				B5BC4FF51DA2D76600614582 /* TextList.swift */,
 				599F25311D8BC9A1002871D6 /* TextStorage.swift */,
 				599F25321D8BC9A1002871D6 /* TextView.swift */,
@@ -802,6 +808,7 @@
 				FF7C89B01E3BC52F000472A8 /* NSAttributedString+FontTraits.swift in Sources */,
 				B5BC4FF61DA2D76600614582 /* TextList.swift in Sources */,
 				F1FA0E821E6EF514009D98EE /* CommentNode.swift in Sources */,
+				B57D1C3D1E92C38000EA4B16 /* HTMLAttachment.swift in Sources */,
 				F1FA0E871E6EF514009D98EE /* StandardElementType.swift in Sources */,
 				599F25391D8BC9A1002871D6 /* InHTMLConverter.swift in Sources */,
 				F1A218151E02D5B3000AF5EB /* UndoManager.swift in Sources */,
@@ -809,6 +816,7 @@
 				599F253E1D8BC9A1002871D6 /* OutHTMLNodeConverter.swift in Sources */,
 				E109B51C1DC33F2C0099605E /* LayoutManager.swift in Sources */,
 				F1FA0E851E6EF514009D98EE /* MarkerNode.swift in Sources */,
+				B5AF89321E93CFC80051EFDB /* RenderableAttachmentDelegate.swift in Sources */,
 				B5BC4FEE1DA2C17800614582 /* NSAttributedString+Lists.swift in Sources */,
 				B5F84B611E70595B0089A76C /* NSAttributedString+Analyzers.swift in Sources */,
 				599F25361D8BC9A1002871D6 /* Converter.swift in Sources */,

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -112,7 +112,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     fileprivate func convertElementNode(_ node: ElementNode, inheritingAttributes attributes: [String: Any]) -> NSAttributedString {
-        guard !node.isSupportedByAztec() else {
+        guard !node.isSupportedByEditor() else {
             return stringForNode(node, inheritingAttributes: attributes)
         }
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -1350,14 +1350,6 @@ extension Libxml2 {
         /// - parameter descriptor:  The descriptor for the element to replace the text with.
         ///
         func replaceCharacters(in targetRange: NSRange, with descriptor: NodeDescriptor) {
-            
-            guard let textNode = lowestTextNodeWrapping(targetRange) else {
-                return
-            }
-            
-            let absoluteLocation = textNode.absoluteLocation()
-            let localRange = NSRange(location: targetRange.location - absoluteLocation, length: targetRange.length)
-            textNode.split(forRange: localRange)
 
             let node: Node
             if let descriptor = descriptor as? ElementNodeDescriptor {
@@ -1368,16 +1360,33 @@ extension Libxml2 {
                 fatalError("Unsupported Node Descriptor")
             }
 
-            
+            replaceCharacters(in: targetRange, with: node)
+        }
+
+        /// Replace characters in targetRange by a node with the name in nodeName and attributes
+        ///
+        /// - parameter targetRange: The range to replace
+        /// - parameter node:  The Element to replace the text with.
+        ///
+        func replaceCharacters(in targetRange: NSRange, with node: Node) {
+
+            guard let textNode = lowestTextNodeWrapping(targetRange) else {
+                return
+            }
+
+            let absoluteLocation = textNode.absoluteLocation()
+            let localRange = NSRange(location: targetRange.location - absoluteLocation, length: targetRange.length)
+            textNode.split(forRange: localRange)
+
             guard let index = textNode.parent?.children.index(of: textNode) else {
                 assertionFailure("Can't remove a node that's not a child.")
                 return
             }
-            
+
             guard let textNodeParent = textNode.parent else {
                 return
             }
-            
+
             textNodeParent.insert(node, at: index)
             textNodeParent.remove(textNode)
         }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -1612,11 +1612,11 @@ extension Libxml2 {
         }
 
         func isSupportedByAztec() -> Bool {
-            guard let editContext = editContext, let standardName = standardName else {
+            guard let standardName = standardName else {
                 return false
             }
 
-            return editContext.knownElements.contains(standardName)
+            return EditContext.knownElements.contains(standardName)
         }
     }
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -1590,6 +1590,10 @@ extension Libxml2 {
                 return true
             }
 
+            guard elementNode.isSupportedByAztec() else {
+                return true
+            }
+
             return ElementNode.elementsThatInterruptStyleAtEdges.contains(elementType)
         }
         

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -1602,6 +1602,14 @@ extension Libxml2 {
                 self?.children.insert(child, at: index)
             }
         }
+
+        func isSupportedByAztec() -> Bool {
+            guard let editContext = editContext, let standardName = standardName else {
+                return false
+            }
+
+            return editContext.knownElements.contains(standardName)
+        }
     }
 
 
@@ -1630,6 +1638,12 @@ extension Libxml2 {
 
         init(children: [Node], editContext: EditContext? = nil) {
             super.init(name: type(of: self).name, attributes: [], children: children, editContext: editContext)
+        }
+
+        // MARK: - Overriden Methods
+
+        override func isSupportedByAztec() -> Bool {
+            return true
         }
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -24,6 +24,10 @@ extension Libxml2 {
             }
         }
 
+        // MARK: - Constants
+
+        fileprivate let defaultLengthForUnsupportedElements = 1
+
         // MARK: - Editing behavior configuration
 
         static let elementsThatInterruptStyleAtEdges: [StandardElementType] = [.a, .br, .img, .hr]
@@ -61,6 +65,10 @@ extension Libxml2 {
         /// Node length.  Calculated by adding the length of all child nodes.
         ///
         override func length() -> Int {
+            guard isSupportedByAztec() else {
+                return defaultLengthForUnsupportedElements
+            }
+
             let nsString = text() as NSString
             return nsString.length
         }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -65,7 +65,7 @@ extension Libxml2 {
         /// Node length.  Calculated by adding the length of all child nodes.
         ///
         override func length() -> Int {
-            guard isSupportedByAztec() else {
+            guard isSupportedByEditor() else {
                 return defaultLengthForUnsupportedElements
             }
 
@@ -1599,7 +1599,7 @@ extension Libxml2 {
                 return true
             }
 
-            guard elementNode.isSupportedByAztec() else {
+            guard elementNode.isSupportedByEditor() else {
                 return true
             }
 
@@ -1624,12 +1624,22 @@ extension Libxml2 {
             }
         }
 
-        func isSupportedByAztec() -> Bool {
+        func isSupportedByEditor() -> Bool {
+            /// NOTE:
+            /// ElementNode.length is coupled to the value of this method. Elements not known by the Editor are
+            /// represented by a single character (NSTextAttachment), with a customizable visual representation.
+            /// In Unit Tests, ElementNode will be decoupled from the Editor, and we'll neutralize this
+            /// "Length=1" workaround.
+            ///
+            guard let editContext = editContext else {
+                return true
+            }
+
             guard let standardName = standardName else {
                 return false
             }
 
-            return EditContext.knownElements.contains(standardName)
+            return editContext.knownElements.contains(standardName)
         }
     }
 
@@ -1663,7 +1673,7 @@ extension Libxml2 {
 
         // MARK: - Overriden Methods
 
-        override func isSupportedByAztec() -> Bool {
+        override func isSupportedByEditor() -> Bool {
             return true
         }
     }

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -480,13 +480,13 @@ extension Libxml2 {
         ///   - range: the range to insert the HTML
         ///   - rawHTML: String representing a raw HTML Snippet, to be converted into Nodes.
         ///
-        func replace(_ range: NSRange, rawHTML: String) {
+        func replace(_ range: NSRange, withRawHTML rawHTML: String) {
             performAsyncUndoable { [weak self] in
-                self?.replaceSynchronously(range, rawHTML: rawHTML)
+                self?.replaceSynchronously(range, withRawHTML: rawHTML)
             }
         }
 
-        private func replaceSynchronously(_ range: NSRange, rawHTML: String) {
+        private func replaceSynchronously(_ range: NSRange, withRawHTML rawHTML: String) {
             do {
                 let htmlToNode = Libxml2.In.HTMLConverter(editContext: editContext)
                 let parsedRootNode = try htmlToNode.convert(rawHTML)
@@ -547,13 +547,13 @@ extension Libxml2 {
         ///     - range: the range to apply the style to.
         ///     - comment: the comment to be stored.
         ///
-        func replace(_ range: NSRange, comment: String) {
+        func replace(_ range: NSRange, withComment comment: String) {
             performAsyncUndoable { [weak self] in
-                self?.replaceSynchronously(range, comment: comment)
+                self?.replaceSynchronously(range, withComment: comment)
             }
         }
 
-        private func replaceSynchronously(_ range: NSRange, comment: String) {
+        private func replaceSynchronously(_ range: NSRange, withComment comment: String) {
             let descriptor = CommentNodeDescriptor(comment: comment)
 
             rootNode.replaceCharacters(in: range, with: descriptor)

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -517,13 +517,13 @@ extension Libxml2 {
         ///     - range: the range to apply the style to.
         ///     - comment: the comment to be stored.
         ///
-        func replace(_ range: NSRange, with comment: String) {
+        func replace(_ range: NSRange, comment: String) {
             performAsyncUndoable { [weak self] in
-                self?.replaceSynchronously(range, with: comment)
+                self?.replaceSynchronously(range, comment: comment)
             }
         }
 
-        private func replaceSynchronously(_ range: NSRange, with comment: String) {
+        private func replaceSynchronously(_ range: NSRange, comment: String) {
             let descriptor = CommentNodeDescriptor(comment: comment)
 
             rootNode.replaceCharacters(in: range, with: descriptor)

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -471,6 +471,36 @@ extension Libxml2 {
             }
         }
 
+
+        // MARK: - Raw HTML
+
+        /// Replaces the specified range with a given Raw HTML String.
+        ///
+        /// - Parameters:
+        ///   - range: the range to insert the HTML
+        ///   - rawHTML: String representing a raw HTML Snippet, to be converted into Nodes.
+        ///
+        func replace(_ range: NSRange, rawHTML: String) {
+            performAsyncUndoable { [weak self] in
+                self?.replaceSynchronously(range, rawHTML: rawHTML)
+            }
+        }
+
+        private func replaceSynchronously(_ range: NSRange, rawHTML: String) {
+            do {
+                let htmlToNode = Libxml2.In.HTMLConverter(editContext: editContext)
+                let parsedRootNode = try htmlToNode.convert(rawHTML)
+
+                guard let firstChild = parsedRootNode.children.first else {
+                    return
+                }
+                rootNode.replaceCharacters(in: range, with: firstChild)
+            } catch {
+                fatalError("Could not replace range with raw HTML: \(rawHTML).")
+            }
+        }
+
+
         // MARK: - Images
 
         /// Replaces the specified range with a given image.

--- a/Aztec/Classes/Libxml2/EditContext.swift
+++ b/Aztec/Classes/Libxml2/EditContext.swift
@@ -16,7 +16,7 @@ extension Libxml2 {
             self.undoManager = undoManager
         }
 
-        static let knownElements: [StandardElementType] = [
+        let knownElements: [StandardElementType] = [
             .a,
             .b,
             .br,

--- a/Aztec/Classes/Libxml2/EditContext.swift
+++ b/Aztec/Classes/Libxml2/EditContext.swift
@@ -16,11 +16,12 @@ extension Libxml2 {
             self.undoManager = undoManager
         }
 
-        let knownElements: [StandardElementType] = [
+        static let knownElements: [StandardElementType] = [
             .a,
             .b,
             .br,
             .blockquote,
+            .div,
             .em,
             .h1,
             .h2,

--- a/Aztec/Classes/Libxml2/EditContext.swift
+++ b/Aztec/Classes/Libxml2/EditContext.swift
@@ -15,5 +15,32 @@ extension Libxml2 {
         init(undoManager: UndoManager) {
             self.undoManager = undoManager
         }
+
+        let knownElements: [StandardElementType] = [
+            .a,
+            .b,
+            .br,
+            .blockquote,
+            .em,
+            .h1,
+            .h2,
+            .h3,
+            .h4,
+            .h5,
+            .h6,
+            .hr,
+            .i,
+            .img,
+            .li,
+            .ol,
+            .p,
+            .pre,
+            .s,
+            .span,
+            .strike,
+            .strong,
+            .u,
+            .ul
+        ]
     }
 }

--- a/Aztec/Classes/TextKit/CommentAttachment.swift
+++ b/Aztec/Classes/TextKit/CommentAttachment.swift
@@ -2,32 +2,6 @@ import Foundation
 import UIKit
 
 
-/// Comment Attachment's Delegate Helpers
-///
-protocol CommentAttachmentDelegate: class {
-
-    /// Returns the Bounds that should be used to render the current attachment.
-    ///
-    /// - Parameters:
-    ///     - commentAttachment: The Comment to be rendered
-    ///     - fragment: Current Line Fragment Bounds
-    ///
-    /// - Returns: CGRect specifiying the Attachment Bounds.
-    ///
-    func commentAttachment(_ commentAttachment: CommentAttachment, boundsForLineFragment fragment: CGRect) -> CGRect
-
-    /// Returns the Image Representation for a given attachment.
-    ///
-    /// - Parameters:
-    ///     - commentAttachment: The Comment to be rendered
-    ///     - size: The Canvas Size
-    ///
-    /// - Returns: Optional UIImage instance, representing a given comment.
-    ///
-    func commentAttachment(_ commentAttachment: CommentAttachment, imageForSize size: CGSize) -> UIImage?
-}
-
-
 /// Comment Attachments: Represents an HTML Comment
 ///
 open class CommentAttachment: NSTextAttachment {
@@ -38,7 +12,7 @@ open class CommentAttachment: NSTextAttachment {
 
     /// Delegate
     ///
-    weak var delegate: CommentAttachmentDelegate?
+    weak var delegate: RenderableAttachmentDelegate?
 
     /// A message to display overlaid on top of the image
     ///
@@ -56,13 +30,13 @@ open class CommentAttachment: NSTextAttachment {
             return cachedImage
         }
 
-        glyphImage = delegate?.commentAttachment(self, imageForSize: imageBounds.size)
+        glyphImage = delegate?.attachment(self, imageForSize: imageBounds.size)
 
         return glyphImage
     }
 
     override open func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
-        guard let bounds = delegate?.commentAttachment(self, boundsForLineFragment: lineFrag) else {
+        guard let bounds = delegate?.attachment(self, boundsForLineFragment: lineFrag) else {
             assertionFailure("Could not determine Comment Attachment Size")
             return .zero
         }

--- a/Aztec/Classes/TextKit/HTMLAttachment.swift
+++ b/Aztec/Classes/TextKit/HTMLAttachment.swift
@@ -1,0 +1,54 @@
+import Foundation
+import UIKit
+
+
+/// HTML Attachments: Represents unknown HTML
+///
+open class HTMLAttachment: NSTextAttachment {
+
+    /// Internal Cached Image
+    ///
+    fileprivate var glyphImage: UIImage?
+
+    /// Delegate
+    ///
+    weak var delegate: RenderableAttachmentDelegate?
+
+    /// Name of the Root "Unknown" Tag
+    ///
+    open var rootTagName: String = "" {
+        didSet {
+            glyphImage = nil
+        }
+    }
+
+    /// Raw Unknown HTML to be rendered
+    ///
+    open var rawHTML: String = "" {
+        didSet {
+            glyphImage = nil
+        }
+    }
+
+
+    // MARK: - NSTextAttachmentContainer
+
+    override open func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
+        if let cachedImage = glyphImage, imageBounds.size.equalTo(cachedImage.size) {
+            return cachedImage
+        }
+
+        glyphImage = delegate?.attachment(self, imageForSize: imageBounds.size)
+
+        return glyphImage
+    }
+
+    override open func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+        guard let bounds = delegate?.attachment(self, boundsForLineFragment: lineFrag) else {
+            assertionFailure("Could not determine HTML Attachment Size")
+            return .zero
+        }
+
+        return bounds
+    }
+}

--- a/Aztec/Classes/TextKit/HTMLAttachment.swift
+++ b/Aztec/Classes/TextKit/HTMLAttachment.swift
@@ -31,6 +31,37 @@ open class HTMLAttachment: NSTextAttachment {
     }
 
 
+    // MARK: - Initializers
+
+    init() {
+        super.init(data: nil, ofType: nil)
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(data: nil, ofType: nil)
+
+        guard let rootTagName = aDecoder.decodeObject(forKey: Keys.rootTagName) as? String,
+            let rawHTML = aDecoder.decodeObject(forKey: Keys.rawHTML) as? String
+            else {
+                return
+        }
+
+        self.rootTagName = rootTagName
+        self.rawHTML = rawHTML
+    }
+
+
+    // MARK: - NSCoder Methods
+
+    open override func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+
+        aCoder.encode(rootTagName, forKey: Keys.rootTagName)
+        aCoder.encode(rawHTML, forKey: Keys.rawHTML)
+    }
+
+
+
     // MARK: - NSTextAttachmentContainer
 
     override open func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
@@ -50,5 +81,16 @@ open class HTMLAttachment: NSTextAttachment {
         }
 
         return bounds
+    }
+}
+
+
+// MARK: - Private Helpers
+//
+private extension HTMLAttachment {
+
+    struct Keys {
+        static let rootTagName  = "rootTagName"
+        static let rawHTML      = "rawHTML"
     }
 }

--- a/Aztec/Classes/TextKit/LineAttachment.swift
+++ b/Aztec/Classes/TextKit/LineAttachment.swift
@@ -1,15 +1,16 @@
 import Foundation
 import UIKit
 
+
 /// Custom horizontal line drawing attachment.
 ///
-open class LineAttachment: NSTextAttachment
-{
+open class LineAttachment: NSTextAttachment {
+
     fileprivate var glyphImage: UIImage?
 
     /// The color to use when drawing progress indicators
     ///
-    open var color: UIColor = UIColor.gray
+    open var color = UIColor.gray
 
     // MARK: - NSTextAttachmentContainer
 

--- a/Aztec/Classes/TextKit/RenderableAttachmentDelegate.swift
+++ b/Aztec/Classes/TextKit/RenderableAttachmentDelegate.swift
@@ -1,0 +1,28 @@
+import Foundation
+import UIKit
+
+
+/// NSTextAttachment Renderable Delegate Helpers
+///
+protocol RenderableAttachmentDelegate: class {
+
+    /// Returns the Bounds that should be used to render a given attachment
+    ///
+    /// - Parameters:
+    ///     - attachment: Attachment to be rendered
+    ///     - fragment: Current Line Fragment Bounds
+    ///
+    /// - Returns: CGRect specifiying the Attachment Bounds.
+    ///
+    func attachment(_ attachment: NSTextAttachment, boundsForLineFragment fragment: CGRect) -> CGRect
+
+    /// Returns the Image Representation for a given attachment.
+    ///
+    /// - Parameters:
+    ///     - attachment: Attachment to be rendered
+    ///     - size: The Canvas Size
+    ///
+    /// - Returns: Optional UIImage instance, representing a given comment.
+    ///
+    func attachment(_ attachment: NSTextAttachment, imageForSize size: CGSize) -> UIImage?
+}

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -494,7 +494,7 @@ open class TextStorage: NSTextStorage {
             return
         }
 
-        dom.replace(range, comment: newAttachment.text)
+        dom.replace(range, withComment: newAttachment.text)
     }
 
     private func processHtmlAttachmentDifferences(in range: NSRange, betweenOriginal original: HTMLAttachment?, andNew new: HTMLAttachment?) {
@@ -502,7 +502,7 @@ open class TextStorage: NSTextStorage {
             return
         }
 
-        dom.replace(range, rawHTML: html)
+        dom.replace(range, withRawHTML: html)
     }
 
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -895,6 +895,9 @@ open class TextStorage: NSTextStorage {
         textStore.enumerateAttachmentsOfType(CommentAttachment.self) { [weak self] (attachment, _, _) in
             attachment.delegate = self
         }
+        textStore.enumerateAttachmentsOfType(HTMLAttachment.self) { [weak self] (attachment, _, _) in
+            attachment.delegate = self
+        }
 
         edited([.editedAttributes, .editedCharacters], range: NSRange(location: 0, length: originalLength), changeInLength: textStore.length - originalLength)
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -498,7 +498,7 @@ open class TextStorage: NSTextStorage {
     }
 
     private func processHtmlAttachmentDifferences(in range: NSRange, betweenOriginal original: HTMLAttachment?, andNew new: HTMLAttachment?) {
-        guard let html = original?.rawHTML ?? new?.rawHTML else {
+        guard let html = new?.rawHTML, original?.rawHTML != new?.rawHTML else {
             return
         }
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -498,8 +498,11 @@ open class TextStorage: NSTextStorage {
     }
 
     private func processHtmlAttachmentDifferences(in range: NSRange, betweenOriginal original: HTMLAttachment?, andNew new: HTMLAttachment?) {
-        // TODO:
-        // Support DOM Insertion
+        guard let html = original?.rawHTML ?? new?.rawHTML else {
+            return
+        }
+
+        dom.replace(range, rawHTML: html)
     }
 
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -54,7 +54,7 @@ protocol TextStorageAttachmentsDelegate {
     ///
     /// - Returns: Rect specifying the Bounds for the comment attachment
     ///
-    func storage(_ storage: TextStorage, boundsForComment attachment: CommentAttachment, with lineFragment: CGRect) -> CGRect
+    func storage(_ storage: TextStorage, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect
 
     /// Provides the (Optional) Image Representation of the specified size, for a given Attachment.
     ///
@@ -65,7 +65,7 @@ protocol TextStorageAttachmentsDelegate {
     ///
     /// - Returns: (Optional) UIImage representation of the Comment Attachment.
     ///
-    func storage(_ storage: TextStorage, imageForComment attachment: CommentAttachment, with size: CGSize) -> UIImage?
+    func storage(_ storage: TextStorage, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage?
 }
 
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -900,15 +900,15 @@ extension TextStorage: TextAttachmentDelegate {
 
 // MARK: - TextStorage: CommentAttachmentDelegate Methods
 //
-extension TextStorage: CommentAttachmentDelegate {
+extension TextStorage: RenderableAttachmentDelegate {
 
-    func commentAttachment(_ commentAttachment: CommentAttachment, imageForSize size: CGSize) -> UIImage? {
+    func attachment(_ attachment: NSTextAttachment, imageForSize size: CGSize) -> UIImage? {
         assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, imageForComment: commentAttachment, with: size)
+        return attachmentsDelegate.storage(self, imageFor: attachment, with: size)
     }
 
-    func commentAttachment(_ commentAttachment: CommentAttachment, boundsForLineFragment fragment: CGRect) -> CGRect {
+    func attachment(_ attachment: NSTextAttachment, boundsForLineFragment fragment: CGRect) -> CGRect {
         assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, boundsForComment: commentAttachment, with: fragment)
+        return attachmentsDelegate.storage(self, boundsFor: attachment, with: fragment)
     }
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -130,9 +130,9 @@ open class TextView: UITextView {
     ///
     open weak var mediaDelegate: TextViewMediaDelegate?
 
-    // MARK: - Properties: Comment Attachments
-
-    open weak var commentsDelegate: TextViewCommentsDelegate?
+    /// Maintains a reference to the user provided Text Attachment Renderers
+    ///
+    fileprivate var textAttachmentRenderers = [TextViewAttachmentRenderer]()
 
     // MARK: - Properties: Formatting
 
@@ -370,6 +370,12 @@ open class TextView: UITextView {
         formattingDelegate?.textViewCommandToggledAStyle()
     }
 
+
+    // MARK: - Attachment Helpers
+
+    open func registerAttachmentRenderer(_ renderer: TextViewAttachmentRenderer) {
+        textAttachmentRenderers.append(renderer)
+    }
 
     // MARK: - Getting format identifiers
 
@@ -1114,20 +1120,20 @@ extension TextView: TextStorageAttachmentsDelegate {
         mediaDelegate?.textView(self, deletedAttachmentWithID: attachmentID)
     }
 
-    func storage(_ storage: TextStorage, imageForComment attachment: CommentAttachment, with size: CGSize) -> UIImage? {
-        guard let commentsDelegate = commentsDelegate else {
-            fatalError("This class requires a comments delegate to be set.")
+    func storage(_ storage: TextStorage, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+        let renderer = textAttachmentRenderers.first { renderer in
+            return renderer.textView(self, shouldRender: attachment)
         }
 
-        return commentsDelegate.textView(self, imageForComment: attachment, with: size)
+        return renderer?.textView(self, imageFor: attachment, with: size)
     }
 
-    func storage(_ storage: TextStorage, boundsForComment attachment: CommentAttachment, with lineFragment: CGRect) -> CGRect {
-        guard let commentsDelegate = commentsDelegate else {
-            fatalError("This class requires a comments delegate to be set.")
+    func storage(_ storage: TextStorage, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+        let renderer = textAttachmentRenderers.first { renderer in
+            return renderer.textView(self, shouldRender: attachment)
         }
 
-        return commentsDelegate.textView(self, boundsForComment: attachment, with: lineFragment)
+        return renderer?.textView(self, boundsFor: attachment, with: lineFragment) ?? .zero
     }
 }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -66,31 +66,41 @@ public protocol TextViewMediaDelegate: class {
 }
 
 
-// MARK: - TextViewCommentsDelegate
+// MARK: - TextAttachmentRenderer
 //
-public protocol TextViewCommentsDelegate: class {
+public protocol TextViewAttachmentRenderer: class {
+
+    /// Indicates whether the current Attachment Renderer supports a given NSTextAttachment instance, or not.
+    ///
+    /// - Parameters:
+    ///     - textView: The textView that is requesting the bounds.
+    ///     - attachment: Attachment about to be rendered.
+    ///
+    /// - Returns: True when supported, false otherwise.
+    ///
+    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool
 
     /// Provides the Bounds required to represent a given attachment, within a specified line fragment.
     ///
     /// - Parameters:
     ///     - textView: The textView that is requesting the bounds.
-    ///     - attachment: CommentAttachment about to be rendered.
+    ///     - attachment: Attachment about to be rendered.
     ///     - lineFragment: Line Fragment in which the glyph would be rendered.
     ///
     /// - Returns: Rect specifying the Bounds for the comment attachment
     ///
-    func textView(_ textView: TextView, boundsForComment attachment: CommentAttachment, with lineFragment: CGRect) -> CGRect
+    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect
 
     /// Provides the (Optional) Image Representation of the specified size, for a given Attachment.
     ///
     /// - Parameters:
     ///     - textView: The textView that is requesting the bounds.
-    ///     - attachment: CommentAttachment about to be rendered.
+    ///     - attachment: Attachment about to be rendered.
     ///     - size: Expected Image Size
     ///
     /// - Returns: (Optional) UIImage representation of the Comment Attachment.
     ///
-    func textView(_ textView: TextView, imageForComment attachment: CommentAttachment, with size: CGSize) -> UIImage?
+    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage?
 }
 
 

--- a/AztecTests/HTML/DOMStringTests.swift
+++ b/AztecTests/HTML/DOMStringTests.swift
@@ -18,7 +18,7 @@ class DOMStringTests: XCTestCase {
     /// Output:
     ///     - Make sure the HTML is updated accordingly at each step.
     ///
-    func testReplaceCharacters() {
+    func testReplaceCharactersWithStringEffectivelyInsertsTheNewString() {
         let string = DOMString()
 
         string.replaceCharacters(inRange: NSRange.zero, withString: "Hello\n", preferLeftNode: true)
@@ -26,5 +26,25 @@ class DOMStringTests: XCTestCase {
 
         string.replaceCharacters(inRange: NSRange(location: 6, length: 0), withString: "World!", preferLeftNode: false)
         XCTAssertEqual(string.getHTML(), "Hello<br>World!")
+    }
+
+
+    /// This test ensures that replace with rawHTML generates the expected HTML.
+    ///
+    /// Input:
+    ///     - Insert "<unknown>plain</unknown>"
+    ///     - Insert "<b>prepended</b>"
+    ///
+    /// Output:
+    ///     - Verify the Updated HTML at each step.
+    ///
+    func testReplaceWithRawHtmlCreatesNewInternalNodes() {
+        let string = DOMString()
+
+        string.replace(NSRange.zero, rawHTML: "<unknown>plain</unknown>")
+        XCTAssertEqual(string.getHTML(), "<unknown>plain</unknown>")
+
+        string.replace(NSRange.zero, rawHTML: "<b>prepended</b>")
+        XCTAssertEqual(string.getHTML(), "<unknown><b>prepended</b>plain</unknown>")
     }
 }

--- a/AztecTests/HTML/DOMStringTests.swift
+++ b/AztecTests/HTML/DOMStringTests.swift
@@ -41,10 +41,10 @@ class DOMStringTests: XCTestCase {
     func testReplaceWithRawHtmlCreatesNewInternalNodes() {
         let string = DOMString()
 
-        string.replace(NSRange.zero, rawHTML: "<unknown>plain</unknown>")
+        string.replace(NSRange.zero, withRawHTML: "<unknown>plain</unknown>")
         XCTAssertEqual(string.getHTML(), "<unknown>plain</unknown>")
 
-        string.replace(NSRange.zero, rawHTML: "<b>prepended</b>")
+        string.replace(NSRange.zero, withRawHTML: "<b>prepended</b>")
         XCTAssertEqual(string.getHTML(), "<unknown><b>prepended</b>plain</unknown>")
     }
 }

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -1237,7 +1237,7 @@ class ElementNodeTests: XCTestCase {
     /// Expected results:
     /// - Output: `<p>Look at this photo:<img src="https://httpbin.org/image/jpeg.It's amazing" /></p>`
     ///
-    func testReplaceCharactersInRangeWithNode() {
+    func testReplaceCharactersInRangeWithNodeDescriptor() {
         let startText = "Look at this photo:"
         let middleText = "image"
         let endText = ".It's amazing"
@@ -1274,7 +1274,54 @@ class ElementNodeTests: XCTestCase {
                 return
         }
     }
-    
+
+    /// Tests `replaceCharacters(inRange:withNode)`.
+    ///
+    /// Input HTML: `<p>Look at this photo:image.It's amazing</p>`
+    /// - Range: the range of the image string.
+    /// - New Node: <img>
+    /// - Attributes:
+    ///
+    /// Expected results:
+    /// - Output: `<p>Look at this photo:<img src="https://httpbin.org/image/jpeg.It's amazing" /></p>`
+    ///
+    func testReplaceCharactersInRangeWithNode() {
+        let startText = "Look at this photo:"
+        let middleText = "image"
+        let endText = ".It's amazing"
+        let paragraphText = TextNode(text: startText + middleText + endText)
+        let paragraph = ElementNode(name: "p", attributes: [], children: [paragraphText])
+
+        let range = NSRange(location: startText.characters.count, length: middleText.characters.count)
+        let imgSrc = "https://httpbin.org/image/jpeg"
+
+        let attributes = [Libxml2.StringAttribute(name: "src", value: imgSrc)]
+        let descriptor = ElementNodeDescriptor(elementType: .img, attributes: attributes)
+        let node = ElementNode(descriptor: descriptor)
+
+        paragraph.replaceCharacters(in: range, with: node)
+
+        XCTAssertEqual(paragraph.children.count, 3)
+
+        guard let startNode = paragraph.children[0] as? TextNode, startNode.text() == startText else {
+
+            XCTFail("Expected a text node")
+            return
+        }
+
+        guard let imgNode = paragraph.children[1] as? ElementNode, imgNode.name == node.name else {
+
+            XCTFail("Expected a img node")
+            return
+        }
+
+        guard let endNode = paragraph.children[2] as? TextNode, endNode.text() == endText else {
+
+            XCTFail("Expected a text node")
+            return
+        }
+    }
+
     // MARK: - pushUp(rightSideDescendantEvaluatedBy:)
     
     

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -413,7 +413,7 @@ class ElementNodeTests: XCTestCase {
     func testSplitWithFullRange() {
 
         let textNode = TextNode(text: "Some text goes here")
-        let elemNode = ElementNode(name: "SomeNode", attributes: [], children: [textNode])
+        let elemNode = ElementNode(name: "div", attributes: [], children: [textNode])
         let rootNode = RootNode(children: [elemNode])
 
         let splitRange = NSRange(location: 0, length: textNode.length())
@@ -429,7 +429,7 @@ class ElementNodeTests: XCTestCase {
 
     func testSplitWithPartialRange1() {
 
-        let elemNodeName = "SomeNode"
+        let elemNodeName = "div"
         let textPart1 = "Some"
         let textPart2 = " text goes here"
         let fullText = "\(textPart1)\(textPart2)"
@@ -476,7 +476,7 @@ class ElementNodeTests: XCTestCase {
 
     func testSplitWithPartialRange2() {
 
-        let elemNodeName = "SomeNode"
+        let elemNodeName = "div"
         let textPart1 = "Some"
         let textPart2 = " text goes here"
         let fullText = "\(textPart1)\(textPart2)"
@@ -524,7 +524,7 @@ class ElementNodeTests: XCTestCase {
 
     func testSplitWithPartialRange3() {
 
-        let elemNodeName = "SomeNode"
+        let elemNodeName = "div"
         let textPart1 = "Some"
         let textPart2 = " text goes "
         let textPart3 = "here"

--- a/AztecTests/HTML/ElementNodeTests.swift
+++ b/AztecTests/HTML/ElementNodeTests.swift
@@ -413,7 +413,7 @@ class ElementNodeTests: XCTestCase {
     func testSplitWithFullRange() {
 
         let textNode = TextNode(text: "Some text goes here")
-        let elemNode = ElementNode(name: "div", attributes: [], children: [textNode])
+        let elemNode = ElementNode(name: "SomeNode", attributes: [], children: [textNode])
         let rootNode = RootNode(children: [elemNode])
 
         let splitRange = NSRange(location: 0, length: textNode.length())
@@ -429,7 +429,7 @@ class ElementNodeTests: XCTestCase {
 
     func testSplitWithPartialRange1() {
 
-        let elemNodeName = "div"
+        let elemNodeName = "SomeNode"
         let textPart1 = "Some"
         let textPart2 = " text goes here"
         let fullText = "\(textPart1)\(textPart2)"
@@ -476,7 +476,7 @@ class ElementNodeTests: XCTestCase {
 
     func testSplitWithPartialRange2() {
 
-        let elemNodeName = "div"
+        let elemNodeName = "SomeNode"
         let textPart1 = "Some"
         let textPart2 = " text goes here"
         let fullText = "\(textPart1)\(textPart2)"

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -118,11 +118,11 @@ class TextStorageTests: XCTestCase
             return UIImage()
         }
 
-        func storage(_ storage: TextStorage, boundsForComment attachment: CommentAttachment, with lineFragment: CGRect) -> CGRect {
+        func storage(_ storage: TextStorage, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
             return .zero
         }
 
-        func storage(_ storage: TextStorage, imageForComment attachment: CommentAttachment, with size: CGSize) -> UIImage? {
+        func storage(_ storage: TextStorage, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
             return UIImage()
         }
     }

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		B570B1C91E82D332008CF41E /* MoreAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570B1C81E82D332008CF41E /* MoreAttachmentRenderer.swift */; };
 		B570B1CC1E82D343008CF41E /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */; };
+		B5AF89341E93ECE60051EFDB /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */; };
 		E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */; };
 		FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
@@ -97,6 +98,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B570B1C81E82D332008CF41E /* MoreAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
+		B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
 		E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorDemoController.swift; sourceTree = "<group>"; };
 		FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsTableView.swift; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 			children = (
 				B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */,
 				B570B1C81E82D332008CF41E /* MoreAttachmentRenderer.swift */,
+				B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */,
 			);
 			name = Renders;
 			sourceTree = "<group>";
@@ -367,6 +370,7 @@
 				59D2873B1D8C599B00B99C80 /* AttachmentDetailsViewController.swift in Sources */,
 				FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */,
 				B570B1CC1E82D343008CF41E /* CommentAttachmentRenderer.swift in Sources */,
+				B5AF89341E93ECE60051EFDB /* HTMLAttachmentRenderer.swift in Sources */,
 				E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				B570B1C91E82D332008CF41E /* MoreAttachmentRenderer.swift in Sources */,

--- a/Example/Example/CommentAttachmentRenderer.swift
+++ b/Example/Example/CommentAttachmentRenderer.swift
@@ -30,7 +30,7 @@ final class CommentAttachmentRenderer {
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension CommentAttachmentRenderer: TextViewAttachmentRenderer {
+extension CommentAttachmentRenderer: TextViewAttachmentImageProvider {
 
     func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         return attachment is CommentAttachment

--- a/Example/Example/CommentAttachmentRenderer.swift
+++ b/Example/Example/CommentAttachmentRenderer.swift
@@ -3,6 +3,8 @@ import UIKit
 import Aztec
 
 
+// MARK: - CommentAttachmentRenderer: Renders HTML Comments!
+//
 final class CommentAttachmentRenderer {
 
     /// Comment Attachment Text
@@ -20,7 +22,7 @@ final class CommentAttachmentRenderer {
 
     /// Default Initializer
     ///
-    init?(font: UIFont) {
+    init(font: UIFont) {
         self.textFont = font
     }
 }
@@ -28,9 +30,13 @@ final class CommentAttachmentRenderer {
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension CommentAttachmentRenderer: TextViewCommentsDelegate {
+extension CommentAttachmentRenderer: TextViewAttachmentRenderer {
 
-    func textView(_ textView: TextView, imageForComment attachment: CommentAttachment, with size: CGSize) -> UIImage? {
+    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+        return attachment is CommentAttachment
+    }
+
+    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
         let message = messageAttributedString()
@@ -44,7 +50,7 @@ extension CommentAttachmentRenderer: TextViewCommentsDelegate {
         return result
     }
 
-    func textView(_ textView: TextView, boundsForComment attachment: CommentAttachment, with lineFragment: CGRect) -> CGRect {
+    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
         let message = messageAttributedString()
 
         let size = CGSize(width: lineFragment.size.width, height: lineFragment.size.height)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -7,7 +7,6 @@ import MobileCoreServices
 
 class EditorDemoController: UIViewController {
 
-
     fileprivate var mediaErrorMode = false
 
     fileprivate(set) lazy var richTextView: Aztec.TextView = {
@@ -21,7 +20,6 @@ class EditorDemoController: UIViewController {
         textView.delegate = self
         textView.formattingDelegate = self
         textView.mediaDelegate = self
-        textView.commentsDelegate = self
 
         return textView
     }()
@@ -117,7 +115,7 @@ class EditorDemoController: UIViewController {
         edgesForExtendedLayout = UIRectEdge()
         navigationController?.navigationBar.isTranslucent = false
 
-        view.backgroundColor = UIColor.white
+        view.backgroundColor = .white
         view.addSubview(titleTextField)
         view.addSubview(titlePlaceholderLabel)
         view.addSubview(separatorView)
@@ -125,6 +123,7 @@ class EditorDemoController: UIViewController {
         view.addSubview(htmlTextView)
 
         configureConstraints()
+        registerAttachmentRenderers()
 
         let html: String
 
@@ -232,6 +231,17 @@ class EditorDemoController: UIViewController {
         textView.keyboardDismissMode = .interactive
         textView.textColor = UIColor.darkText
         textView.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private func registerAttachmentRenderers() {
+        let renderers: [TextViewAttachmentRenderer] = [
+            MoreAttachmentRenderer(),
+            CommentAttachmentRenderer(font: Constants.defaultContentFont)
+        ]
+
+        for renderer in renderers {
+            richTextView.registerAttachmentRenderer(renderer)
+        }
     }
 
 
@@ -700,34 +710,6 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         ]
     }
 
-}
-
-
-extension EditorDemoController: TextViewCommentsDelegate {
-
-    func textView(_ textView: TextView, imageForComment attachment: CommentAttachment, with size: CGSize) -> UIImage? {
-        if let render = MoreAttachmentRenderer(attachment: attachment) {
-            return render.textView(textView, imageForComment: attachment, with: size)
-        }
-
-        if let render = CommentAttachmentRenderer(font: Constants.defaultContentFont) {
-            return render.textView(textView, imageForComment: attachment, with: size)
-        }
-
-        return nil
-    }
-
-    func textView(_ textView: TextView, boundsForComment attachment: CommentAttachment, with lineFragment: CGRect) -> CGRect {
-        if let render = MoreAttachmentRenderer(attachment: attachment) {
-            return render.textView(textView, boundsForComment: attachment, with: lineFragment)
-        }
-
-        if let render = CommentAttachmentRenderer(font: Constants.defaultContentFont) {
-            return render.textView(textView, boundsForComment: attachment, with: lineFragment)
-        }
-
-        return .zero
-    }
 }
 
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -236,7 +236,8 @@ class EditorDemoController: UIViewController {
     private func registerAttachmentRenderers() {
         let renderers: [TextViewAttachmentRenderer] = [
             MoreAttachmentRenderer(),
-            CommentAttachmentRenderer(font: Constants.defaultContentFont)
+            CommentAttachmentRenderer(font: Constants.defaultContentFont),
+            HTMLAttachmentRenderer(font: Constants.defaultContentFont)
         ]
 
         for renderer in renderers {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -123,7 +123,7 @@ class EditorDemoController: UIViewController {
         view.addSubview(htmlTextView)
 
         configureConstraints()
-        registerAttachmentRenderers()
+        registerAttachmentImageProviders()
 
         let html: String
 
@@ -233,15 +233,15 @@ class EditorDemoController: UIViewController {
         textView.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    private func registerAttachmentRenderers() {
-        let renderers: [TextViewAttachmentRenderer] = [
+    private func registerAttachmentImageProviders() {
+        let providers: [TextViewAttachmentImageProvider] = [
             MoreAttachmentRenderer(),
             CommentAttachmentRenderer(font: Constants.defaultContentFont),
             HTMLAttachmentRenderer(font: Constants.defaultContentFont)
         ]
 
-        for renderer in renderers {
-            richTextView.registerAttachmentRenderer(renderer)
+        for provider in providers {
+            richTextView.registerAttachmentImageProvider(provider)
         }
     }
 

--- a/Example/Example/HTMLAttachmentRenderer.swift
+++ b/Example/Example/HTMLAttachmentRenderer.swift
@@ -30,7 +30,7 @@ final class HTMLAttachmentRenderer {
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension HTMLAttachmentRenderer: TextViewAttachmentRenderer {
+extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
 
     func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         return attachment is HTMLAttachment

--- a/Example/Example/HTMLAttachmentRenderer.swift
+++ b/Example/Example/HTMLAttachmentRenderer.swift
@@ -9,7 +9,7 @@ final class HTMLAttachmentRenderer {
 
     /// Comment Attachment Text
     ///
-    let defaultText = NSLocalizedString("[HTML]", comment: "HTML Attachment Label")
+    let defaultText = NSLocalizedString("HTML", comment: "HTML Attachment Label")
 
     /// Text Color
     ///
@@ -39,7 +39,7 @@ extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
     func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
-        let message = messageAttributedString()
+        let message = messageAttributedString(with: attachment)
         let targetRect = boundingRect(for: message, size: size)
 
         message.draw(in: targetRect)
@@ -51,7 +51,7 @@ extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
     }
 
     func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
-        let message = messageAttributedString()
+        let message = messageAttributedString(with: attachment)
 
         let size = CGSize(width: lineFragment.size.width, height: lineFragment.size.height)
         var rect = boundingRect(for: message, size: size)
@@ -73,12 +73,15 @@ private extension HTMLAttachmentRenderer {
         return CGRect(origin: targetPosition, size: targetBounds.size)
     }
 
-    func messageAttributedString() -> NSAttributedString {
+    func messageAttributedString(with attachment: NSTextAttachment) -> NSAttributedString {
         let attributes: [String: Any] = [
             NSForegroundColorAttributeName: textColor,
             NSFontAttributeName: textFont
         ]
 
-        return NSAttributedString(string: defaultText, attributes: attributes)
+        let htmlAttachment = attachment as? HTMLAttachment
+        let displayText = htmlAttachment?.rootTagName.uppercased() ?? defaultText
+
+        return NSAttributedString(string: "[\(displayText)]", attributes: attributes)
     }
 }

--- a/Example/Example/HTMLAttachmentRenderer.swift
+++ b/Example/Example/HTMLAttachmentRenderer.swift
@@ -1,0 +1,84 @@
+import Foundation
+import UIKit
+import Aztec
+
+
+// MARK: - HTMLAttachmentRenderer: Renders Unknown HTML
+//
+final class HTMLAttachmentRenderer {
+
+    /// Comment Attachment Text
+    ///
+    let defaultText = NSLocalizedString("[HTML]", comment: "HTML Attachment Label")
+
+    /// Text Color
+    ///
+    var textColor = UIColor.gray
+
+    /// Text Font
+    ///
+    var textFont: UIFont
+
+
+    /// Default Initializer
+    ///
+    init(font: UIFont) {
+        self.textFont = font
+    }
+}
+
+
+// MARK: - TextViewCommentsDelegate Methods
+//
+extension HTMLAttachmentRenderer: TextViewAttachmentRenderer {
+
+    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+        return attachment is HTMLAttachment
+    }
+
+    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+
+        let message = messageAttributedString()
+        let targetRect = boundingRect(for: message, size: size)
+
+        message.draw(in: targetRect)
+
+        let result = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return result
+    }
+
+    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+        let message = messageAttributedString()
+
+        let size = CGSize(width: lineFragment.size.width, height: lineFragment.size.height)
+        var rect = boundingRect(for: message, size: size)
+        rect.origin.y = textFont.descender
+
+        return rect.integral
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension HTMLAttachmentRenderer {
+
+    func boundingRect(for message: NSAttributedString, size: CGSize) -> CGRect {
+        let targetBounds = message.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
+        let targetPosition = CGPoint(x: ((size.width - targetBounds.width) * 0.5), y: ((size.height - targetBounds.height) * 0.5))
+
+        return CGRect(origin: targetPosition, size: targetBounds.size)
+    }
+
+    func messageAttributedString() -> NSAttributedString {
+        let attributes: [String: Any] = [
+            NSForegroundColorAttributeName: textColor,
+            NSFontAttributeName: textFont
+        ]
+
+        return NSAttributedString(string: defaultText, attributes: attributes)
+    }
+}

--- a/Example/Example/MoreAttachmentRenderer.swift
+++ b/Example/Example/MoreAttachmentRenderer.swift
@@ -15,7 +15,7 @@ final class MoreAttachmentRenderer {
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension MoreAttachmentRenderer: TextViewAttachmentRenderer {
+extension MoreAttachmentRenderer: TextViewAttachmentImageProvider {
 
     func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         let commentAttachment = attachment as? CommentAttachment

--- a/Example/Example/MoreAttachmentRenderer.swift
+++ b/Example/Example/MoreAttachmentRenderer.swift
@@ -3,37 +3,30 @@ import UIKit
 import Aztec
 
 
-// MARK: - MoreAttachmentRenderer: Renders More Comments!
+// MARK: - MoreAttachmentRenderer: This render is expected to only work with `<!--more-->` comments!
 //
 final class MoreAttachmentRenderer {
-
-    /// Attachment to be rendered
-    ///
-    let attachment: CommentAttachment
 
     /// Text Color
     ///
     var textColor = UIColor.gray
-
-
-    /// Default Initializer: Returns *nil* whenever the Attachment's text is not *more*.
-    /// This render is expected to only work with `<!--more-->` comments!
-    ///
-    init?(attachment: CommentAttachment) {
-        self.attachment = attachment
-
-        guard attachment.text == Constants.defaultCommentText else {
-            return nil
-        }
-    }
 }
 
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension MoreAttachmentRenderer: TextViewCommentsDelegate {
+extension MoreAttachmentRenderer: TextViewAttachmentRenderer {
 
-    func textView(_ textView: TextView, imageForComment attachment: CommentAttachment, with size: CGSize) -> UIImage? {
+    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+        let commentAttachment = attachment as? CommentAttachment
+        return commentAttachment?.text == Constants.defaultCommentText
+    }
+
+    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+        guard let attachment = attachment as? CommentAttachment else {
+            return nil
+        }
+
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
         let label = attachment.text.uppercased()
@@ -66,7 +59,7 @@ extension MoreAttachmentRenderer: TextViewCommentsDelegate {
         return result
     }
 
-    func textView(_ textView: TextView, boundsForComment attachment: CommentAttachment, with lineFragment: CGRect) -> CGRect {
+    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
         let padding = textView.textContainer.lineFragmentPadding
         let width = lineFragment.width - padding * 2
 

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -74,3 +74,15 @@ Image:<br/><br/>
 <p>
 Fanny pack Odd Future Intelligentsia lo-fi semiotics whatever. Selvage keffiyeh mustache sustainable ethnic, chambray mumblecore McSweeney's biodiesel Pitchfork four loko disrupt post-ironic art party American Apparel. Kitsch umami beard salvia, Vice before they sold out vegan tousled lomo jean shorts pickled PBR&amp;B. Tousled Wes Anderson Shoreditch flannel, 90's XOXO quinoa whatever mumblecore cliche Truffaut stumptown. Photo booth crucifix plaid Brooklyn. Authentic letterpress PBR&amp;B, sustainable VHS master cleanse ethnic High Life. Messenger bag umami pug flannel.
 </p>
+
+
+<br/><br/>
+
+<p>
+Unsupported HTML
+
+<table>
+<tr><td></td></tr>
+</table>
+
+</p>


### PR DESCRIPTION
### Details:
This PR implements **Unknown HTML** Support: tags not recognized by Aztec (defined in **EditContext**'s `knownElements` property) will be rendered, in visual mode, as `[HTML]`.

The way "Unknown HTML" attachments get displayed is 100% customizable. We've also revamped the mechanism used to render "Comment Attachments" + "More Attachment". In order to keep the Delegate's fingerprint low, a new protocol was introduced: `TextAttachmentImageProvider`.

Host Application gets to register "Attachment Image Providers", and customize the way attachments will be displayed.

Please, verify the following test scenarios pass, along with the new Unit Tests.

Closes #369 

Thanks in advance!!
Needs Review: @diegoreymendez  @SergioEstevao 
🔥 


### Testing:

#### Scenario: Unsupported HTML
1. Switch to Raw Edition Mode
2. Enter the following snippet:
   `AZTEC <unknown>payload<something>else</something></unknown> LINE`
3. Switch to Visual Edition Mode
4. Verify that the unknown HTML shows up as `[HTML]`
5. Try editing the document. Add text on top / at the bottom
6. Switch to HTML mode
7. Verify everything looks as expected

#### Scenario: Paste
1. Switch to Raw Edition Mode
2. Enter the following snippet:
   `Head <unknown>payload</unknown> Tail`
3. Switch to Visual Mode
4. Select the `[HTML]` text, and copy it
5. Try pasting the `[HTML]` (visual attachment) into any position / range
6. Verify that the raw HTML looks as expected

#### Scenario: Replace
1. Switch to Raw Edition Mode
2. Enter the following snippet:
   `<unknown>payload</unknown> LINE <second>test</second>`
3. Switch to Visual Mode
4. Select the **first** `[HTML]` and copy it
5. Select the **Second** `[HTML]` and paste over it
6. Verify that the raw HTML looks as follows:
   `<unknown>payload</unknown> LINE <unknown>payload</unknown>`
