### PR TITLE
Retain Heading attribute when headings are autocorrected.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -233,8 +233,14 @@ open class TextStorage: NSTextStorage {
         let currentAttrs = attributes(at: 0, effectiveRange: nil)
 
         guard
+            // the text currently in storage has a headingRepresentation key
             let headerSize = currentAttrs[.headingRepresentation],
-            attributedString.attribute(.headingRepresentation, at: 0, effectiveRange: nil) == nil
+            // the text coming in doesn't have a headingRepresentation key
+            attributedString.attribute(.headingRepresentation, at: 0, effectiveRange: nil) == nil,
+            // the text coming in has a paragraph style attribute
+            let paragraphStyle = attributedString.attributes(at: 0, effectiveRange: nil)[.paragraphStyle] as? ParagraphStyle,
+            // the paragraph style contains a property that's a Header type
+            paragraphStyle.properties.contains(where: { $0 is Header })
         else {
             // Either the heading attribute wasn't present in the existing string,
             // or the attributed string already had it.

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -145,8 +145,9 @@ open class TextStorage: NSTextStorage {
 
     private func preprocessAttributesForInsertion(_ attributedString: NSAttributedString) -> NSAttributedString {
         let stringWithAttachments = preprocessAttachmentsForInsertion(attributedString)
+        let preprocessedString = preprocessHeadingsForInsertion(stringWithAttachments)
 
-        return stringWithAttachments
+        return preprocessedString
     }
 
     /// Preprocesses an attributed string's attachments for insertion in the storage.
@@ -209,6 +210,41 @@ open class TextStorage: NSTextStorage {
         }
 
         return finalString
+    }
+
+    /// Preprocesses an attributed string that is missing a `headingRepresentation` attribute for insertion in the storage.
+    ///
+    /// - Important: This method adds the `headingRepresentation` attribute if it determines the string should contain it.
+    ///  This works around a problem where autocorrected text didn't contain the attribute. This may change in future versions.
+    ///
+    /// - Parameters:
+    ///     - attributedString: the string we need to preprocess.
+    ///
+    /// - Returns: the preprocessed string.
+    ///
+    fileprivate func preprocessHeadingsForInsertion(_ attributedString: NSAttributedString) -> NSAttributedString {
+        // Ref. https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1334
+
+        guard textStore.length > 0, attributedString.length > 0 else {
+            return attributedString
+        }
+
+        // Get the attributes of the start of the current string in storage.
+        let currentAttrs = attributes(at: 0, effectiveRange: nil)
+
+        guard
+            let headerSize = currentAttrs[.headingRepresentation],
+            attributedString.attribute(.headingRepresentation, at: 0, effectiveRange: nil) == nil
+        else {
+            // Either the heading attribute wasn't present in the existing string,
+            // or the attributed string already had it.
+            return attributedString
+        }
+
+        let processedString = NSMutableAttributedString(attributedString: attributedString)
+        processedString.addAttribute(.headingRepresentation, value: headerSize, range: attributedString.rangeOfEntireString)
+
+        return processedString
     }
 
     fileprivate func detectAttachmentRemoved(in range: NSRange) {

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -579,4 +579,45 @@ class TextStorageTests: XCTestCase {
         let result = storage.getHTML()
         XCTAssertEqual(expectedResult, result)
     }
+
+    /// Verifies that missing Heading attributes are retained on string replacements
+    ///
+    func testMissingHeadingAttributeIsRetained() {
+        let defaultAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 14),
+            .paragraphStyle: ParagraphStyle.default,
+            .headingRepresentation: 2
+        ]
+
+        let headerString = NSAttributedString(
+            string: "Hello i'm a header",
+            attributes: defaultAttributes
+        )
+
+        storage.setAttributedString(headerString)
+
+        let originalAttributes = storage.attributes(at: 0, effectiveRange: nil)
+        XCTAssertEqual(storage.string, "Hello i'm a header")
+        XCTAssertEqual(originalAttributes.count, 3)
+        XCTAssertNotNil(originalAttributes[.headingRepresentation])
+
+        // autocorrect seemed to strip custom keys, so remove .headingRepresentation
+        let autoCorrectedAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 14),
+            .paragraphStyle: ParagraphStyle.default
+        ]
+
+        let autoCorrectedString = NSAttributedString(
+            string: "I'm",
+            attributes: autoCorrectedAttributes
+        )
+
+        let range = NSRange(location: 6, length: 3)
+        storage.replaceCharacters(in: range, with: autoCorrectedString)
+
+        let finalAttributes = storage.attributes(at: range.location, effectiveRange: nil)
+        XCTAssertEqual(storage.string, "Hello I'm a header")
+        XCTAssertEqual(finalAttributes.count, 3)
+        XCTAssertNotNil(finalAttributes[.headingRepresentation])
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.19.8
+-------
+* Retain Heading attribute when headings are autocorrected.
+
 1.19.7
 -------
 * Add variable to control whether typing attributes should be recalculated when deleting backward.

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'WordPress-Aztec-iOS'
-  s.version       = '1.19.7'
+  s.version       = '1.19.8'
 
   s.summary       = 'The native HTML Editor.'
   s.description   = <<-DESC

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'WordPress-Editor-iOS'
-  s.version       = '1.19.7'
+  s.version       = '1.19.8'
 
   s.summary       = 'The WordPress HTML Editor.'
   s.description   = <<-DESC


