### PR TITLE
Add variable to control whether typing attributes should be recalculated when deleting backward

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -177,11 +177,11 @@ open class TextView: UITextView {
     /// If this is true the text view will notify is delegate and notification system when changes happen by calls to methods like setHTML
     ///
     open var shouldNotifyOfNonUserChanges = true
-    
+
     /// If this is true the typing attributes will be recalculated when deleting backward
     ///
     open var shouldRecalculateTypingAttributesOnDeleteBackward = true
-    
+
     // MARK: - Customizable Input VC
     
     private var customInputViewController: UIInputViewController?
@@ -742,7 +742,7 @@ open class TextView: UITextView {
         evaluateRemovalOfSingleLineParagraphAttributesAfterSelectionChange()
         ensureRemovalOfParagraphAttributesWhenPressingBackspaceAndEmptyingTheDocument()
         ensureCursorRedraw(afterEditing: deletedString.string)
-        if(shouldRecalculateTypingAttributesOnDeleteBackward) {
+        if shouldRecalculateTypingAttributesOnDeleteBackward {
             recalculateTypingAttributes()
         }
         notifyTextViewDidChange()

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -177,7 +177,11 @@ open class TextView: UITextView {
     /// If this is true the text view will notify is delegate and notification system when changes happen by calls to methods like setHTML
     ///
     open var shouldNotifyOfNonUserChanges = true
-
+    
+    /// If this is true the typing attributes will be recalculated when deleting backward
+    ///
+    open var shouldRecalculateTypingAttributesOnDeleteBackward = true
+    
     // MARK: - Customizable Input VC
     
     private var customInputViewController: UIInputViewController?
@@ -738,7 +742,9 @@ open class TextView: UITextView {
         evaluateRemovalOfSingleLineParagraphAttributesAfterSelectionChange()
         ensureRemovalOfParagraphAttributesWhenPressingBackspaceAndEmptyingTheDocument()
         ensureCursorRedraw(afterEditing: deletedString.string)
-        recalculateTypingAttributes()
+        if(shouldRecalculateTypingAttributesOnDeleteBackward) {
+            recalculateTypingAttributes()
+        }
         notifyTextViewDidChange()
     }
 


### PR DESCRIPTION
**Related to Gutenberg PR: https://github.com/WordPress/gutenberg/pull/37676**

The purpose of this PR is allowing to control whether the typing attributes should be recalculated when deleting backward, this will be handy when we want typing attributes/text format to be fully controlled by other libraries, therefore prevent that Aztec modifies them.

Additionally, there's a comment in the `recalculateTypingAttributes` function that states the following ([reference](https://github.com/wordpress-mobile/AztecEditor-iOS/blob/bd01a630f8e26c12b6e3ab4bd0514bca801d5f15/Aztec/Classes/TextKit/TextView.swift#L1341-L1343)):

>     /// Only call this method when sure that the typingAttributes need to be recalculated.  Keep in mind that
>     /// recalculating the typingAttributes in the wrong moment can cause trouble (for example reverting a decision
>     /// by the user to turn a style off).

If the recalculation only should happen in specific cases, this aligns with the idea of giving control over whether to recalculate the typing attributes through a variable.

**To test:**
This change shouldn't modify the current behavior when deleting text, so we should only verify that deleting backward works as expected.