### PR TITLE
Adding support for different bullets by UL indentation level

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -34,7 +34,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        let newList = TextList(style: self.listStyle, with: representation)
+        let newList = TextList(style: self.listStyle, with: representation, level: newParagraphStyle.lists.count)
         if newParagraphStyle.lists.isEmpty || increaseDepth {
             newParagraphStyle.insertProperty(newList, afterLastOfType: HTMLLi.self)
         } else {

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -255,7 +255,7 @@ private extension LayoutManager {
         let paragraphAttributes = textStorage.attributes(at: location, effectiveRange: nil)
         let markerAttributes = markerAttributesBasedOnParagraph(attributes: paragraphAttributes)
 
-        let markerPlain = list.style.markerText(forItemNumber: number)
+        let markerPlain = list.style.markerText(forItemNumber: number, level: list.level)
         let markerText = NSAttributedString(string: markerPlain, attributes: markerAttributes)
 
         var yOffset = CGFloat(0)

--- a/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
@@ -26,7 +26,9 @@ open class TextList: ParagraphProperty {
             case 0:
                 return "\t\u{2022}"
             default:
-                return "\t\u{25E6}"
+                // Using the same black bullet for now until Android side is able to edit bullets by level too.
+                // Then this should be updated to "{25E6}"
+                return "\t\u{2022}"
             }
         }
     }

--- a/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
@@ -14,10 +14,19 @@ open class TextList: ParagraphProperty {
         case ordered
         case unordered
 
-        func markerText(forItemNumber number: Int) -> String {
+        func markerText(forItemNumber number: Int, level: Int) -> String {
             switch self {
             case .ordered:      return "\t\(number)."
-            case .unordered:    return "\t\u{2022}"
+            case .unordered:    return unorderedMarker(for: level)
+            }
+        }
+
+        func unorderedMarker(for level: Int) -> String {
+            switch level {
+            case 0:
+                return "\t\u{2022}"
+            default:
+                return "\t\u{25E6}"
             }
         }
     }
@@ -27,9 +36,11 @@ open class TextList: ParagraphProperty {
     /// Kind of List: Ordered / Unordered
     ///
     let style: Style
+    let level: Int
 
-    init(style: Style, with representation: HTMLRepresentation? = nil) {
+    init(style: Style, with representation: HTMLRepresentation? = nil, level: Int = 0) {
         self.style = style
+        self.level = level
         super.init(with: representation)
     }
     
@@ -40,12 +51,19 @@ open class TextList: ParagraphProperty {
         } else {
             style = .ordered
         }
+        if aDecoder.containsValue(forKey: String(describing: \TextList.level)) {
+            level = aDecoder.decodeInteger(forKey: String(describing: \TextList.level))
+        } else {
+            level = 0
+        }
+
         super.init(coder: aDecoder)
     }
 
     public override func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
         aCoder.encode(style.rawValue, forKey: String(describing: Style.self))
+        aCoder.encode(level, forKey: String(describing: \TextList.level))
     }
 
     public static func ==(lhs: TextList, rhs: TextList) -> Bool {


### PR DESCRIPTION
This PR adds support for different bullets by UL indentation level for parity with Gutenberg Web:

The indented bullet will still be the same than the previous one (black bullet) until Android adds support for this too.

![bullets](https://user-images.githubusercontent.com/9772967/56265397-b8778d80-60e9-11e9-96c4-8819a8ba2fd2.png)

To test:
- `TextList.swift`.
- Search for `return "\t\u{2022}"` and change the unicode from `2022` to `25E6` (white bullet).
- Open the example project and check that the indented bullets are the white dot. (as in the screenshot)