### PR TITLE
Fix Carthage build for Xcode 12

### DIFF
--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -614,6 +614,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};
@@ -667,6 +668,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;
 		};
@@ -829,6 +831,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Profiling;
 		};
@@ -912,6 +915,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = "Release-Alpha";
 		};

--- a/Example/carthage.sh
+++ b/Example/carthage.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"

--- a/Example/carthage.sh
+++ b/Example/carthage.sh
@@ -2,6 +2,7 @@
 
 # carthage.sh
 # Usage example: ./carthage.sh build --platform iOS
+# This script was copied from here: https://github.com/Carthage/Carthage/issues/3019#issuecomment-665136323
 
 set -euo pipefail
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ cd Example
 carthage update --platform iOS
 ```
 
+*If using XCode 12 use the follow script:*
+
+```bash
+cd Example
+./carthage.sh update --platform iOS
+```
+
 Once Carthage finishes, you should open the file `Aztec.xcworkspace` from the root directory of Aztec.
 
 Make sure the `AztecExample` target it selected, and press CMD + R to run it.


### PR DESCRIPTION
Fixes #1313 

Adds a Carthage script and configures a setting in the project to allow to build `Gridicons` on the `Example` project.

To test:
 - Make sure you are able to build and run the Example project following the updated instructions in the readme.

