### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   }
   s.xcconfig = {
     'OTHER_LDFLAGS' => '-lxml2',
-  	'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'
+    'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'
   }
 end

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = 'https://github.com/wordpress-mobile/AztecEditor-iOS'
   s.license       = { :type => 'MPLv2', :file => 'LICENSE.md' }
-  s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@wordpress.org' }
 
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -1,34 +1,22 @@
-#
-# Be sure to run `bundle exec pod lib lint WordPress-Aztec-iOS.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
-  s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.19.4'
-  s.summary          = 'The native HTML Editor.'
+  s.name          = 'WordPress-Aztec-iOS'
+  s.version       = '1.19.4'
 
-# This description is used to generate tags and improve search results.
-#   * Think: What does it do? Why did you write it? What is the focus?
-#   * Try to keep it short, snappy and to the point.
-#   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.summary       = 'The native HTML Editor.'
+  s.description   = <<-DESC
+                    The native HTML Editor by Automattic Inc.
 
-  s.description      = <<-DESC
-                       The native HTML Editor by Automattic Inc.
-                       DESC
+                    This library provides a UITextView subclass with HTML visual editing capabilities.
+                  DESC
 
-  s.homepage         = 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS'
-  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
-  s.license          = { :type => 'MPLv2', :file => 'LICENSE.md' }
-  s.author           = { 'Automattic' => 'mobile@automattic.com', 'Diego Rey Mendez' => 'diego.rey.mendez@automattic.com', 'Sergio Estevao' => 'sergioestevao@gmail.com', 'Jorge Leandro Perez' => 'jorge.perez@automattic.com' }
-  s.source           = { :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :tag => s.version.to_s }
+  s.homepage      = 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS'
+  s.license       = { :type => 'MPLv2', :file => 'LICENSE.md' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
+
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
 
+  s.source        = { :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :tag => s.version.to_s }
   s.module_name = "Aztec"
   s.source_files = 'Aztec/Classes/**/*'
   s.resource_bundles = {
@@ -36,7 +24,8 @@ Pod::Spec.new do |s|
       "Aztec/Assets/**/*"
     ]
   }
-
-  s.xcconfig = {'OTHER_LDFLAGS' => '-lxml2',
-  				'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
+  s.xcconfig = {
+    'OTHER_LDFLAGS' => '-lxml2',
+  	'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'
+  }
 end

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -9,14 +9,14 @@ Pod::Spec.new do |s|
                     This library provides a UITextView subclass with HTML visual editing capabilities.
                   DESC
 
-  s.homepage      = 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS'
+  s.homepage      = 'https://github.com/wordpress-mobile/AztecEditor-iOS'
   s.license       = { :type => 'MPLv2', :file => 'LICENSE.md' }
   s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
 
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
 
-  s.source        = { :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :tag => s.version.to_s }
+  s.source        = { :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag => s.version.to_s }
   s.module_name = "Aztec"
   s.source_files = 'Aztec/Classes/**/*'
   s.resource_bundles = {

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = 'https://github.com/wordpress-mobile/AztecEditor-iOS'
   s.license       = { :type => 'MPLv2', :file => 'LICENSE.md' }
-  s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@wordpress.org' }
 
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.resources = 'WordPressEditor/WordPressEditor/Assets/**/*'
   s.xcconfig = {
     'OTHER_LDFLAGS' => '-lxml2',
-  	'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'
+    'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'
   }
 
   s.dependency "WordPress-Aztec-iOS", s.version.to_s

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -10,14 +10,14 @@ Pod::Spec.new do |s|
                     Use this library if you want to create an App that interacts with WordPress HTML content.
                   DESC
 
-  s.homepage      = 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS'
+  s.homepage      = 'https://github.com/wordpress-mobile/AztecEditor-iOS'
   s.license       = { :type => 'MPLv2', :file => 'LICENSE.md' }
   s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
 
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
   
-  s.source        = { :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :tag => s.version.to_s }
+  s.source        = { :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag => s.version.to_s }
   s.module_name = "WordPressEditor"
   s.source_files = 'WordPressEditor/WordPressEditor/Classes/**/*'
   s.resources = 'WordPressEditor/WordPressEditor/Assets/**/*'

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -1,39 +1,30 @@
-#
-# Be sure to run `bundle exec pod lib lint WordPress-Editor-iOS.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
-  s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.19.4'
-  s.summary          = 'The WordPress HTML Editor.'
+  s.name          = 'WordPress-Editor-iOS'
+  s.version       = '1.19.4'
 
-# This description is used to generate tags and improve search results.
-#   * Think: What does it do? Why did you write it? What is the focus?
-#   * Try to keep it short, snappy and to the point.
-#   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.summary       = 'The WordPress HTML Editor.'
+  s.description   = <<-DESC
+                    The WordPress HTML Editor by Automattic Inc.
 
-  s.description      = <<-DESC
-                       The WordPress HTML Editor by Automattic Inc.
-                       DESC
+                    This library provides a UITextView subclass with HTML visual editing capabilities.
+                    Use this library if you want to create an App that interacts with WordPress HTML content.
+                  DESC
 
-  s.homepage         = 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS'
-  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
-  s.license          = { :type => 'MPLv2', :file => 'LICENSE.md' }
-  s.author           = { 'Automattic' => 'mobile@automattic.com', 'Diego Rey Mendez' => 'diego.rey.mendez@automattic.com', 'Sergio Estevao' => 'sergioestevao@gmail.com', 'Jorge Leandro Perez' => 'jorge.perez@automattic.com' }
-  s.source           = { :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :tag => s.version.to_s }
+  s.homepage      = 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS'
+  s.license       = { :type => 'MPLv2', :file => 'LICENSE.md' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
+
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
+  
+  s.source        = { :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :tag => s.version.to_s }
   s.module_name = "WordPressEditor"
   s.source_files = 'WordPressEditor/WordPressEditor/Classes/**/*'
   s.resources = 'WordPressEditor/WordPressEditor/Assets/**/*'
-
-  s.xcconfig = {'OTHER_LDFLAGS' => '-lxml2',
-  				'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
+  s.xcconfig = {
+    'OTHER_LDFLAGS' => '-lxml2',
+  	'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'
+  }
 
   s.dependency "WordPress-Aztec-iOS", s.version.to_s
 end


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

See wordpress-mobile/WordPressAuthenticator-iOS#582 for the rules I decided to follow on the format and content standardization.

---

### Notes

* This contains changes to 2 (two) podspecs at once – `WordPress-Aztec-iOS` and `WordPress-Editor-iOS` – since those are related and hosted in that same single repo.
* It appears that this repository has been renamed a while ago – and indeed the old https://github.com/wordpress-mobile/WordPress-Aztec-iOS URL redirects to https://github.com/wordpress-mobile/AztecEditor-iOS – so I've also updated the `s.source` and `s.homepage` of those 2 podspecs accordingly.