### PR TITLE
Use consistent formatting in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,24 +52,16 @@ _None._
 
 ### Bug Fixes
 
-- Improve Mark formatting. [#1352]
+* Improve Mark formatting. [#1352]
 
 ## 1.19.10
 
 ### Bug Fixes
 
-- Fixed crash when attempting to render Gutenberg comment. [#1383]
-- Fixed crash when underlining text with special glyphs. [#1384]
+* Fixed crash when attempting to render Gutenberg comment. [#1383]
+* Fixed crash when underlining text with special glyphs. [#1384]
 
 ## 1.19.9
-
-### Breaking Changes
-
-_None._
-
-### New Features
-
-_None._
 
 ### Bug Fixes
 
@@ -77,7 +69,7 @@ _None._
 
 ### Internal Changes
 
-- Add this changelog file. [#1365]
+* Add this changelog file. [#1365]
 
 ---
 
@@ -138,15 +130,15 @@ _Versions below this precede the Keep a Changelog-inspired formatting._
 
 1.16.0
 -----
- * Improve display of ordered lists with large bullet numbers
- * Fix bug where links with text that had a mix of Latin and non-Latin characters were getting split.
+* Improve display of ordered lists with large bullet numbers
+* Fix bug where links with text that had a mix of Latin and non-Latin characters were getting split.
 
 1.15.0
 -----
- * Allow to use headers fonts without bold effect applied
- * Support for multilevel blockquotes
- * Fix presentation of placeholder images in dark mode.
- * Fix bug that didn't set default text color when changing text color
+* Allow to use headers fonts without bold effect applied
+* Support for multilevel blockquotes
+* Fix presentation of placeholder images in dark mode.
+* Fix bug that didn't set default text color when changing text color
 
 1.14.1
 -----


### PR DESCRIPTION
Noticed these inconsistencies while working on #1406...

- Always use `*` for lists (some entries had `-`)
- Remove placeholder sections from published releases
- Fix some items being right-indented

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.  ( 😄 )
