### PR TITLE
Fix iOS 13 deprecation

### DIFF
--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -269,11 +269,11 @@ extension EditorView: UITextInput {
         return activeView.characterRange(byExtending: position, in: direction)
     }
     
-    public func baseWritingDirection(for position: UITextPosition, in direction: UITextStorageDirection) -> UITextWritingDirection {
+    public func baseWritingDirection(for position: UITextPosition, in direction: UITextStorageDirection) -> NSWritingDirection {
         return activeView.baseWritingDirection(for: position, in: direction)
     }
     
-    public func setBaseWritingDirection(_ writingDirection: UITextWritingDirection, for range: UITextRange) {
+    public func setBaseWritingDirection(_ writingDirection: NSWritingDirection, for range: UITextRange) {
         activeView.setBaseWritingDirection(writingDirection, for: range)
     }
     


### PR DESCRIPTION
Fixes this fixes a depreaction warning which breaks treating warnings as errors.

To test: 
* Change iOS deployment target to 13 or above
* Enable "Treat warnings as errors"