### PR DESCRIPTION
**Related:**
- https://github.com/wordpress-mobile/gutenberg-mobile/issues/4063
- https://github.com/wordpress-mobile/WordPress-iOS/pull/17844

This PR aims to resolve an issue where `TextStorage` attributed string replacements from the operating system (e.g. autocorrect, keyboard suggestions, double-tapping the spacebar to insert a period) aren't copying all of the existing attributes for the range they're replacing. When this is performed on a Heading, the `headingRepresentation` attribute key is missing, and ultimately causes the HTML generator to wrap certain strings in `<strong>` tags. This PR only addresses missing `headingRepresentation` keys.

[I've created a POC to show that may be a bug on Apple's side.](https://github.com/twstokes/UITextViewAutocorrectCustomAttributes)

**State inspection using the Aztec demo:**

When inserting a [breakpoint here](https://github.com/wordpress-mobile/AztecEditor-iOS/blob/8d72edcde64eb2a05175ae877fad97985153c26c/Aztec/Classes/TextKit/TextStorage.swift#L307), outputting the supplied `attrString` after autocorrect has taken place will show the `NSAttributedString` doesn't contain the `headingRepresentation` attribute.

**Functionality of these changes:**

1. When [`func replaceCharacters(in range: NSRange, with attrString: NSAttributedString)`](https://github.com/wordpress-mobile/AztecEditor-iOS/blob/8d72edcde64eb2a05175ae877fad97985153c26c/Aztec/Classes/TextKit/TextStorage.swift#L306) is called, the provided attributed string is checked to see if it includes a `headingRepresentation` custom key.
2. If it doesn't, we do another check to see if the first character of the existing storage string `textStore` includes it. If so, we determine that it's a heading and inject the custom attribute. Otherwise we don't mutate the string.

An edge case may come into question: **What if the first word is autocorrected, won't the first character be missing the heading attribute?**

This should be **no** due to the insertion of the initial characters from the keyboard, which carry the heading attribute.

**To test:** 

Add a breakpoint to [this line.](https://github.com/wordpress-mobile/AztecEditor-iOS/blob/8d72edcde64eb2a05175ae877fad97985153c26c/Aztec/Classes/TextKit/TextStorage.swift#L307), but don't enable it yet.

1. In the Aztec demo app, load an Empty Demo.
2. Change the input to any Heading.
3. Type: "Hello i'm"
4. Observe that "i'm" is highlighted in blue, indicating that it's about to be autocorrected.
5. Enable the breakpoint.
6. Press the spacebar on the demo app. (the breakpoint should be caught)

7a. Observe the value of `attrString`. It should equal:

```
I'm{
    NSColor = "<UIDynamicSystemColor: 0x600000101680; name = labelColor>";
    NSFont = "<UICTFont: 0x7fecd47112e0> font-family: \".SFUI-Regular\"; font-weight: normal; font-style: normal; font-size: 24.00pt";
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 8, ParagraphSpacingBefore 8, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n    4N,\n    8N,\n    12N,\n    16N,\n    20N,\n    24N,\n    28N,\n    32N,\n    36N,\n    40N,\n    44N\n), DefaultTabInterval 0, Blocks (\n), Lists (\n), BaseWritingDirection -1, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0 PresentationIntents (\n) ListIntentOrdinal 0 CodeBlockIntentLanguageHint '(null)', paragraphProperties: [<Aztec.Header: 0x6000014f7a80>]";
}
```

7b. Observe the value of `textStore`. It should equal:

```
Hello i'm{
    NSColor = "<UIDynamicSystemColor: 0x600000a56700; name = labelColor>";
    NSFont = "<UICTFont: 0x7f7fed910640> font-family: \".SFUI-Regular\"; font-weight: normal; font-style: normal; font-size: 24.00pt";
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 8, ParagraphSpacingBefore 8, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n    4N,\n    8N,\n    12N,\n    16N,\n    20N,\n    24N,\n    28N,\n    32N,\n    36N,\n    40N,\n    44N\n), DefaultTabInterval 0, Blocks (\n), Lists (\n), BaseWritingDirection -1, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0 PresentationIntents (\n) ListIntentOrdinal 0 CodeBlockIntentLanguageHint '(null)', paragraphProperties: [<Aztec.Header: 0x600001fb4840>]";
    headingRepresentation = 1;
}
```

8. Step to line 304 and observe the value of `preprocessedString`. It should equal:

```
I'm{
    NSColor = "<UIDynamicSystemColor: 0x600000101680; name = labelColor>";
    NSFont = "<UICTFont: 0x7fecd47112e0> font-family: \".SFUI-Regular\"; font-weight: normal; font-style: normal; font-size: 24.00pt";
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 8, ParagraphSpacingBefore 8, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n    4N,\n    8N,\n    12N,\n    16N,\n    20N,\n    24N,\n    28N,\n    32N,\n    36N,\n    40N,\n    44N\n), DefaultTabInterval 0, Blocks (\n), Lists (\n), BaseWritingDirection -1, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0 PresentationIntents (\n) ListIntentOrdinal 0 CodeBlockIntentLanguageHint '(null)', paragraphProperties: [<Aztec.Header: 0x6000014f7a80>]";
    headingRepresentation = 1;
}
```

9. Advance to line 310 and observe the value of `textStore`. It should equal:

```
Hello I'm{
    NSColor = "<UIDynamicSystemColor: 0x600000101680; name = labelColor>";
    NSFont = "<UICTFont: 0x7fecd47112e0> font-family: \".SFUI-Regular\"; font-weight: normal; font-style: normal; font-size: 24.00pt";
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 8, ParagraphSpacingBefore 8, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n    4N,\n    8N,\n    12N,\n    16N,\n    20N,\n    24N,\n    28N,\n    32N,\n    36N,\n    40N,\n    44N\n), DefaultTabInterval 0, Blocks (\n), Lists (\n), BaseWritingDirection -1, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0 PresentationIntents (\n) ListIntentOrdinal 0 CodeBlockIntentLanguageHint '(null)', paragraphProperties: [<Aztec.Header: 0x6000014f7a80>]";
    headingRepresentation = 1;
}
```

Before this change, the output would equal:

```
Hello {
    NSColor = "<UIDynamicSystemColor: 0x600000a56700; name = labelColor>";
    NSFont = "<UICTFont: 0x7f7fed910640> font-family: \".SFUI-Regular\"; font-weight: normal; font-style: normal; font-size: 24.00pt";
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 8, ParagraphSpacingBefore 8, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n    4N,\n    8N,\n    12N,\n    16N,\n    20N,\n    24N,\n    28N,\n    32N,\n    36N,\n    40N,\n    44N\n), DefaultTabInterval 0, Blocks (\n), Lists (\n), BaseWritingDirection -1, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0 PresentationIntents (\n) ListIntentOrdinal 0 CodeBlockIntentLanguageHint '(null)', paragraphProperties: [<Aztec.Header: 0x600001fb4840>]";
    headingRepresentation = 1;
}I'm{
    NSColor = "<UIDynamicSystemColor: 0x600000a56700; name = labelColor>";
    NSFont = "<UICTFont: 0x7f7fed910640> font-family: \".SFUI-Regular\"; font-weight: normal; font-style: normal; font-size: 24.00pt";
    NSParagraphStyle = "Alignment 4, LineSpacing 0, ParagraphSpacing 8, ParagraphSpacingBefore 8, HeadIndent 0, TailIndent 0, FirstLineHeadIndent 0, LineHeight 0/0, LineHeightMultiple 0, LineBreakMode 0, Tabs (\n    4N,\n    8N,\n    12N,\n    16N,\n    20N,\n    24N,\n    28N,\n    32N,\n    36N,\n    40N,\n    44N\n), DefaultTabInterval 0, Blocks (\n), Lists (\n), BaseWritingDirection -1, HyphenationFactor 0, TighteningForTruncation NO, HeaderLevel 0 LineBreakStrategy 0 PresentationIntents (\n) ListIntentOrdinal 0 CodeBlockIntentLanguageHint '(null)', paragraphProperties: [<Aztec.Header: 0x600001fb4840>]";
}
```

Note that the trailing space doesn't appear until after this text is processed, so it won't be shown in these steps.