### PR TITLE
Add `CHANGELOG.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,3 +2,6 @@ Fixes #
 
 To test:
 
+---
+
+- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Add this changelog file. [#1365]
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,58 @@
+# Changelog
+
+The format of this document is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- This is a comment, you won't see it when GitHub renders the Markdown file.
+
+When releasing a new version:
+
+1. Remove any empty section (those with `_None._`)
+2. Update the `## Unreleased` header to `## [<version_number>](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/<version_number>)`
+3. Add a new "Unreleased" section for the next iteration, by copy/pasting the following template:
+
+## Unreleased
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+-->
+
+## Unreleased
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+---
+
+_Versions below this precede the Keep a Changelog-inspired formatting._
+
+
 1.19.8
 -------
 * Fix Li tag when switching the list style.


### PR DESCRIPTION
Adds `CHANGELOG.md`. Based on https://github.com/wordpress-mobile/WordPressKit-iOS/pull/545 and the PR template iteration from https://github.com/wordpress-mobile/WordPressUI-iOS/pull/119.