### PR TITLE
Use NSString.paragraphRange method due to iOS 17 crash

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+ParagraphRange.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+ParagraphRange.swift
@@ -22,14 +22,13 @@ extension NSAttributedString {
     ///
     func paragraphRanges(intersecting range: NSRange, includeParagraphSeparator: Bool = true) -> [NSRange] {
         var paragraphRanges = [NSRange]()
-        let swiftRange = string.range(fromUTF16NSRange: range)
-        let paragraphsRange = string.paragraphRange(for: swiftRange)
-        
-        string.enumerateSubstrings(in: paragraphsRange, options: .byParagraphs) { [unowned self] (substring, substringRange, enclosingRange, stop) in
+        let paragraphsRange = foundationString.paragraphRange(for: range)
+
+        foundationString.enumerateSubstrings(in: paragraphsRange, options: .byParagraphs) { (substring, substringRange, enclosingRange, stop) in
             let paragraphRange = includeParagraphSeparator ? enclosingRange : substringRange
-            paragraphRanges.append(self.string.utf16NSRange(from: paragraphRange))
+            paragraphRanges.append(paragraphRange)
         }
-        
+
         return paragraphRanges
     }
     
@@ -44,16 +43,12 @@ extension NSAttributedString {
     ///
     func paragraphRanges(intersecting range: NSRange) -> ([ParagraphRange]) {
         var paragraphRanges = [ParagraphRange]()
-        let swiftRange = string.range(fromUTF16NSRange: range)
-        let paragraphsRange = string.paragraphRange(for: swiftRange)
-        
-        string.enumerateSubstrings(in: paragraphsRange, options: .byParagraphs) { [unowned self] (substring, substringRange, enclosingRange, stop) in
-            let substringNSRange = self.string.utf16NSRange(from: substringRange)
-            let enclosingNSRange = self.string.utf16NSRange(from: enclosingRange)
-            
-            paragraphRanges.append((substringNSRange, enclosingNSRange))
+        let paragraphsRange = foundationString.paragraphRange(for: range)
+
+        foundationString.enumerateSubstrings(in: paragraphsRange, options: .byParagraphs) { (substring, substringRange, enclosingRange, stop) in
+            paragraphRanges.append((substringRange, enclosingRange))
         }
-        
+
         return paragraphRanges
     }
     
@@ -62,10 +57,7 @@ extension NSAttributedString {
     /// This is an attributed string wrapper for `NSString.paragraphRangeForRange()`
     ///
     func paragraphRange(for range: NSRange) -> NSRange {
-        let swiftRange = string.range(fromUTF16NSRange: range)
-        let outRange = string.paragraphRange(for: swiftRange)
-        
-        return string.utf16NSRange(from: outRange)
+        return foundationString.paragraphRange(for: range)
     }
     
     func paragraphRange(for attachment: NSTextAttachment) -> NSRange {

--- a/AztecTests/Extensions/NSAttributedStringParagraphRangeTests.swift
+++ b/AztecTests/Extensions/NSAttributedStringParagraphRangeTests.swift
@@ -46,4 +46,54 @@ class NSAttributedStringParagraphRangeTests: XCTestCase {
         XCTAssertEqual(ranges.first?.rangeExcludingParagraphSeparator, expectedRangeWithoutSeparator)
         XCTAssertEqual(ranges.first?.rangeIncludingParagraphSeparator, expectedRangeWithSeparator)
     }
+
+    /// Tests that `paragraphRange(for:)` with a paragraph separator character
+    /// returns the correct `NSRange`.
+    ///
+    /// This test was added due to an iOS 17 crash when calling String.paragraphRange(for: range)
+    /// on a single paragraph separator character.
+    ///
+    func testParagraphRangeWorkWithParagraphSeparator() {
+        let attributedString = NSAttributedString(string: "\u{2029}")
+        let range = NSRange(location: 0, length: 1)
+        let expectedRange = NSRange(location: 0, length: 1)
+
+        let paragraphRange = attributedString.paragraphRange(for: range)
+
+        XCTAssertEqual(paragraphRange, expectedRange)
+    }
+
+    /// Tests that `paragraphRanges(intersecting:)` with a paragraph separator character
+    /// returns the correct `[NSRange]`.
+    ///
+    /// This test was added due to an iOS 17 crash when calling String.paragraphRange(for: range)
+    /// on a single paragraph separator character.
+    ///
+    func testParagraphRangesWorkWithParagraphSeparator() {
+        let attributedString = NSAttributedString(string: "\u{2029}")
+        let range = NSRange(location: 0, length: 1)
+        let expectedRange = NSRange(location: 0, length: 1)
+
+        let ranges = attributedString.paragraphRanges(intersecting: range, includeParagraphSeparator: true)
+
+        XCTAssertEqual(ranges.first!, expectedRange)
+    }
+
+    /// Tests that `paragraphRanges(intersecting:)` with a paragraph separator character
+    /// returns the correct `ParagraphRange`.
+    ///
+    /// This test was added due to an iOS 17 crash when calling String.paragraphRange(for: range)
+    /// on a single paragraph separator character.
+    ///
+    func testParagraphRangesWorkWithAndWithoutParagraphSeparator() {
+        let attributedString = NSAttributedString(string: "\u{2029}")
+        let range = NSRange(location: 0, length: 1)
+        let expectedRangeWithoutSeparator = NSRange(location: 0, length: 0)
+        let expectedRangeWithSeparator = NSRange(location: 0, length: 1)
+
+        let ranges = attributedString.paragraphRanges(intersecting: range)
+
+        XCTAssertEqual(ranges.first!.rangeIncludingParagraphSeparator, expectedRangeWithSeparator)
+        XCTAssertEqual(ranges.first!.rangeExcludingParagraphSeparator, expectedRangeWithoutSeparator)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+* Worked around a crash that could occur when calling String.paragraphRange(for:) on iOS 17. [#1373]
 
 ### Internal Changes
 


### PR DESCRIPTION
Fixes #1374

Addresses a crash that occurs when calling [`String.paragraphRange(for:)`](https://developer.apple.com/documentation/swift/stringprotocol/paragraphrange(for:)). The workaround for now is to call the [`NSString` equivalent](https://developer.apple.com/documentation/foundation/nsstring/1408548-paragraphrange).

Related issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/21261

- The crash also occurs when calling [`String.lineRange(for:)`](https://developer.apple.com/documentation/swift/stringprotocol/linerange(for:))
- It only seems to happen when a lone [paragraph separator](https://www.compart.com/en/unicode/U+2029) is passed to it: "\u{2029}"

Xcode 16 Playground code that will reproduce the crash:

```swift
import Foundation

/// Fails when using Xcode 16.0 beta 8 Playground and when running on iOS 17 beta.
let paragraphSeparator = "\u{2029}"

/// Try adding a character before or after the separator - it should not crash.
let string = paragraphSeparator
let range = string.startIndex ..< string.endIndex

/// Throws an exception.
let outRange = string.paragraphRange(for: range)
/// Success if this was reached.
print(string)
```

To test:

1. Run the AztecExample demo app in the Simulator or on a real device running iOS 17
2. Tap "Standard Demo"
3. Place the cursor at the end of the top line "Welcome to Aztec"
4. Erase characters until there are no more to erase
5. **Expect:** No exception is thrown and the app doesn't crash.

Repeat the test for iOS 16.

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
