### PR TITLE
Fix bullet point's vertical alignment of list items

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -254,7 +254,7 @@ private extension LayoutManager {
         var effectiveLineRange = NSRange.zero
 
         // Since only the first line in a paragraph can have a bullet, we only need the first line fragment.
-        let lineFragmentRect = self.lineFragmentRect(forGlyphAt: range.location, effectiveRange: &effectiveLineRange)
+        let lineFragmentUsedRect = self.lineFragmentUsedRect(forGlyphAt: range.location, effectiveRange: &effectiveLineRange)
 
         // Whenever we're rendering an Item with multiple lines, within a Blockquote, we need to account for the
         // paragraph spacing. Otherwise the Marker will show up slightly off.
@@ -265,7 +265,7 @@ private extension LayoutManager {
             paddingY = Metrics.paragraphSpacing
         }
 
-        return lineFragmentRect.offsetBy(dx: origin.x, dy: origin.y + paddingY)
+        return CGRect(origin: CGPoint(x: origin.x, y: origin.y + lineFragmentUsedRect.origin.y + paddingY), size: lineFragmentUsedRect.size)
     }
 
 
@@ -284,14 +284,12 @@ private extension LayoutManager {
         let markerAttributes = markerAttributesBasedOnParagraph(attributes: paragraphAttributes)
         let markerAttributedText = NSAttributedString(string: markerText, attributes: markerAttributes)
 
-        var yOffset = CGFloat(0)
+        let markerWidth = markerAttributedText.size().width * 1.5
+        let markerHeight = markerAttributedText.size().height
+        var yOffset = CGFloat(rect.size.height / 2.0 - markerHeight / 2.0)
         var xOffset = CGFloat(0)
         let indentWidth = style.indentToLast(TextList.self)
-        let markerWidth = markerAttributedText.size().width * 1.5
 
-        if location > 0 {
-            yOffset += style.paragraphSpacingBefore
-        }
         // If the marker width is larger than the indent available let's offset the area to draw to the left
         if markerWidth > indentWidth {
             xOffset = indentWidth - markerWidth
@@ -300,6 +298,7 @@ private extension LayoutManager {
         var markerRect = rect.offsetBy(dx: xOffset, dy: yOffset)
 
         markerRect.size.width = max(indentWidth, markerWidth)
+        markerRect.size.height = markerHeight
 
         markerAttributedText.draw(in: markerRect)
     }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -286,7 +286,7 @@ private extension LayoutManager {
 
         let markerWidth = markerAttributedText.size().width * 1.5
         let markerHeight = markerAttributedText.size().height
-        var yOffset = CGFloat(rect.size.height / 2.0 - markerHeight / 2.0)
+        let yOffset = CGFloat(rect.size.height / 2.0 - markerHeight / 2.0)
         var xOffset = CGFloat(0)
         let indentWidth = style.indentToLast(TextList.self)
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1314

## Description

Align the bullet point vertically with the text line.

## How

The marker's (bullet point) render rectangle calculation has been changed.

### Origin rectangle
The line fragment rectangle was used as the origin for the calculation, after some checks I realised that unfortunately it's not providing a uniform size (first and last items are providing different heights). For this reason I swapped it to use the used rectangle version (`lineFragmentUsedRect`) which it provides the same height for all items.

### Vertical alignment
The Y offset now is calculated for center it vertically which also required to set the proper height, calculated from the glyph size.

## Screenshot

https://user-images.githubusercontent.com/14905380/103278490-e3903680-49cb-11eb-80e9-56bab11bbc92.mp4


## How to test

**The issue was spotted in the WordPress app which uses a different font family so the issue has to be tested there or modifying the default font for the content in [Aztec's example project](https://github.com/wordpress-mobile/AztecEditor-iOS/blob/develop/Example/Example/EditorDemoController.swift#L1119).**

1. Go to a post/page.
2. Create list with different items.
3. Add a emoji character to one of the items.

**Expected result**:
Bullet points are properly aligned with the text line.
