### PR TITLE
Enable Dynamic Type for `RichText` within Gutenberg

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -31,14 +31,6 @@ public class HTMLParagraphFormatter: ParagraphAttributeFormatter {
 
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
-
-        if let font = attributes[.font] as? UIFont,
-           font.familyName != UIFont.systemFont(ofSize: UIFont.systemFontSize).familyName {
-            let fontMetrics = UIFontMetrics(forTextStyle: .body)
-            let scaledFont = fontMetrics.scaledFont(for: font)
-            resultingAttributes[.font] = scaledFont
-        }
-
         return resultingAttributes
     }
 

--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -31,6 +31,14 @@ public class HTMLParagraphFormatter: ParagraphAttributeFormatter {
 
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
+
+        if let font = attributes[.font] as? UIFont,
+           font.familyName != UIFont.systemFont(ofSize: UIFont.systemFontSize).familyName {
+            let fontMetrics = UIFontMetrics(forTextStyle: .body)
+            let scaledFont = fontMetrics.scaledFont(for: font)
+            resultingAttributes[.font] = scaledFont
+        }
+
         return resultingAttributes
     }
 

--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -32,7 +32,8 @@ public class HTMLParagraphFormatter: ParagraphAttributeFormatter {
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
 
-        if let font = attributes[.font] as? UIFont {
+        if let font = attributes[.font] as? UIFont,
+           font.familyName != UIFont.systemFont(ofSize: UIFont.systemFontSize).familyName {
             let fontMetrics = UIFontMetrics(forTextStyle: .body)
             let scaledFont = fontMetrics.scaledFont(for: font)
             resultingAttributes[.font] = scaledFont

--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -31,6 +31,13 @@ public class HTMLParagraphFormatter: ParagraphAttributeFormatter {
 
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
+
+        if let font = attributes[.font] as? UIFont {
+            let fontMetrics = UIFontMetrics(forTextStyle: .body)
+            let scaledFont = fontMetrics.scaledFont(for: font)
+            resultingAttributes[.font] = scaledFont
+        }
+
         return resultingAttributes
     }
 

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -115,7 +115,8 @@ private extension HeaderFormatter {
 
     func headerFontSize(for type: Header.HeaderType, defaultSize: Float?) -> Float {
         if Configuration.useDefaultFont {
-            return defaultSize!
+            let scaledDefaultSize = Float(UIFontMetrics.default.scaledValue(for: CGFloat(defaultSize!)))
+            return scaledDefaultSize
         }
 
         guard type == .none, let defaultSize = defaultSize else {


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/4097

## Related PRs

* iOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/22242
* Gutenberg Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6465

## To Test

* Open the Aztec demo app and play with different font sizes (via accessibility settings) to ensure there are no regressions. 
* Install the build available at https://github.com/wordpress-mobile/WordPress-iOS/pull/22242 and follow the testing instructions set out in that PR.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
