### PR TITLE
Update activesupport to fix security vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.2.2.1)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -14,7 +14,7 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
@@ -45,8 +45,8 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.3.0)
-    benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    benchmark (0.5.0)
+    bigdecimal (4.0.1)
     claide (1.1.0)
     cocoapods (1.16.2)
       addressable (~> 2.8)
@@ -89,8 +89,8 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.3)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
@@ -220,7 +220,7 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.12.2)
@@ -230,7 +230,7 @@ GEM
     logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    minitest (5.25.5)
+    minitest (5.27.0)
     molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.4.1)
@@ -323,4 +323,4 @@ DEPENDENCIES
   rubocop (~> 1.18)
 
 BUNDLED WITH
-   2.4.14
+   2.6.8


### PR DESCRIPTION
## Summary
- Updates `activesupport` gem to fix three security vulnerabilities published on 2026-03-23
- **GHSA-cg4j-q9v8-6v38**: ReDoS vulnerability in `number_to_delimited` (`NumberToDelimitedConverter` used a regex with `gsub!` causing quadratic time complexity)
- **GHSA-89vf-4333-qx8v**: XSS vulnerability in `SafeBuffer#%`
- **GHSA-2j26-frm8-cmj9**: DoS vulnerability in number helpers

## Test plan
- [ ] Verify CI passes
- [ ] Confirm `activesupport` version in `Gemfile.lock` is patched (>= 8.1.2.1 for 8.1.x, >= 8.0.4.1 for 8.0.x, >= 7.2.3.1 for 7.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)