### PR TITLE
Fixing PreFormatter Removal

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		59FEA0751D8BDFA700D138DF /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA0661D8BDFA700D138DF /* NodeTests.swift */; };
 		59FEA0781D8BDFA700D138DF /* HTMLToAttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06A1D8BDFA700D138DF /* HTMLToAttributedStringTests.swift */; };
 		59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */; };
+		B542D6421E9EB122009D12D3 /* PreFormaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542D6411E9EB122009D12D3 /* PreFormaterTests.swift */; };
 		B551A4A01E770B3800EE3A7F /* UIFont+Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = B551A49F1E770B3800EE3A7F /* UIFont+Emoji.swift */; };
 		B572AC281E817CFE008948C2 /* CommentAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B572AC271E817CFE008948C2 /* CommentAttachment.swift */; };
 		B577DC651E7B18E90012A1F8 /* NodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B577DC641E7B18E90012A1F8 /* NodeDescriptor.swift */; };
@@ -184,6 +185,7 @@
 		59FEA06B1D8BDFA700D138DF /* InAttributeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAttributeConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InHTMLConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
+		B542D6411E9EB122009D12D3 /* PreFormaterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreFormaterTests.swift; sourceTree = "<group>"; };
 		B551A49F1E770B3800EE3A7F /* UIFont+Emoji.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Emoji.swift"; sourceTree = "<group>"; };
 		B572AC271E817CFE008948C2 /* CommentAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachment.swift; sourceTree = "<group>"; };
 		B577DC641E7B18E90012A1F8 /* NodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NodeDescriptor.swift; path = Descriptors/NodeDescriptor.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */,
 				E11B775F1DBA14B40024E455 /* BlockquoteFormatterTests.swift */,
 				FFD436971E3180A500A0E26F /* FontFormatterTests.swift */,
+				B542D6411E9EB122009D12D3 /* PreFormaterTests.swift */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -863,6 +866,7 @@
 				599F25951D8BDCFC002871D6 /* TextViewTests.swift in Sources */,
 				594C9D711D8BE6B800D74542 /* OutAttributeConverterTests.swift in Sources */,
 				59FEA06F1D8BDFA700D138DF /* OutHTMLConverterTests.swift in Sources */,
+				B542D6421E9EB122009D12D3 /* PreFormaterTests.swift in Sources */,
 				599F25941D8BDCFC002871D6 /* TextStorageTests.swift in Sources */,
 				59FEA0741D8BDFA700D138DF /* ElementNodeTests.swift in Sources */,
 				B5BC4FF21DA2D17000614582 /* NSAttributedStringListsTests.swift in Sources */,

--- a/Aztec/Classes/Formatters/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/PreFormatter.swift
@@ -6,7 +6,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
     let monospaceFont: UIFont
     let placeholderAttributes: [String : Any]?
 
-    init(monospaceFont: UIFont = UIFont(descriptor:UIFontDescriptor(name: "Courier", size: 12), size:12) ,placeholderAttributes: [String : Any]? = nil) {
+    init(monospaceFont: UIFont = UIFont(descriptor:UIFontDescriptor(name: "Courier", size: 12), size:12), placeholderAttributes: [String : Any]? = nil) {
         self.monospaceFont = monospaceFont
         self.placeholderAttributes = placeholderAttributes
     }
@@ -21,11 +21,14 @@ open class PreFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(from attributes:[String: Any]) -> [String: Any] {
-        var resultingAttributes = attributes
+    func remove(from attributes: [String: Any]) -> [String: Any] {
+        guard let placeholderAttributes = placeholderAttributes else {
+            return attributes
+        }
 
-        if let attributes = placeholderAttributes {
-            resultingAttributes = attributes
+        var resultingAttributes = attributes
+        for (key, value) in placeholderAttributes {
+            resultingAttributes[key] = value
         }
 
         return resultingAttributes

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -2,7 +2,10 @@ import XCTest
 import Gridicons
 @testable import Aztec
 
+// MARK: - BlockquoteFormatterTests Tests
+//
 class BlockquoteFormatterTests: XCTestCase {
+
     func testApplyingBlockquoteOnFirstParagraph() {
         let textView = testTextView
         let storage = textView.storage

--- a/AztecTests/Formatters/PreFormaterTests.swift
+++ b/AztecTests/Formatters/PreFormaterTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import Gridicons
+@testable import Aztec
+
+
+// MARK: - PreFormatterTests Tests
+//
+class PreFormatterTests: XCTestCase {
+
+    /// Verifies that the PreFormatter is not interacting with NSTextAttachment Attributes, that are unrelated
+    /// to the formatter's behavior.
+    ///
+    func testPreFormatterDoesNotLooseAttachmentAttribuesOnRemove() {
+        let placeholderAttributes: [String: Any] = [
+            NSFontAttributeName: "Value",
+            NSParagraphStyleAttributeName: NSParagraphStyle()
+        ]
+
+        let stringAttributes: [String: Any] = [
+            NSAttachmentAttributeName: NSTextAttachment(),
+        ]
+
+        let formatter = PreFormatter(placeholderAttributes: placeholderAttributes)
+        let updated = formatter.remove(from: stringAttributes)
+
+        let expectedValue = stringAttributes[NSAttachmentAttributeName] as! NSTextAttachment
+        let updatedValue = updated[NSAttachmentAttributeName] as! NSTextAttachment
+
+        XCTAssert(updatedValue == expectedValue)
+    }
+}

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -4,8 +4,8 @@ import XCTest
 
 // MARK: - TextListFormatter Tests
 //
-class TextListFormatterTests: XCTestCase
-{
+class TextListFormatterTests: XCTestCase {
+    
     // Helpers #1:
     // ===========
     //


### PR DESCRIPTION
### Steps:
1. Launch the Empty Editor
2. Switch to HTML Edition
3. Enter `<unknown/>`
4. Switch to Rich Edition
5. With the cursor at the initial position (no need to change anything!) hit backspace

Verify that the `[Unknown]` Attachment does not get removed. Please, repeat all of the steps with `<!--comment-->` and `<hr>`.

Closes #410

Needs Review: @diegoreymendez 
cc @SergioEstevao 

Thanks gentlemen!
