### PR TITLE
Remove elementType from Formatters.

### DIFF
--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -3,8 +3,6 @@ import UIKit
 
 class BlockquoteFormatter: ParagraphAttributeFormatter {
 
-    let elementType: Libxml2.StandardElementType = .blockquote 
-
     let placeholderAttributes: [String : Any]?
 
     init(placeholderAttributes: [String : Any]? = nil) {

--- a/Aztec/Classes/Formatters/FontFormatter.swift
+++ b/Aztec/Classes/Formatters/FontFormatter.swift
@@ -3,14 +3,10 @@ import UIKit
 
 class FontFormatter: CharacterAttributeFormatter {
 
-    let elementType: Libxml2.StandardElementType
-    
     let traits: UIFontDescriptorSymbolicTraits
 
-    init(elementType: Libxml2.StandardElementType, traits: UIFontDescriptorSymbolicTraits) {
-        self.elementType = elementType
+    init(traits: UIFontDescriptorSymbolicTraits) {
         self.traits = traits
-
     }
 
     func apply(to attributes: [String : Any]) -> [String: Any] {
@@ -49,14 +45,14 @@ class FontFormatter: CharacterAttributeFormatter {
 class BoldFormatter: FontFormatter {
 
     init() {
-        super.init(elementType: .strong, traits: .traitBold)
+        super.init(traits: .traitBold)
     }
 }
 
 class ItalicFormatter: FontFormatter {
 
     init() {
-        super.init(elementType: .em, traits: .traitItalic)
+        super.init(traits: .traitItalic)
     }
 }
 

--- a/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
@@ -4,14 +4,11 @@ import UIKit
 /// Formatter to apply simple value (NSNumber, UIColor) attributes to an attributed string. 
 class StandardAttributeFormatter: CharacterAttributeFormatter {
 
-    let elementType: Libxml2.StandardElementType
-
     let attributeKey: String
 
     var attributeValue: Any
 
-    init(elementType: Libxml2.StandardElementType, attributeKey: String, attributeValue: Any) {
-        self.elementType = elementType
+    init(attributeKey: String, attributeValue: Any) {
         self.attributeKey = attributeKey
         self.attributeValue = attributeValue
     }
@@ -41,38 +38,38 @@ class StandardAttributeFormatter: CharacterAttributeFormatter {
 class UnderlineFormatter: StandardAttributeFormatter {
 
     init() {
-        super.init(elementType: .u, attributeKey: NSUnderlineStyleAttributeName, attributeValue: NSUnderlineStyle.styleSingle.rawValue)
+        super.init(attributeKey: NSUnderlineStyleAttributeName, attributeValue: NSUnderlineStyle.styleSingle.rawValue)
     }
 }
 
 class StrikethroughFormatter: StandardAttributeFormatter {
 
     init() {
-        super.init(elementType: .del, attributeKey: NSStrikethroughStyleAttributeName, attributeValue: NSUnderlineStyle.styleSingle.rawValue)
+        super.init(attributeKey: NSStrikethroughStyleAttributeName, attributeValue: NSUnderlineStyle.styleSingle.rawValue)
     }
 }
 
 class LinkFormatter: StandardAttributeFormatter {
     init() {
-        super.init(elementType: .a, attributeKey: NSLinkAttributeName, attributeValue: NSURL(string:"")!)
+        super.init(attributeKey: NSLinkAttributeName, attributeValue: NSURL(string:"")!)
     }
 }
 
 class ImageFormatter: StandardAttributeFormatter {
     init() {
-        super.init(elementType: .img, attributeKey: NSAttachmentAttributeName, attributeValue: TextAttachment(identifier: NSUUID().uuidString))
+        super.init(attributeKey: NSAttachmentAttributeName, attributeValue: TextAttachment(identifier: NSUUID().uuidString))
     }
 }
 
 class HRFormatter: StandardAttributeFormatter {
     init() {
-        super.init(elementType: .hr, attributeKey: NSAttachmentAttributeName, attributeValue: LineAttachment())
+        super.init(attributeKey: NSAttachmentAttributeName, attributeValue: LineAttachment())
     }
 }
 
 class ColorFormatter: StandardAttributeFormatter {
     init(color: UIColor = .black) {
-        super.init(elementType: .span, attributeKey: NSForegroundColorAttributeName, attributeValue: color)
+        super.init(attributeKey: NSForegroundColorAttributeName, attributeValue: color)
     }
 }
 

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -2,8 +2,7 @@ import Foundation
 import UIKit
 
 class TextListFormatter: ParagraphAttributeFormatter {
-
-    let elementType: Libxml2.StandardElementType = .li
+    
     let listStyle: TextList.Style
     let placeholderAttributes: [String : Any]?
 


### PR DESCRIPTION
This property is no longer needed so we can safely remove it from the code.

How to test:
 - Run unit test and check that everything is working properly.
 - Open the demo app on the mode with content and see if all works ok.