### PR TITLE
Fix: indent and undent using tab and shift+tab

### DIFF
--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -2016,4 +2016,70 @@ class TextViewTests: XCTestCase {
 
         XCTAssertEqual(output, expected)
     }
+
+    func testNestedListItemsAreIndentedProperlyUsingTabKey() {
+        let textView = TextViewStub(withHTML: "WordPress")
+
+        let html = "<ul><li>Hello</li><li>world</li></ul>"
+        let expected = "<ul><li>Hello<ul><li>world</li></ul></li></ul>"
+
+        textView.setHTML(html)
+
+        selectRange(location: 6, length: 0, on: textView)
+        simulateTab(on: textView)
+
+        let output = textView.getHTML(prettify: false)
+
+        XCTAssertEqual(output, expected)
+    }
+
+    func testNestedListItemsAreUndentedProperlyUsingShiftTabKeyBinding() {
+        let textView = TextViewStub(withHTML: "WordPress")
+
+        let html = "<ul><li>Hello<ul><li>world</li></ul></li></ul>"
+        let expected = "<ul><li>Hello</li><li>world</li></ul>"
+
+        textView.setHTML(html)
+        selectRange(location: 6, length: 0, on: textView)
+        simulateShiftTab(on: textView)
+
+        let output = textView.getHTML(prettify: false)
+
+        XCTAssertEqual(output, expected)
+    }
+}
+
+// MARK: - Helpers
+
+extension TextViewTests {
+    func selectRange(location: Int, length: Int, on textView: TextViewStub) {
+        let newSelectedRange = NSRange(location: location, length: length)
+        textView.selectedRange = textView.text.utf16NSRange(from: newSelectedRange)
+    }
+
+    func simulateTab(on textView: TextViewStub) {
+        let command = textView.keyCommands?.first { command in
+            return command.input == String(.tab) && command.modifierFlags.isEmpty
+        }
+
+        guard let tab = command else {
+            XCTFail()
+            return
+        }
+
+        textView.handleTab(command: tab)
+    }
+
+    func simulateShiftTab(on textView: TextViewStub) {
+        let command = textView.keyCommands?.first { command in
+            return command.input == String(.tab) && command.modifierFlags.contains(.shift)
+        }
+
+        guard let tab = command else {
+            XCTFail()
+            return
+        }
+
+        textView.handleShiftTab(command: tab)
+    }
 }


### PR DESCRIPTION
This PR fixes indent and undent view Tab / Shift+Tab keys.

**Note:** So far the unit tests were created, but not fix have been added yet.

# Explanation of the issue:

### Example indent:

From this initial HTML:
```html
<ul>
    <li>Hello</li>
    <li>world</li>
</ul>
```
Pressing Tab in the last list item we should get this:
```html
<ul>
    <li>Hello
        <ul>
            <li>world</li>
        </ul>
    </li>
</ul>
```

But we get this:
```html
<ul>
    <li>Hello</li>
    <li>
        <ul>
            <li>world</li>
        </ul>
    </li>
</ul>
```

### Example undent:

Starting from this HTML:
```html
<ul>
    <li>Hello
        <ul>
            <li>world</li>
        </ul>
    </li>
</ul>
```

Pressing Shift + Tab in the indented list item we should get the original:
```html
<ul>
    <li>Hello</li>
    <li>world</li>
</ul>
```

But we get:
```html
<ul>
  <li>Hello </li>
world
</ul>
````
