### PR TITLE
Merge `trunk` changes of 1.19.8 to `develop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 1.19.8
 -------
+* Fix Li tag when switching the list style.
 * Retain Heading attribute when headings are autocorrected.
 
 1.19.7


### PR DESCRIPTION
This PR brings the changes of release 1.19.8 into `develop`.