### PR TITLE
Conversion of Range<String.Index> to NSRange.

### DIFF
--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -4,25 +4,53 @@ import Foundation
 // MARK: - String NSRange and Location convertion Extensions
 //
 extension String
-{    
-    func rangeFromNSRange(_ nsRange : NSRange) -> Range<String.Index>? {
-        let from16 = utf16.index(utf16.startIndex, offsetBy: nsRange.location)
-        let to16 = utf16.index(from16, offsetBy: nsRange.length)
+{
+    /// Converts a UTF16 NSRange into a `Range<String.Index>` for this string.
+    ///
+    /// - Parameters:
+    ///     - nsRange: the UTF16 NSRange to convert.
+    ///
+    /// - Returns: the requested `Range<String.Index>`
+    ///
+    func range(from nsRange : NSRange) -> Range<String.Index>? {
+        let utf16Start = utf16.index(utf16.startIndex, offsetBy: nsRange.location)
+        let utf16End = utf16.index(utf16Start, offsetBy: nsRange.length)
 
         guard
-            let from = from16.samePosition(in: self),
-            let to = to16.samePosition(in: self)
-            else { return nil }
-        return from ..< to
-                
+            let start = utf16Start.samePosition(in: self),
+            let end = utf16End.samePosition(in: self) else {
+                return nil
+        }
+
+        return start ..< end
+    }
+
+    /// Converts a `Range<String.Index>` into an UTF16 NSRange.
+    ///
+    /// - Parameters:
+    ///     - range: the range to convert.
+    ///
+    /// - Returns: the requested `NSRange`.
+    ///
+    func nsRange(from range: Range<String.Index>) -> NSRange {
+
+        let lowerBound = range.lowerBound.samePosition(in: utf16)
+        let upperBound = range.upperBound.samePosition(in: utf16)
+
+        let location = utf16.distance(from: utf16.startIndex, to: lowerBound)
+        let length = utf16.distance(from: lowerBound, to: upperBound)
+
+        return NSRange(location: location, length: length)
     }
 
     func indexFromLocation(_ location: Int) -> String.Index? {
         guard
-            let from16 = utf16.index(utf16.startIndex, offsetBy: location, limitedBy: utf16.endIndex),
-            let from = from16.samePosition(in: self)
-            else { return nil }
-        return from
+            let unicodeLocation = utf16.index(utf16.startIndex, offsetBy: location, limitedBy: utf16.endIndex),
+            let location = unicodeLocation.samePosition(in: self) else {
+                return nil
+        }
+
+        return location
     }
 
     func isLastValidLocation(_ location: Int) -> Bool {

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -806,7 +806,7 @@ extension Libxml2 {
             
             for textNodeAndRange in textNodesAndRanges {
                 let nodeText = textNodeAndRange.node.text()
-                let range = nodeText.rangeFromNSRange(textNodeAndRange.range)!
+                let range = nodeText.range(from: textNodeAndRange.range)!
                 
                 text = text + nodeText.substring(with: range)
             }

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -131,7 +131,7 @@ extension Libxml2 {
         ///
         private func replaceCharacters(inRange range: NSRange, withSanitizedString string: String) {
             
-            guard let range = contents.rangeFromNSRange(range) else {
+            guard let range = contents.range(from: range) else {
                 fatalError("The specified range is out of bounds.")
             }
             
@@ -231,7 +231,7 @@ extension Libxml2 {
 
         override func deleteCharacters(inRange range: NSRange) {
 
-            guard let range = contents.rangeFromNSRange(range) else {
+            guard let range = contents.range(from: range) else {
                 fatalError("The specified range is out of bounds.")
             }
             
@@ -321,7 +321,7 @@ extension Libxml2 {
         
         override func split(forRange range: NSRange) {
 
-            guard let swiftRange = contents.rangeFromNSRange(range) else {
+            guard let swiftRange = contents.range(from: range) else {
                 fatalError("This scenario should not be possible. Review the logic.")
             }
 

--- a/AztecTests/StringRangeConversionTests.swift
+++ b/AztecTests/StringRangeConversionTests.swift
@@ -12,130 +12,135 @@ class StringRangeConversionTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
-    func testRangeConversion() {
-        // test simple word
-        var nsString: NSString = "Hello World!"
-        var string: String = nsString as String
 
-        var wordToCapture = "World"
-        var nsRange = nsString.range(of: wordToCapture)
-        var range = string.rangeFromNSRange(nsRange)
+    func testRangeConversion1() {
+        let nsString: NSString = "Hello World!"
+        let string: String = nsString as String
 
-        var wordCaptured = string.substring(with: range!)
+        let wordToCapture = "World"
+        let nsRange = nsString.range(of: wordToCapture)
+        let range = string.range(from: nsRange)
 
-        XCTAssertEqual(wordToCapture, wordCaptured)
-
-        // test with emoji size 2
-        nsString = "Hello 🌍!"
-        string = nsString as String
-
-        wordToCapture = "🌍"
-        nsRange = nsString.range(of: wordToCapture)
-        range = string.rangeFromNSRange(nsRange)
-
-        wordCaptured = string.substring(with: range!)
-
-        XCTAssertEqual(wordToCapture, wordCaptured)
-
-        // test with emoji size 4
-        nsString = "Hello 🇮🇳!"
-        string = nsString as String
-
-        wordToCapture = "🇮🇳"
-        nsRange = nsString.range(of: wordToCapture)
-        range = string.rangeFromNSRange(nsRange)
-
-        wordCaptured = string.substring(with: range!)
-
-        XCTAssertEqual(wordToCapture, wordCaptured)
-
-        // test with two emojis
-        nsString = "Hello 🇮🇳 🌍!"
-        string = nsString as String
-
-        wordToCapture = "🌍"
-        nsRange = nsString.range(of: wordToCapture)
-        range = string.rangeFromNSRange(nsRange)
-
-        wordCaptured = string.substring(with: range!)
+        let wordCaptured = string.substring(with: range!)
 
         XCTAssertEqual(wordToCapture, wordCaptured)
     }
 
-    func testLocationConversion() {
+    func testRangeConversion2() {
+        let nsString: NSString = "Hello 🌍!"
+        let string: String = nsString as String
+
+        let wordToCapture = "🌍"
+        let nsRange = nsString.range(of: wordToCapture)
+        let range = string.range(from: nsRange)
+
+        let wordCaptured = string.substring(with: range!)
+
+        XCTAssertEqual(wordToCapture, wordCaptured)
+    }
+
+    func testRangeConversion3() {
+        let nsString: NSString = "Hello 🇮🇳!"
+        let string: String = nsString as String
+
+        let wordToCapture = "🇮🇳"
+        let nsRange = nsString.range(of: wordToCapture)
+        let range = string.range(from: nsRange)
+
+        let wordCaptured = string.substring(with: range!)
+
+        XCTAssertEqual(wordToCapture, wordCaptured)
+    }
+
+    func testRangeConversion4() {
+        let nsString: NSString = "Hello 🇮🇳 🌍!"
+        let string: String = nsString as String
+
+        let wordToCapture = "🌍"
+        let nsRange = nsString.range(of: wordToCapture)
+        let range = string.range(from: nsRange)
+
+        let wordCaptured = string.substring(with: range!)
+
+        XCTAssertEqual(wordToCapture, wordCaptured)
+    }
+
+    func testLocationConversion1() {
         // test simple word
-        var nsString: NSString = "Hello World!"
-        var string: String = nsString as String
+        let nsString: NSString = "Hello World!"
+        let string: String = nsString as String
 
-        var wordToCapture = "World"
-        var nsRange = nsString.range(of: wordToCapture)
-        var index = string.indexFromLocation(nsRange.location)!
+        let wordToCapture = "World"
+        let nsRange = nsString.range(of: wordToCapture)
+        let index = string.indexFromLocation(nsRange.location)!
 
-        var wordCaptured = string.substring(to: index)
-
-        XCTAssertEqual("Hello ", wordCaptured)
-
-        // test with emoji size 2
-        nsString = "Hello 🌍!"
-        string = nsString as String
-
-        wordToCapture = "🌍"
-        nsRange = nsString.range(of: wordToCapture)
-        index = string.indexFromLocation(nsRange.location)!
-
-        wordCaptured = string.substring(to: index)
+        let wordCaptured = string.substring(to: index)
 
         XCTAssertEqual("Hello ", wordCaptured)
+    }
 
-        // test with emoji size 4
-        nsString = "Hello 🇮🇳!"
-        string = nsString as String
+    func testLocationConversion2() {
+        let nsString: NSString = "Hello 🌍!"
+        let string: String = nsString as String
 
-        wordToCapture = "🇮🇳"
-        nsRange = nsString.range(of: wordToCapture)
-        index = string.indexFromLocation(nsRange.location)!
+        let wordToCapture = "🌍"
+        let nsRange = nsString.range(of: wordToCapture)
+        let index = string.indexFromLocation(nsRange.location)!
 
-        wordCaptured = string.substring(to: index)
+        let wordCaptured = string.substring(to: index)
 
         XCTAssertEqual("Hello ", wordCaptured)
+    }
 
-        // test with two emojis
-        nsString = "Hello 🇮🇳 🌍!"
-        string = nsString as String
+    func testLocationConversion3() {
+        let nsString: NSString = "Hello 🇮🇳!"
+        let string: String = nsString as String
 
-        wordToCapture = "🌍"
-        nsRange = nsString.range(of: wordToCapture)
-        index = string.indexFromLocation(nsRange.location)!
+        let wordToCapture = "🇮🇳"
+        let nsRange = nsString.range(of: wordToCapture)
+        let index = string.indexFromLocation(nsRange.location)!
 
-        wordCaptured = string.substring(to: index)
-        
+        let wordCaptured = string.substring(to: index)
+
+        XCTAssertEqual("Hello ", wordCaptured)
+    }
+
+    func testLocationConversion4() {
+        let nsString: NSString = "Hello 🇮🇳 🌍!"
+        let string: String = nsString as String
+
+        let wordToCapture = "🌍"
+        let nsRange = nsString.range(of: wordToCapture)
+        let index = string.indexFromLocation(nsRange.location)!
+
+        let wordCaptured = string.substring(to: index)
+
         XCTAssertEqual("Hello 🇮🇳 ", wordCaptured)
     }
 
-    func testLocationBefore() {
-        var nsString: NSString = "Hello World!"
-        var string: String = nsString as String
+    func testLocationBefore1() {
+        let nsString: NSString = "Hello World!"
+        let string: String = nsString as String
 
-        var wordToCapture = "World"
-        var nsRange = nsString.range(of: wordToCapture)
-        var location = string.location(before: nsRange.location)!
-        var index = string.indexFromLocation(location)!
-        var wordCaptured = string.substring(to: index)
+        let wordToCapture = "World"
+        let nsRange = nsString.range(of: wordToCapture)
+        let location = string.location(before: nsRange.location)!
+        let index = string.indexFromLocation(location)!
+        let wordCaptured = string.substring(to: index)
 
         XCTAssertEqual("Hello", wordCaptured)
+    }
 
-        // test with emoji size 2
-        nsString = "Hello 🌍!"
-        string = nsString as String
+    func testLocationBefore2() {
+        let nsString: NSString = "Hello 🌍!"
+        let string: String = nsString as String
 
-        wordToCapture = "🌍"
-        nsRange = nsString.range(of: wordToCapture)
-        location = string.location(before: nsRange.endLocation)!
-        index = string.indexFromLocation(location)!
+        let wordToCapture = "🌍"
+        let nsRange = nsString.range(of: wordToCapture)
+        let location = string.location(before: nsRange.endLocation)!
+        let index = string.indexFromLocation(location)!
+        let wordCaptured = string.substring(to: index)
 
-        wordCaptured = string.substring(to: index)
-        
         XCTAssertEqual("Hello ", wordCaptured)
     }
 
@@ -153,5 +158,76 @@ class StringRangeConversionTests: XCTestCase {
         XCTAssertNil(nonExistentLocation)
     }
 
+    /// Tests that converting a range back and forth works.
+    ///
+    /// Input:
+    ///     - String is: "Hello world!"
+    ///     - NSRange is: range of "Hello"
+    ///
+    /// Expected Output:
+    ///     - The range will be converted to a range and back, the final NSRange should stay the
+    ///         same.
+    ///
+    func testNSRangeFromRange1() {
+        let string = "Hello world!"
+        let nsRange = (string as NSString).range(of: "Hello")
+
+        guard let range = string.range(from: nsRange) else {
+            XCTFail("Range conversion failed!")
+            return
+        }
+
+        let finalNSRange = string.nsRange(from: range)
+
+        XCTAssertEqual(nsRange, finalNSRange)
+    }
+
+    /// Tests that converting a range back and forth works.
+    ///
+    /// Input:
+    ///     - String is: "Hello 😬 world!"
+    ///     - NSRange is: (loc: 5, len: 3)
+    ///
+    /// Expected Output:
+    ///     - The range will be converted to a range and back, the final NSRange should stay the
+    ///         same.
+    ///
+    func testNSRangeFromRange2() {
+        let nsRange = NSRange(location: 5, length: 3)
+        let string = "Hello world!"
+
+        guard let range = string.range(from: nsRange) else {
+            XCTFail("Range conversion failed!")
+            return
+        }
+
+        let finalNSRange = string.nsRange(from: range)
+
+        XCTAssertEqual(nsRange, finalNSRange)
+    }
+
+    /// Tests that converting a range back and forth works.
+    ///
+    /// Input:
+    ///     - String is: "Hello 😬 world!"
+    ///     - NSRange is: (loc: 5, len: 3)
+    ///
+    /// Expected Output:
+    ///     - The range will be converted to a range and back, the final NSRange should stay the
+    ///         same.
+    ///
+    func testNSRangeFromRange3() {
+        let string = "Hello 🌎!"
+        let nsRange = (string as NSString).range(of: "🌎")
+
+        guard let range = string.range(from: nsRange) else {
+            XCTFail("Range conversion failed!")
+            return
+        }
+
+        let finalNSRange = string.nsRange(from: range)
+
+        XCTAssertEqual(nsRange, finalNSRange)
+    }
     
 }

--- a/AztecTests/StringRangeConversionTests.swift
+++ b/AztecTests/StringRangeConversionTests.swift
@@ -186,15 +186,15 @@ class StringRangeConversionTests: XCTestCase {
     ///
     /// Input:
     ///     - String is: "Hello 😬 world!"
-    ///     - NSRange is: (loc: 5, len: 3)
+    ///     - NSRange is: range of "world"
     ///
     /// Expected Output:
     ///     - The range will be converted to a range and back, the final NSRange should stay the
     ///         same.
     ///
     func testNSRangeFromRange2() {
-        let nsRange = NSRange(location: 5, length: 3)
         let string = "Hello world!"
+        let nsRange = (string as NSString).range(of: "world")
 
         guard let range = string.range(from: nsRange) else {
             XCTFail("Range conversion failed!")
@@ -209,8 +209,8 @@ class StringRangeConversionTests: XCTestCase {
     /// Tests that converting a range back and forth works.
     ///
     /// Input:
-    ///     - String is: "Hello 😬 world!"
-    ///     - NSRange is: (loc: 5, len: 3)
+    ///     - String is: "Hello 🌎!"
+    ///     - NSRange is: range of "🌎"
     ///
     /// Expected Output:
     ///     - The range will be converted to a range and back, the final NSRange should stay the


### PR DESCRIPTION
<h3>Description:</h3>

This PR:
- Adds the method `nsRange(from range: Range<String.Index>)` (closes #412).
- Renames `rangeFromNSRange(_ range: NSRange)` to `range(from range: NSRange)`.
- Separates some previously written unit tests to make them more atomic, and easier to maintain.
- Adds unit tests to tests to make sure the newly added method works correctly.

<h3>Testing:</h3>

Running the unit tests should be enough to make sure this PR works as expected.
Make sure to thoroughly review the code changes.