### PR TITLE
Expose indentation operations

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -555,43 +555,44 @@ open class TextView: UITextView {
     }
 
     @objc func handleShiftTab(command: UIKeyCommand) {
-        
-        let lists = TextListFormatter.lists(in: typingAttributes)
-        let quotes = BlockquoteFormatter.blockquotes(in: typingAttributes)
-        
-        if let list = lists.last {
-            indent(list: list, increase: false)
-            
-        } else if let quote = quotes.last {
-            indent(blockquote: quote, increase: false)
-            
-        } else {
-            return
-        }
+        decreaseIndent()
     }
 
     @objc func handleTab(command: UIKeyCommand) {
-        
+        increaseIndent()
+    }
+    
+    // MARK: - General Indentation
+    
+    /// Increases the indentation of the selected range
+    open func increaseIndent() {
         let lists = TextListFormatter.lists(in: typingAttributes)
         let quotes = BlockquoteFormatter.blockquotes(in: typingAttributes)
 
         if let list = lists.last, lists.count < maximumListIndentationLevels {
             indent(list: list)
-
         } else if let quote = quotes.last, quotes.count < maximumBlockquoteIndentationLevels {
             indent(blockquote: quote)
-
         } else {
             insertText(String(.tab))
         }
-        
     }
     
+    /// Decreases the indentation of the selected range
+    open func decreaseIndent() {
+        let lists = TextListFormatter.lists(in: typingAttributes)
+        let quotes = BlockquoteFormatter.blockquotes(in: typingAttributes)
+        
+        if let list = lists.last {
+            indent(list: list, increase: false)
+        } else if let quote = quotes.last {
+            indent(blockquote: quote, increase: false)
+        }
+    }
     
     // MARK: - Text List indent methods
     
     private func indent(list: TextList, increase: Bool = true) {
-
         let formatter = TextListFormatter(style: list.style, placeholderAttributes: nil, increaseDepth: true)
         let li = LiFormatter(placeholderAttributes: nil)
 
@@ -629,9 +630,6 @@ open class TextView: UITextView {
     // MARK: - Blockquote indent methods
     
     private func indent(blockquote: Blockquote, increase: Bool = true) {
-        
-        
-        
         let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributes, increaseDepth: true)
         let targetRange = formatter.applicationRange(for: selectedRange, in: storage)
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -561,7 +561,7 @@ open class TextView: UITextView {
     @objc func handleTab(command: UIKeyCommand) {
         increaseIndent()
     }
-    
+
     // MARK: - General Indentation
 
     /// Increases the indentation of the selected range

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -563,7 +563,7 @@ open class TextView: UITextView {
     }
     
     // MARK: - General Indentation
-    
+
     /// Increases the indentation of the selected range
     open func increaseIndent() {
         let lists = TextListFormatter.lists(in: typingAttributes)
@@ -582,14 +582,14 @@ open class TextView: UITextView {
     open func decreaseIndent() {
         let lists = TextListFormatter.lists(in: typingAttributes)
         let quotes = BlockquoteFormatter.blockquotes(in: typingAttributes)
-        
+
         if let list = lists.last {
             indent(list: list, increase: false)
         } else if let quote = quotes.last {
             indent(blockquote: quote, increase: false)
         }
     }
-    
+
     // MARK: - Text List indent methods
     
     private func indent(list: TextList, increase: Bool = true) {


### PR DESCRIPTION
This will make increase/decrease indentation actions visible to other developers, namely to provide them as format bar actions.

To test:
Perform an indentation increase or decrease action (e.g. via keyboard command) and it should function as expected.

