### PR TITLE
CommentAttachment: Fixing Paste

### DIFF
--- a/Aztec/Classes/TextKit/CommentAttachment.swift
+++ b/Aztec/Classes/TextKit/CommentAttachment.swift
@@ -49,6 +49,33 @@ open class CommentAttachment: NSTextAttachment {
     }
 
 
+    // MARK: - Initializers
+
+    init() {
+        super.init(data: nil, ofType: nil)
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(data: nil, ofType: nil)
+
+        guard let text = aDecoder.decodeObject(forKey: Keys.text) as? String else {
+            return
+        }
+
+        self.text = text
+    }
+
+
+    // MARK: - NSCoder Methods
+
+    open override func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+
+        aCoder.encode(text, forKey: Keys.text)
+    }
+
+
+
     // MARK: - NSTextAttachmentContainer
 
     override open func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
@@ -68,5 +95,15 @@ open class CommentAttachment: NSTextAttachment {
         }
 
         return bounds
+    }
+}
+
+
+// MARK: - Private Helpers
+//
+private extension CommentAttachment {
+
+    struct Keys {
+        static let text = "text"
     }
 }


### PR DESCRIPTION
### Testing:
1. Insert a comment: `<!--comment 1234-->`
2. Switch to graphic mode
3. Copy + paste the comment

Verify that the HTML looks a expected.

Closes #406
Needs Review: @diegoreymendez 
Thanks in advance!