### PR TITLE
Fix oblique type bug for Chinese

### DIFF
--- a/Aztec/Classes/Extensions/UIFont+Traits.swift
+++ b/Aztec/Classes/Extensions/UIFont+Traits.swift
@@ -30,6 +30,15 @@ extension UIFont {
             // This is a very viable scenario, and our default handling mechanism for it is to
             // return the original, unmodified font.
             //
+            
+            // MARK: Fix oblique type for Chinese
+            if newTraits.contains(.traitItalic) && familyDescriptor.postscriptName.hasPrefix(".PingFangSC") {
+                newTraits.remove(.traitItalic)
+                if let newDescriptor = familyDescriptor.withSymbolicTraits(newTraits) {
+                    return UIFont(descriptor: newDescriptor, size: pointSize)
+                }
+            }
+            
             return self
         }
 


### PR DESCRIPTION
The bug is: When you type Chinese (or other language that has not `italic` type) and English at the same line with `italic` format enable, and then when you delete all the English characters, the `italic` format button won't be able to hit again. 

To test:
Just type Chinese and English with `italic` open and delete all the English characters. 
After doing so, try to hit the `italic` format button again and you will see the different. 