### PR TITLE
Fix crash when underlining text with special glyphs

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -366,6 +366,12 @@ extension LayoutManager {
         guard let textStorage = textStorage else {
             return
         }
+
+        guard Range(glyphRange, in: textStorage.string) != nil else {
+            // range out of bound for the glyph, fallback to default behavior
+            return super.underlineGlyphRange(glyphRange, underlineType: underlineVal, lineFragmentRect: lineRect, lineFragmentGlyphRange: lineGlyphRange, containerOrigin: containerOrigin)
+        }
+
         let underlinedString = textStorage.attributedSubstring(from: glyphRange).string
         var updatedGlyphRange = glyphRange
         if glyphRange.endLocation == lineGlyphRange.endLocation,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fixed crash when attempting to render Gutenberg comment. [#1383]
+- Fixed crash when underlining text with special glyphs. [#1384]
 
 ### Internal Changes
 

--- a/Example/Example/SampleContent/underline.html
+++ b/Example/Example/SampleContent/underline.html
@@ -4,3 +4,9 @@
 <p>Before link <a href="www.wordpress.com">Link&nbsp;to&nbsp;WordPress</a></p>
 <p>Before link <a href="www.jetpack.com">Link&nbsp;to&nbsp;Jetpack</a> After link</p>
 Link at end of text<a href="www.jetpack.com">Link&nbsp;to&nbsp;Jetpack</a>
+
+<!-- underline for special glyphs --->
+<a href="https://example.com/">&nbsp;قسم شنط &nbsp;الكايلي &nbsp;</a>
+
+<!-- link for image with special glyphs in title/alt/data-image-description --->
+<a href="https://www.wordpress.com/"><img class="alignnone wp-image-65" title="شنطة كايلي" src="https://www.wordpress.com/" alt="لوقو انستجرام" width="40" height="40" data-image-description="&lt;/p&gt; &lt;p&gt;لوقو انستجرام&lt;/p&gt; &lt;p&gt;" /></a>


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/11866

## Description
We have a [custom implementation](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1271) for underlining text, and the logic involves checking for a range of glyphs in strings. For text with special glyphs (e.g. Arabic language), this range is sometimes out of the bound of the text (I have yet to find an exact explanation for this).

The fix is to fall back to using the default implementation if we detect that a glyph range is invalid.

## Testing steps
- Run the demo app
- Open the content Underline NBSP
- Check that underlines are drawn correctly and the app doesn't crash.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
