### PR TITLE
Allow using the default font for the PreFormatter/HeaderFormatter

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -114,6 +114,10 @@ private extension HeaderFormatter {
     }
 
     func headerFontSize(for type: Header.HeaderType, defaultSize: Float?) -> Float {
+        if Configuration.useDefaultFont {
+            return defaultSize!
+        }
+
         guard type == .none, let defaultSize = defaultSize else {
             return type.fontSize
         }

--- a/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
@@ -30,8 +30,10 @@ open class PreFormatter: ParagraphAttributeFormatter {
 
         newParagraphStyle.appendProperty(HTMLPre(with: representation))
 
+        let defaultFont = attributes[.font]
+
         resultingAttributes[.paragraphStyle] = newParagraphStyle
-        resultingAttributes[.font] = monospaceFont
+        resultingAttributes[.font] = Configuration.useDefaultFont ? defaultFont : monospaceFont
 
         return resultingAttributes
     }

--- a/Aztec/Classes/TextKit/Configuration.swift
+++ b/Aztec/Classes/TextKit/Configuration.swift
@@ -3,6 +3,7 @@ import Foundation
 public final class Configuration {
 
     public static var headersWithBoldTrait = false
+    public static var useDefaultFont = false
 
     static var defaultBoldFormatter: AttributeFormatter {
         get {


### PR DESCRIPTION
Currently, there's not an option to use a custom font size for the HeaderFormatter since it uses the default values for each level, as well as for the PreFormatter which uses the default monospace font.

This introduces a new configuration flag `useDefaultFont` that will allow to use the `defaultFont` for both formatters.

To test use this [WordPress build](https://github.com/wordpress-mobile/WordPress-iOS/pull/17707#issuecomment-1003071218).