### PR TITLE
Fix: Drag and Drop Crash

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -79,17 +79,28 @@ protocol TextStorageAttachmentsDelegate: class {
 ///
 open class TextStorage: NSTextStorage {
 
+    // MARK: - Private Properties
+
     fileprivate var textStore = NSMutableAttributedString(string: "", attributes: nil)
-    
-    // MARK: - NSTextStorage
+
+
+    // MARK: - Public Properties
+
+    /// NOTE:
+    /// `attachmentsDelegate` is an optional property. On purpose. During a Drag and Drop OP, the
+    /// LayoutManager may instantiate an entire TextKit stack. Since there is absolutely no entry point
+    /// in which we may set this delegate, we need to set it as optional.
+    ///
+    /// Ref. Issue #727
+    ///
+    weak var attachmentsDelegate: TextStorageAttachmentsDelegate?
+
+
+    // MARK: - Calculated Properties
 
     override open var string: String {
         return textStore.string
     }
-
-    // MARK: - Attachments
-
-    weak var attachmentsDelegate: TextStorageAttachmentsDelegate!
 
     open var mediaAttachments: [MediaAttachment] {
         let range = NSMakeRange(0, length)

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -91,7 +91,7 @@ open class TextStorage: NSTextStorage {
     /// LayoutManager may instantiate an entire TextKit stack. Since there is absolutely no entry point
     /// in which we may set this delegate, we need to set it as optional.
     ///
-    /// Ref. Issue #727
+    /// Ref. https://github.com/wordpress-mobile/AztecEditor-iOS/issues/727
     ///
     weak var attachmentsDelegate: TextStorageAttachmentsDelegate?
 
@@ -115,7 +115,7 @@ open class TextStorage: NSTextStorage {
     }
 
 
-    // MARK: - Public Helpers
+    // MARK: - Public Methods
 
     func range<T : NSTextAttachment>(for attachment: T) -> NSRange? {
         var range: NSRange?
@@ -149,7 +149,7 @@ open class TextStorage: NSTextStorage {
     /// - Returns: the preprocessed string.
     ///
     fileprivate func preprocessAttachmentsForInsertion(_ attributedString: NSAttributedString) -> NSAttributedString {
-        // Ref. #727:
+        // Ref. https://github.com/wordpress-mobile/AztecEditor-iOS/issues/727:
         // If the delegate is not set, we *Explicitly* do not want to crash here.
         //
         guard let delegate = attachmentsDelegate else {
@@ -204,7 +204,7 @@ open class TextStorage: NSTextStorage {
     }
 
     fileprivate func detectAttachmentRemoved(in range: NSRange) {
-        // Ref. #727:
+        // Ref. https://github.com/wordpress-mobile/AztecEditor-iOS/issues/727:
         // If the delegate is not set, we *Explicitly* do not want to crash here.
         //
         guard let delegate = attachmentsDelegate else {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -79,12 +79,12 @@ protocol TextStorageAttachmentsDelegate: class {
 ///
 open class TextStorage: NSTextStorage {
 
-    // MARK: - Private Properties
+    // MARK: - Storage
 
     fileprivate var textStore = NSMutableAttributedString(string: "", attributes: nil)
 
 
-    // MARK: - Public Properties
+    // MARK: - Delegates
 
     /// NOTE:
     /// `attachmentsDelegate` is an optional property. On purpose. During a Drag and Drop OP, the
@@ -115,7 +115,7 @@ open class TextStorage: NSTextStorage {
     }
 
 
-    // MARK: - Public Methods
+    // MARK: - Range Methods
 
     func range<T : NSTextAttachment>(for attachment: T) -> NSRange? {
         var range: NSRange?

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -353,8 +353,11 @@ open class TextStorage: NSTextStorage {
 extension TextStorage: MediaAttachmentDelegate {
 
     func mediaAttachmentPlaceholderImageFor(attachment: MediaAttachment) -> UIImage {
-        assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, placeholderFor: attachment)
+        guard let delegate = attachmentsDelegate else {
+            fatalError()
+        }
+
+        return delegate.storage(self, placeholderFor: attachment)
     }
 
     func mediaAttachment(
@@ -363,8 +366,11 @@ extension TextStorage: MediaAttachmentDelegate {
         onSuccess success: @escaping (UIImage) -> (),
         onFailure failure: @escaping () -> ())
     {
-        assert(attachmentsDelegate != nil)
-        attachmentsDelegate.storage(self, attachment: mediaAttachment, imageFor: url, onSuccess: success, onFailure: failure)
+        guard let delegate = attachmentsDelegate else {
+            fatalError()
+        }
+
+        delegate.storage(self, attachment: mediaAttachment, imageFor: url, onSuccess: success, onFailure: failure)
     }
 }
 
@@ -374,8 +380,11 @@ extension TextStorage: MediaAttachmentDelegate {
 extension TextStorage: VideoAttachmentDelegate {
 
     func videoAttachmentPlaceholderImageFor(attachment: VideoAttachment) -> UIImage {
-        assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, placeholderFor: attachment)
+        guard let delegate = attachmentsDelegate else {
+            fatalError()
+        }
+
+        return delegate.storage(self, placeholderFor: attachment)
     }
 
     func videoAttachment(
@@ -384,8 +393,11 @@ extension TextStorage: VideoAttachmentDelegate {
         onSuccess success: @escaping (UIImage) -> (),
         onFailure failure: @escaping () -> ())
     {
-        assert(attachmentsDelegate != nil)
-        attachmentsDelegate.storage(self, attachment: videoAttachment, imageFor: url, onSuccess: success, onFailure: failure)
+        guard let delegate = attachmentsDelegate else {
+            fatalError()
+        }
+
+        delegate.storage(self, attachment: videoAttachment, imageFor: url, onSuccess: success, onFailure: failure)
     }
 }
 
@@ -396,12 +408,18 @@ extension TextStorage: VideoAttachmentDelegate {
 extension TextStorage: RenderableAttachmentDelegate {
 
     func attachment(_ attachment: NSTextAttachment, imageForSize size: CGSize) -> UIImage? {
-        assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, imageFor: attachment, with: size)
+        guard let delegate = attachmentsDelegate else {
+            fatalError()
+        }
+
+        return delegate.storage(self, imageFor: attachment, with: size)
     }
 
     func attachment(_ attachment: NSTextAttachment, boundsForLineFragment fragment: CGRect) -> CGRect {
-        assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, boundsFor: attachment, with: fragment)
+        guard let delegate = attachmentsDelegate else {
+            fatalError()
+        }
+
+        return delegate.storage(self, boundsFor: attachment, with: fragment)
     }
 }


### PR DESCRIPTION
### Details:
Upon a Drag and Drop OP (in the scenario specified below), iOS will create a new TextView stack. Since we do not have any way to setup the TextView's **attachmentDelegate**, we're converting this property into an optional one.

Fixes #727

### To test:
1. Open Aztec, and Safari side-by-side
2. Open a web page with images
3. Drag one image into Aztec
4. Tap to the right of the image, and type a new line (enter)
5. Drag another image (or the same one) in again, into the new space

Verify that Aztec does not crash.
