### PR TITLE
Removing fileprivate level from scroll bar in formater bar

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -23,12 +23,12 @@ open class FormatBar: UIView {
 
     /// Container ScrollView
     ///
-    fileprivate let scrollView = UIScrollView()
+    let scrollView = UIScrollView()
 
 
     /// StackView embedded within the ScrollView
     ///
-    fileprivate let scrollableStackView = UIStackView()
+    let scrollableStackView = UIStackView()
 
 
     /// Top and bottom dividing lines


### PR DESCRIPTION
Fixes #

To test:

