### PR TITLE
Bugfix: Broken HTML after H1

### DIFF
--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -214,7 +214,7 @@ extension CharacterAttributeFormatter {
     }
 
     func needsEmptyLinePlaceholder() -> Bool {
-        return true
+        return false
     }
 }
 

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -64,6 +64,8 @@ protocol AttributeFormatter {
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange
 
     func worksInEmptyRange() -> Bool
+
+    func needsEmptyLinePlaceholder() -> Bool
 }
 
 
@@ -118,7 +120,7 @@ extension AttributeFormatter {
     @discardableResult func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) -> NSRange {
         var rangeToApply = applicationRange(for: range, in: text)
 
-        if worksInEmptyRange() && ( rangeToApply.length == 0 || text.length == 0)   {
+        if needsEmptyLinePlaceholder() && worksInEmptyRange() && ( rangeToApply.length == 0 || text.length == 0)   {
             let placeholder = placeholderForEmptyLine(using: placeholderAttributes)
             text.insert(placeholder, at: rangeToApply.location)
             rangeToApply = NSMakeRange(rangeToApply.location, placeholder.length)
@@ -210,6 +212,10 @@ extension CharacterAttributeFormatter {
     func worksInEmptyRange() -> Bool {
         return false
     }
+
+    func needsEmptyLinePlaceholder() -> Bool {
+        return true
+    }
 }
 
 
@@ -225,6 +231,10 @@ extension ParagraphAttributeFormatter {
     }
 
     func worksInEmptyRange() -> Bool {
+        return true
+    }
+
+    func needsEmptyLinePlaceholder() -> Bool {
         return true
     }
 }

--- a/Aztec/Classes/Formatters/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/HeaderFormatter.swift
@@ -97,5 +97,9 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         }
         return false
     }
+
+    func needsEmptyLinePlaceholder() -> Bool {
+        return false
+    }
 }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -803,8 +803,8 @@ open class TextView: UITextView {
         }
 
         for formatter in formattersThatBreakAfterEnter {
-            if formatter.present(in: textStorage, at: range.location) {
-                formatter.removeAttributes(from: textStorage, at: range)
+            if formatter.present(in: typingAttributes) {
+                typingAttributes = formatter.remove(from: typingAttributes)
                 return true
             }
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -833,8 +833,10 @@ open class TextView: UITextView {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             let pristine = self.selectedRange
             let updated = NSMakeRange(max(pristine.location - 1, 0), 0)
+            let beforeTypingAttributes = self.typingAttributes
             self.selectedRange = updated
             self.selectedRange = pristine
+            self.typingAttributes = beforeTypingAttributes
         }
     }
 

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -652,4 +652,31 @@ class AztecVisualTextViewTests: XCTestCase {
 
         XCTAssertEqual(textView.getHTML(), "<h1>Header</h1>")
     }
+
+
+    /// Tests that there is no HTML Corruption when editing text, after toggling H1 and entering two lines of text.
+    ///
+    /// Input:
+    ///     - "Header\n12" (Inserted character by character)
+    ///     - Delete Backwards event.
+    ///
+    /// Ref. https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/407
+    ///
+    func testDeletingBackwardAfterTogglingHeaderDoesNotTriggerInvalidHTML() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleHeader(.h1, range: .zero)
+        textView.insertText("H")
+        textView.insertText("e")
+        textView.insertText("a")
+        textView.insertText("d")
+        textView.insertText("e")
+        textView.insertText("r")
+        textView.insertText("\n")
+        textView.insertText("1")
+        textView.insertText("2")
+        textView.deleteBackward()
+
+        XCTAssertEqual(textView.getHTML(), "<h1>Header</h1><br>1")
+    }
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -677,6 +677,6 @@ class AztecVisualTextViewTests: XCTestCase {
         textView.insertText("2")
         textView.deleteBackward()
 
-        XCTAssertEqual(textView.getHTML(), "<h1>Header</h1><br>1")
+        XCTAssertEqual(textView.getHTML(), "<h1>Header<br></h1>1")
     }
 }


### PR DESCRIPTION
### Scenario: Corrupt HTML
1. Type `Heading`
2. Select the new word and toggle H1
3. Press return
4. Type a two characters
5. Delete one of the two characters

Verify that the HTML generated looks as follows:
`<h1>Heading<br></h1>A`

### Scenario: Randomness
1. Launch the empty editor
2. Toggle H1
3. Enter some text. Hit return
4. Enter some text

Verify that the second line is, effectively, in `Paragraph` style


Nukes Zero Width Characters Usage in HeaderFormatter (Ref. #414)
Closes #407
Closes #415

Needs Review: @diegoreymendez 
cc @SergioEstevao 

Thanks in advance gentlemen!
:bowtie: 
